### PR TITLE
Clean up extract blocks, and simplify sexp formatting.

### DIFF
--- a/defaults.df
+++ b/defaults.df
@@ -149,17 +149,18 @@
   (define 'function.body.default'
     (seq
       (preorder 0)
-      (extract (append.value (vbruint32 6))
-        (loop (append.value (vbruint32 6))
-          (call local_entry))
-        (loop.unbounded
-          (eval 'code.inst')
-          (append)
-        )
+      (append.value (extract.begin 0xFE))    # fake opcode 0xFE
+      (append)
+      (loop (append.value (vbruint32 6))
+        (call local_entry))
+      (loop.unbounded
+        (eval 'code.inst')
+        (append)
       )
+      (append.value (extract.end 0xFF))      # fake opcode 0xFF
     )
     (method local_entry
-      (loop (append.value (vbruint32 6))  # Type of each local variable.
+      (loop (append.value (vbruint32 6))     # Type of each local variable.
         (append.value (fixed32 3)))
     )
   )
@@ -208,6 +209,7 @@
         (case 0x34 (call memory_immediate))      # i64.store address
         (case 0x35 (call memory_immediate))      # f32.store address
         (case 0x36 (call memory_immediate))      # f64.store address
+        (case 0xFF (extract.eof))                # end function block
       )
     )
     (method branch_table

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -114,6 +114,9 @@ id	{letter}({letter}|{digit}|[_.])*
 "define"          return Parser::make_DEFINE(Driver.getLoc());
 "eval"            return Parser::make_EVAL(Driver.getLoc());
 "extract"         return Parser::make_EXTRACT(Driver.getLoc());
+"extract.begin"   return Parser::make_EXTRACT_BEGIN(Driver.getLoc());
+"extract.end"     return Parser::make_EXTRACT_END(Driver.getLoc());
+"extract.eof"     return Parser::make_EXTRACT_EOF(Driver.getLoc());
 "filter"          return Parser::make_FILTER(Driver.getLoc());
 "fixed32"         return Parser::make_FIXED32(Driver.getLoc());
 "fixed64"         return Parser::make_FIXED64(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -87,6 +87,9 @@ class Node;
 %token DEFINE        "define"
 %token EVAL          "eval"
 %token EXTRACT       "extract"
+%token EXTRACT_BEGIN "extract.begin"
+%token EXTRACT_END   "extract.end"
+%token EXTRACT_EOF   "extract.eof"
 %token FILTER        "filter"
 %token FIXED32       "fixed32"
 %token FIXED64       "fixed64"
@@ -224,6 +227,15 @@ expression
         | "(" "append.value" expression ")" {
             $$ = Unary<NodeType::AppendValue>::create($3);
           }
+        | "(" "extract.begin" integer ")" {
+            $$ = Unary<NodeType::ExtractBegin>::create($3);
+          }
+        | "(" "extract.end" integer ")" {
+            $$ = Unary<NodeType::ExtractEnd>::create($3);
+          }
+        | "(" "extract.eof" ")" {
+            $$ = Nullary<NodeType::ExtractEof>::create();
+          }
         | "(" "i32.const" integer ")" {
             $$ = Unary<NodeType::I32Const>::create($3);
           }
@@ -317,10 +329,9 @@ expression
         ;
 
 extract_statement_list
-        : expression statement { // extract size / first statement
+        : statement { // first statement of extract
             $$ = Nary<NodeType::Extract>::create();
             $$->append($1);
-            $$->append($2);
           }
         | extract_statement_list statement { // remaining statements of extract.
             $$ = $1;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -46,6 +46,9 @@ struct { NodeType Type; const char* Name; } NodeTypeData[] = {
   {NodeType::Define, "define"},
   {NodeType::Eval, "eval"},
   {NodeType::Extract, "extract"},
+  {NodeType::ExtractBegin, "extract.begin"},
+  {NodeType::ExtractEnd, "extract.end"},
+  {NodeType::ExtractEof, "extract.eof"},
   {NodeType::File, "file"},
   {NodeType::Filter, "filter"},
   {NodeType::Fixed32, "fixed32"},
@@ -141,6 +144,7 @@ void Nary<Kind>::forceCompilation() {}
 
 template class Nullary<NodeType::Append>;
 template class Nullary<NodeType::Copy>;
+template class Nullary<NodeType::ExtractEof>;
 template class Nullary<NodeType::Uint8>;
 template class Nullary<NodeType::Uint32>;
 template class Nullary<NodeType::Uint64>;
@@ -165,6 +169,8 @@ template class Unary<NodeType::ByteToAst>;
 template class Unary<NodeType::ByteToBit>;
 template class Unary<NodeType::ByteToByte>;
 template class Unary<NodeType::ByteToInt>;
+template class Unary<NodeType::ExtractBegin>;
+template class Unary<NodeType::ExtractEnd>;
 template class Unary<NodeType::Call>;
 template class Unary<NodeType::Eval>;
 template class Unary<NodeType::Fixed32>;

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -50,6 +50,9 @@ enum class NodeType {
     Define,
     Eval,
     Extract,
+    ExtractBegin,
+    ExtractEnd,
+    ExtractEof,
     File,
     Filter,
     Fixed32,
@@ -94,8 +97,10 @@ enum class NodeType {
     Vbruint64,
     Version,
     Void,
-    Write
+    Write // Assumed to be last in list (see NumNodeTypes).
 };
+
+static constexpr size_t NumNodeTypes = static_cast<int>(NodeType::Write) + 1;
 
 const char *getNodeTypeName(NodeType Type);
 

--- a/src/sexp/TextWriter.h
+++ b/src/sexp/TextWriter.h
@@ -55,13 +55,14 @@ class TextWriter {
   };
 
 public:
-  TextWriter() {}
+  TextWriter();
   void write(FILE *file, Node *Root);
 
 private:
   FILE *File = 0;
   size_t IndentCount = 0;
   bool LineEmpty = true;
+  std::vector<Node::IndexType> KidCountSameLine;
 
   void initialize(FILE *File);
 


### PR DESCRIPTION
Allow alternative form for extract blocks to use
   (extract.begin N)
   ...
   (extract.end N)

Uses (select E ... (case N (extract.eof)...) to force eof for most recent extract.begin.
