### PR TITLE
Add text writer of filter s-expressions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ PARSER_OBJS=$(patsubst %.cpp, $(PARSER_OBJDIR)/%.o, $(PARSER_SRCS))
 SEXP_SRCDIR = $(SRCDIR)/sexp
 SEXP_OBJDIR = $(OBJDIR)/sexp
 SEXP_SRCS = \
-	Ast.cpp
+	Ast.cpp \
+	TextWriter.cpp
 
 SEXP_OBJS=$(patsubst %.cpp, $(SEXP_OBJDIR)/%.o, $(SEXP_SRCS))
 

--- a/defaults.df
+++ b/defaults.df
@@ -150,13 +150,11 @@
     (seq
       (preorder 0)
       (extract (append.value (vbruint32 6))
-        (seq
-          (loop (append.value (vbruint32 6))
-            (call local_entry))
-          (loop.unbounded
-            (eval 'code.inst')
-            (append)
-          )
+        (loop (append.value (vbruint32 6))
+          (call local_entry))
+        (loop.unbounded
+          (eval 'code.inst')
+          (append)
         )
       )
     )

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -26,6 +26,9 @@
 #include <cstdint>
 #include <limits>
 
+template<class T, size_t N>
+size_t size(T (&)[N]) { return N; }
+
 namespace wasm {
 
 namespace decode {

--- a/src/sexp-parser/Driver.cpp
+++ b/src/sexp-parser/Driver.cpp
@@ -21,6 +21,7 @@ using namespace wasm::filt;
 
 bool Driver::parse (const std::string &Filename) {
   this->Filename = Filename;
+  ParsedAst = nullptr;
   Begin();
   wasm::filt::Parser parser (*this);
   parser.set_debug_level(TraceParsing);

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -68,7 +68,16 @@ public:
 
   // Run the parser on file F. Returns true on success.
   bool parse (const std::string& Filename);
-  // Whether parser traces should be generated.
+
+
+  // Returns the last parsed ast.
+  Node *getParsedAst() const {
+    return ParsedAst;
+  }
+
+  void setParsedAst(Node *Ast) {
+    ParsedAst = Ast;
+  }
 
   // Error handling.
   void error (const wasm::filt::location& Loc,
@@ -81,6 +90,7 @@ private:
   bool TraceParsing = false;
   // The location of the last token.
   location Loc;
+  Node *ParsedAst = nullptr;
 
   // Called before parsing for setup.
   void Begin ();

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -165,7 +165,10 @@ class Node;
 
 %%
 
-file    : section_list { $$ = $1; }
+file    : section_list {
+            $$ = $1;
+            Driver.setParsedAst($1);
+          }
         ;
 
 case    : "(" "case" case_statement_list ")" { $$ = $3; }
@@ -179,6 +182,7 @@ case_list
           }
         | case_list case {
             $$ = $1;
+            $$->append($2);
           }
         ;
 

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -20,8 +20,98 @@
 #include "Defs.h"
 #include "sexp/Ast.h"
 
+#include <unordered_map>
+
+namespace {
+
+using namespace wasm::filt;
+
+struct { NodeType Type; const char* Name; } NodeTypeData[] = {
+  {NodeType::Append, "append" },
+  {NodeType::AppendValue, "append.value"},
+  {NodeType::AstToBit, "ast.to.bit"},
+  {NodeType::AstToByte, "ast.to.byte"},
+  {NodeType::AstToInt, "ast.to.int"},
+  {NodeType::BitToAst, "bit.to.ast"},
+  {NodeType::BitToBit, "bit.to.bit"},
+  {NodeType::BitToByte, "bit.to.byte"},
+  {NodeType::BitToInt, "bit.to.int"},
+  {NodeType::ByteToAst, "byte.to.ast"},
+  {NodeType::ByteToBit, "byte.to.bit"},
+  {NodeType::ByteToByte, "byte.to.byte"},
+  {NodeType::ByteToInt, "byte.to.int"},
+  {NodeType::Call, "call"},
+  {NodeType::Case, "case"},
+  {NodeType::Copy, "copy"},
+  {NodeType::Define, "define"},
+  {NodeType::Eval, "eval"},
+  {NodeType::Extract, "extract"},
+  {NodeType::File, "file"},
+  {NodeType::Filter, "filter"},
+  {NodeType::Fixed32, "fixed32"},
+  {NodeType::Fixed64, "fixed64"},
+  {NodeType::IfThenElse, "if"},
+  {NodeType::Integer, "<integer>"},
+  {NodeType::IntToAst, "int.to.ast"},
+  {NodeType::IntToBit, "int.to.bit"},
+  {NodeType::IntToByte, "int.to.byte"},
+  {NodeType::IntToInt, "int.to.int"},
+  {NodeType::I32Const, "i32.const"},
+  {NodeType::I64Const, "i64.const"},
+  {NodeType::Lit, "lit"},
+  {NodeType::Loop, "loop"},
+  {NodeType::LoopUnbounded, "loop.unbounded"},
+  {NodeType::Map, "map"},
+  {NodeType::Method, "method"},
+  {NodeType::Peek, "peek"},
+  {NodeType::Postorder, "preorder"},
+  {NodeType::Preorder, "postorder" },
+  {NodeType::Read, "read"},
+  {NodeType::Section, "section"},
+  {NodeType::Select, "select"},
+  {NodeType::Sequence, "sequence"},
+  {NodeType::Symbol, "symbol"},
+  {NodeType::SymConst, "sym.const"},
+  {NodeType::Uint32, "uint32"},
+  {NodeType::Uint8, "uint8"},
+  {NodeType::Uint64, "uint64"},
+  {NodeType::U32Const, "u32.const"},
+  {NodeType::U64Const, "u64.const"},
+  {NodeType::Value, "value"},
+  {NodeType::Varint32, "varint32"},
+  {NodeType::Varint64, "varint64"},
+  {NodeType::Varuint1, "varuint1"},
+  {NodeType::Varuint7, "varuint7"},
+  {NodeType::Varuint32, "varuint32"},
+  {NodeType::Varuint64, "varuint64"},
+  {NodeType::Vbrint32, "vbrint32"},
+  {NodeType::Vbrint64, "vbrint64"},
+  {NodeType::Vbruint32, "vbruint32"},
+  {NodeType::Vbruint64, "vbruint64"},
+  {NodeType::Version, "version"},
+  {NodeType::Void, "void"},
+  {NodeType::Write, "write"}
+};
+
+
+} // end of anonymous namespace
+
 namespace wasm {
 namespace filt {
+
+const char *getNodeTypeName(NodeType Type) {
+  static std::unordered_map<int, const char*> Mapping;
+  if (Mapping.empty()) {
+    for (size_t i = 0; i < size(NodeTypeData); ++i) {
+      const char *Name = NodeTypeData[i].Name;
+      Mapping[static_cast<int>(NodeTypeData[i].Type)] = Name;
+    }
+  }
+  const char *Name = Mapping[static_cast<int>(Type)];
+  if (Name == nullptr)
+    Mapping[static_cast<int>(Type)] = Name = "?NodeType?";
+  return Name;
+}
 
 NodeMemory NodeMemory::Default;
 

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -85,9 +85,9 @@ enum class NodeType {
     Varint32,
     Varint64,
     Varuint1,
+    Varuint7,
     Varuint32,
     Varuint64,
-    Varuint7,
     Vbrint32,
     Vbrint64,
     Vbruint32,
@@ -96,6 +96,8 @@ enum class NodeType {
     Void,
     Write
 };
+
+const char *getNodeTypeName(NodeType Type);
 
 class Node;
 

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -1,0 +1,215 @@
+/* -*- C++ -*- */
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Implements a textual writer of filter s-expressions */
+
+#include "sexp/TextWriter.h"
+
+namespace wasm {
+
+namespace filt {
+
+namespace {
+
+constexpr const char *IndentString = "  ";
+
+} // end of anonyous namespace
+
+TextWriter::Indent::Indent(TextWriter *Writer, bool AddNewline)
+    : Writer(Writer), AddNewline(AddNewline) {
+  Writer->writeIndent();
+}
+
+TextWriter::Indent::~Indent() {
+  Writer->maybeWriteNewline(AddNewline);
+}
+
+TextWriter::Parenthesize::Parenthesize(
+    TextWriter *Writer, NodeType Type, bool AddNewline)
+    : Writer(Writer), AddNewline(AddNewline) {
+  Writer->writeIndent();
+  fputc('(', Writer->File);
+  fputs(getNodeTypeName(Type), Writer->File);
+  Writer->LineEmpty = false;
+  ++Writer->IndentCount;
+}
+
+TextWriter::Parenthesize::~Parenthesize() {
+  --Writer->IndentCount;
+  Writer->writeIndent();
+  fputc(')', Writer->File);
+  Writer->LineEmpty = false;
+  Writer->maybeWriteNewline(AddNewline);
+}
+
+void TextWriter::write(FILE *File, Node *Root) {
+  initialize(File);
+  writeNode(Root, true);
+}
+
+void TextWriter::initialize(FILE *File) {
+  this->File = File;
+  IndentCount = 0;
+  LineEmpty = true;
+}
+
+void TextWriter::writeIndent() {
+  if (!LineEmpty)
+    return;
+  for (size_t i = 0; i < IndentCount; ++i)
+    fputs(IndentString, File);
+  LineEmpty = (IndentCount > 0);
+}
+
+void TextWriter::writeNode(Node *Node, bool AddNewline) {
+  if (Node == nullptr) {
+    Indent _(this, AddNewline);
+    fprintf(File, "null");
+    LineEmpty = false;
+    return;
+  }
+  switch (NodeType Type = Node->getType()) {
+    case NodeType::Append:
+    case NodeType::AppendValue:
+    case NodeType::Call:
+    case NodeType::Copy:
+    case NodeType::Eval:
+    case NodeType::Fixed32:
+    case NodeType::Fixed64:
+    case NodeType::I32Const:
+    case NodeType::I64Const:
+    case NodeType::Lit:
+    case NodeType::Map:
+    case NodeType::Peek:
+    case NodeType::Postorder:
+    case NodeType::Preorder:
+    case NodeType::Read:
+    case NodeType::SymConst:
+    case NodeType::Uint8:
+    case NodeType::Uint32:
+    case NodeType::Uint64:
+    case NodeType::U32Const:
+    case NodeType::U64Const:
+    case NodeType::Value:
+    case NodeType::Varint32:
+    case NodeType::Varint64:
+    case NodeType::Varuint1:
+    case NodeType::Varuint7:
+    case NodeType::Varuint32:
+    case NodeType::Varuint64:
+    case NodeType::Vbrint32:
+    case NodeType::Vbrint64:
+    case NodeType::Vbruint32:
+    case NodeType::Vbruint64:
+    case NodeType::Version:
+    case NodeType::Void:
+    case NodeType::Write: {
+      // Treat like expression, which goes on same line.
+      Parenthesize _(this, Type, AddNewline);
+      for (auto *Kid : *Node) {
+        writeSpace();
+        writeNode(Kid, false);
+      }
+      return;
+    }
+    case NodeType::Case:
+    case NodeType::Extract: {
+      // Treat like statement where all but first element put on separate lines,
+      // unless there is only 2 or less arguments.
+      Parenthesize _(this, Type, AddNewline);
+      bool KidAddNewline = Node->getNumKids() > 2;
+      for (auto *Kid : *Node) {
+        if (!KidAddNewline)
+          writeSpace();
+        writeNode(Kid, KidAddNewline);
+      }
+      return;
+    }
+    case NodeType::Define:
+    case NodeType::IfThenElse:
+    case NodeType::Loop:
+    case NodeType::Method:
+    case NodeType::Section:
+    case NodeType::Select: {
+      // Treat like statement where all but first element put on separate lines.
+      Parenthesize _(this, Type, AddNewline);
+      bool IsFirst = true;
+      for (auto *Kid : *Node) {
+        if (IsFirst) {
+          writeSpace();
+          IsFirst = false;
+        }
+        writeNode(Kid, true);
+      }
+      return;
+    }
+    case NodeType::AstToBit:
+    case NodeType::AstToByte:
+    case NodeType::AstToInt:
+    case NodeType::BitToAst:
+    case NodeType::BitToBit:
+    case NodeType::BitToByte:
+    case NodeType::BitToInt:
+    case NodeType::ByteToAst:
+    case NodeType::ByteToBit:
+    case NodeType::ByteToByte:
+    case NodeType::ByteToInt:
+    case NodeType::Filter:
+    case NodeType::IntToAst:
+    case NodeType::IntToBit:
+    case NodeType::IntToByte:
+    case NodeType::IntToInt:
+    case NodeType::LoopUnbounded:
+    case NodeType::Sequence: {
+      // Treat like statement where all elements put on separate line.
+      Parenthesize _(this, Type, AddNewline);
+      if (Node->getNumKids() == 0)
+        return;
+      writeNewline();
+      for (auto *Kid : *Node)
+        writeNode(Kid, true);
+      return;
+    }
+    case NodeType::File: {
+      // Treat like hidden node. That is, visually just a list of s-expressions.
+      for (auto *Kid : *Node)
+        writeNode(Kid, true);
+      return;
+    }
+    case NodeType::Integer: {
+      Indent _(this, AddNewline);
+      auto *Int = dynamic_cast<IntegerNode*>(Node);
+      // TODO: Get sign/format correct.
+      // TODO: Get format directive correct on all platforms!
+      fprintf(File, "%lu", Int->getValue());
+      LineEmpty = false;
+      return;
+    }
+    case NodeType::Symbol: {
+      Indent _(this, AddNewline);
+      auto *Sym = dynamic_cast<SymbolNode*>(Node);
+      // TODO: Get if needs to be quoted.
+      fprintf(File, "%s", Sym->getName().c_str());
+      LineEmpty = false;
+      return;
+    }
+  }
+}
+
+} // end of namespace filt
+
+} // end of namespace wasm

--- a/src/sexp/TextWriter.h
+++ b/src/sexp/TextWriter.h
@@ -1,0 +1,92 @@
+/* -*- C++ -*- */
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Defines a textual writer of filter s-expressions */
+
+#ifndef DECOMPRESSOR_SRC_EXP_TEXTWRITER_H
+#define DECOMPRESSOR_SRC_EXP_TEXTWRITER_H
+
+#include "Defs.h"
+#include "sexp/Ast.h"
+
+#include <cstdio>
+
+namespace wasm {
+
+namespace filt {
+
+class TextWriter {
+  TextWriter(const TextWriter&) = delete;
+  TextWriter &operator=(const TextWriter&) = delete;
+
+  class Indent {
+  public:
+    // Indent if new line. Add newline, if requested, when going out of scope.
+    Indent(TextWriter *Writer, bool AddNewline);
+    ~Indent();
+  private:
+    TextWriter *Writer;
+    bool AddNewline;
+  };
+
+  class Parenthesize {
+  public:
+    // Indent if new line. Indent elements between constructor and destructor by
+    // one. Add newline, if requested, when going out of scopre.
+    Parenthesize(TextWriter *Writer, NodeType Type, bool AddNewline);
+    ~Parenthesize();
+  private:
+    TextWriter *Writer;
+    bool AddNewline;
+  };
+
+public:
+  TextWriter() {}
+  void write(FILE *file, Node *Root);
+
+private:
+  FILE *File = 0;
+  size_t IndentCount = 0;
+  bool LineEmpty = true;
+
+  void initialize(FILE *File);
+
+  void writeNode(Node *Node, bool AddNewline);
+
+  void writeIndent();
+
+  void writeNewline() {
+    fputc('\n', File);
+    LineEmpty = true;
+  }
+
+  void maybeWriteNewline(bool Yes) {
+    if (Yes)
+      writeNewline();
+  }
+
+  void writeSpace() {
+    fputc(' ', File);
+    LineEmpty = false;
+  }
+};
+
+} // end of namespace filt
+
+} // end of namespace wasm
+
+#endif // DECOMPRESSOR_SRC_EXP_TEXTWRITER_H

--- a/test/TestParser.cpp
+++ b/test/TestParser.cpp
@@ -15,20 +15,34 @@
  * limitations under the License.
  */
 
+#include "sexp/TextWriter.h"
 #include "sexp-parser/Parser.tab.hpp"
 #include "sexp-parser/Driver.h"
+
 #include <iostream>
 
+using namespace wasm::filt;
+
 int main(int Argc, char *Argv[]) {
-  wasm::filt::Driver Driver;
+  Driver Driver;
+  bool PrintAst = false;
   for (int i = 1; i < Argc; ++i) {
     if (Argv[i] == std::string("-p"))
       Driver.setTraceParsing(true);
     else if (Argv[i] == std::string("-s"))
       Driver.setTraceLexing(true);
+    else if (Argv[i] == std::string("-w"))
+      PrintAst = true;
     else if (!Driver.parse(Argv[i])) {
-      std::cerr << "Errors detected: " << Argv[i] << "\n";
+      fprintf(stderr, "Errors detected: %s\n", Argv[i]);
       return EXIT_FAILURE;
+    } else if (PrintAst) {
+      if (Node *Root = Driver.getParsedAst()) {
+        TextWriter Writer;
+        Writer.write(stdout, Root);
+      } else {
+        fprintf(stderr, "No filter s-expressions found: %s\n", Argv[i]);
+      }
     }
   }
   return EXIT_SUCCESS;


### PR DESCRIPTION
Adds simple, pretty-print s-expression writer to filter s-expressions.

Also fixes minor issues discovered once s-expressions are printable.

To test, run:

  build/test/TestParser -w defaults.df
