### PR TITLE
Fix handling of block.end concepts in s-expressions.

### DIFF
--- a/defaults.df
+++ b/defaults.df
@@ -49,12 +49,14 @@
   )
 
   (default 'code.function'
-    (block 
-      (block.args (varuint32) 0xFF) # number of bytes in function.
+    (block
+      # block implicitly reads # bytes using (varuint32) on byte stream.
       (loop (varuint32 6)            # number of locals in function.
         (eval 'code.local'))
       (loop.unbounded                # instructions
         (eval 'code.inst'))
+      # Insert 0xFF eob opcode if byte stream.
+      (block.end (map (i32.const  0xFF) (uint8)))
     )
   )
 

--- a/src/interp/State.cpp
+++ b/src/interp/State.cpp
@@ -53,9 +53,8 @@ IntType State::eval(const Node *Nd) {
     case OpSymConst:
     case OpFilter:
     case OpSelect:
-    case OpBlockArgsOne:
-    case OpBlockArgsTwo:
-    case OpBlockEnd:
+    case OpBlockEndNoArgs:
+    case OpBlockEndOneArg:
     case OpCase:
     case OpSymbol:
       // TODO(kschimpf): Fix above cases.

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -209,7 +209,6 @@ id ({letter}|{digit}|[_.])*
 ")"               return Parser::make_CLOSEPAREN(Driver.getLoc());
 "("               return Parser::make_OPENPAREN(Driver.getLoc());
 "block"           return Parser::make_BLOCK(Driver.getLoc());
-"block.args"      return Parser::make_BLOCK_ARGS(Driver.getLoc());
 "block.end"       return Parser::make_BLOCKEND(Driver.getLoc());
 "byte.to.byte"    return Parser::make_BYTE_TO_BYTE(Driver.getLoc());
 "case"            return Parser::make_CASE(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -75,7 +75,6 @@ struct IntegerValue {
 
 // Keywords
 %token BLOCK         "block"
-%token BLOCK_ARGS    "block.args"
 %token BLOCKEND      "block.end"
 %token BYTE_TO_BYTE  "byte.to.byte"
 %token CASE          "case"
@@ -116,7 +115,6 @@ struct IntegerValue {
 %token <wasm::filt::IntegerValue> INTEGER
 
 // Nonterminal classes.
-%type <wasm::filt::Node *> block_begin
 %type <wasm::filt::Node *> block_stmt_list
 %type <wasm::filt::Node *> case
 %type <wasm::filt::Node *> case_list
@@ -221,36 +219,26 @@ declaration_list
           }
         ;
 
-block_begin
-        : "(" "block.args" expression ")" {
-            $$ = Driver.create<Unary<OpBlockArgsOne>>($3);
-          }
-        | "(" "block.args" expression integer ")" {
-            $$ = Driver.create<Binary<OpBlockArgsTwo>>($3, $4);
-          }
-        ;
-
 block_stmt_list
-        : block_begin statement  {
-            $$ = Driver.create<Binary<OpBlock>>($1, $2);
+        : statement  {
+            $$ = Driver.create<Unary<OpBlock>>($1);
           }
         | block_stmt_list statement {
             $$ = $1;
-            Node *StmtList = $1->getKid(1);
+            Node *StmtList = $1->getKid(0);
             auto *Seq = dyn_cast<Nary<OpSequence>>(StmtList);
             if (Seq == nullptr) {
               Seq = Driver.create<Nary<OpSequence>>();
               Seq->append(StmtList);
-              $1->setKid(1, Seq);
+              $1->setKid(0, Seq);
             }
             Seq->append($2);
           }
         ;
 
 expression
-        : "(" "block" block_stmt_list ")"  { $$ = $3; }
-        | "(" "block.end" ")" {
-            $$ = Driver.create<Nullary<OpBlockEnd>>();
+        : "(" "block.end" ")" {
+            $$ = Driver.create<Nullary<OpBlockEndNoArgs>>();
           }
         | "(" "error" ")" {
             $$ = Driver.create<Nullary<OpError>>();
@@ -403,6 +391,10 @@ seq_stmt_list
 statement
         : expression { $$ = $1; }
         | stream_conv { $$ = $1; }
+        | "(" "block" block_stmt_list ")"  { $$ = $3; }
+        | "(" "block.end" statement ")" {
+            $$ = Driver.create<Unary<OpBlockEndOneArg>>($3);
+          }
         | "(" "filter" stream_conv_list ")" { $$ = $3; }
         | "(" loop_body ")" { $$ = $2; }
         | "(" "select" case_list ")" { $$ = $3; }

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -33,10 +33,9 @@
   /* enum name, opcode */                                                      \
                                                                                \
   /* Control flow operators */                                                 \
-  X(BlockArgsOne,      0x00, "block.args",       "blockArgsOne",    1, 0)      \
-  X(BlockArgsTwo,      0x01, "block.args",       "blockTwoArgs",    2, 0)      \
-  X(BlockEnd,          0x03, "block.end",        nullptr,           0, 0)      \
-  X(Block,             0x04, "block",            nullptr,           2, 0)      \
+  X(BlockEndNoArgs,    0x00, "block.end",        "BlockEndNoArgs",  0, 0)      \
+  X(BlockEndOneArg,    0x01, "block.end",        "BlockEndOneArg",  1, 0)      \
+  X(Block,             0x04, "block",            nullptr,           0, 0)      \
   X(Case,              0x05, "case",             nullptr,           2, 0)      \
   X(Error,             0x07, "error",            nullptr,           0, 0)      \
   X(Eval,              0x08, "eval",             nullptr,           1, 0)      \
@@ -113,7 +112,7 @@
 //#define X(tag)
 #define AST_NULLARYNODE_TABLE                                                  \
 /*  X(AppendNoArgs)                                                         */ \
-  X(BlockEnd)                                                                  \
+  X(BlockEndNoArgs)                                                            \
   X(Error)                                                                     \
   X(Uint8NoArgs)                                                               \
   X(Uint32NoArgs)                                                              \
@@ -135,7 +134,8 @@
 /*  X(BitToBit)                                                             */ \
 /*  X(BitToByte)                                                            */ \
 /*  X(BitToInt)                                                             */ \
-  X(BlockArgsOne)                                                              \
+  X(Block)                                                                     \
+  X(BlockEndOneArg)                                                            \
 /*  X(ByteToAst)                                                            */ \
 /*  X(ByteToBit)                                                            */ \
   X(ByteToByte)                                                                \
@@ -167,8 +167,6 @@
 
 //#define X(tag)
 #define AST_BINARYNODE_TABLE                                                   \
-  X(BlockArgsTwo)                                                              \
-  X(Block)                                                                     \
   X(Case)                                                                      \
   X(Default)                                                                   \
   X(Define)                                                                    \

--- a/test/test-sources/defaults.df-w
+++ b/test/test-sources/defaults.df-w
@@ -21,9 +21,10 @@
     (varuint32 6)
   )
   (default 'code.function'
-    (block (block.args (varuint32) 0xff)
+    (block
       (loop (varuint32 6) (eval 'code.local'))
       (loop.unbounded (eval 'code.inst'))
+      (block.end (map (i32.const 0xff) (uint8)))
     )
   )
   (default 'code.local'


### PR DESCRIPTION
Removes specifying how to handle #bytes in a block, and make insertion of "end of block" (on byte streams) explicit.
