### PR TITLE
Extract out buffer queue from byte version.

### DIFF
--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -158,10 +158,10 @@ void ByteQueue::freezeEob(size_t Address) {
   size_t LockedSize;
   // This call zero-fill pages if writing hasn't reached Address yet.
   assert(getWriteLockedPointer(Address, 0, LockedSize) != nullptr);
-  QueuePage *Page = getPage(Address);
-  Page->MaxAddress = Address;
-  assert(Page != nullptr);
-  assert(Page->Next == nullptr);
+  QueuePage *P = getPage(Address);
+  P->MaxAddress = Address;
+  assert(P != nullptr);
+  assert(P->Next == nullptr);
   unlock(Address);
 }
 

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -64,7 +64,7 @@ size_t ByteQueue::read(size_t &Address, uint8_t *ToBuf, size_t WantedSize) {
       // TODO: Block if Count == 0 and blocked by a lock.
       return Count;
     memcpy(ToBuf, FromBuf, FoundSize);
-    unlockAddress(Address);
+    unlock(Address);
     Count += FoundSize;
     WantedSize -= FoundSize;
     Address += FoundSize;
@@ -81,7 +81,7 @@ bool ByteQueue::write(size_t &Address, uint8_t *FromBuf, size_t WantedSize) {
     if (FromBuf == nullptr)
       return false;
     memcpy(ToBuf, FromBuf, FoundSize);
-    unlockAddress(Address);
+    unlock(Address);
     Address += FoundSize;
     WantedSize -= FoundSize;
   }
@@ -163,7 +163,7 @@ void ByteQueue::freezeEob(size_t Address) {
   Page->MaxAddress = Address;
   assert(Page != nullptr);
   assert(Page->Next == nullptr);
-  unlockAddress(Address);
+  unlock(Address);
 }
 
 bool ByteQueue::isAddressLocked(size_t Address) const {

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -189,22 +189,22 @@ void ByteQueue::lock(QueuePage *P) {
   LockedPages.emplace(P->Index);
 }
 
-void ByteQueue::unlock(QueuePage *Page) {
-  Page->unlock();
+void ByteQueue::unlock(QueuePage *P) {
+  P->unlock();
   // Remove smallest page indices from queue that no longer have locks.
   while (!LockedPages.empty()) {
     size_t PageIndex = LockedPages.top();
-    QueuePage *Page = getPageAt(PageIndex);
-    if (Page && Page->isLocked())
+    QueuePage *P = getPageAt(PageIndex);
+    if (P && P->isLocked())
       return;
     LockedPages.pop();
   }
 }
 
 void ByteQueue::dumpFirstPage() {
-  QueuePage *Tmp = FirstPage;
+  QueuePage *TmpPage = FirstPage;
   FirstPage = FirstPage->Next;
-  delete Tmp;
+  delete TmpPage;
   if (FirstPage)
     FirstPage->Last = nullptr;
 }

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -111,7 +111,7 @@ uint8_t *ByteQueue::getReadLockedPointer(size_t Address, size_t WantedSize,
   // Find page associated with Address.
   QueuePage *ReadPage = getPage(Address);
   if (ReadPage == nullptr
-      || (!LockedPages.empty() && ReadPage->PageIndex < LockedPages.top())) {
+      || (!LockedPages.empty() && ReadPage->Index < LockedPages.top())) {
     LockedSize = 0;
     return nullptr;
   }
@@ -187,7 +187,7 @@ bool ByteQueue::readFill(size_t Address) {
 
 void ByteQueue::lockPage(QueuePage *Page) {
   Page->lock();
-  LockedPages.emplace(Page->PageIndex);
+  LockedPages.emplace(Page->Index);
 }
 
 void ByteQueue::unlockPage(QueuePage *Page) {

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -115,7 +115,7 @@ uint8_t *ByteQueue::getReadLockedPointer(size_t Address, size_t WantedSize,
     LockedSize = 0;
     return nullptr;
   }
-  lockPage(ReadPage);
+  lock(ReadPage);
   dumpPreviousPages(Address);
   // Compute largest contiguous range of bytes available.
   LockedSize =
@@ -146,7 +146,7 @@ uint8_t *ByteQueue::getWriteLockedPointer(size_t Address, size_t WantedSize,
     LockedSize = 0;
     return nullptr;
   }
-  lockPage(Page);
+  lock(Page);
   LockedSize =
       (Address + WantedSize > Page->MaxAddress)
       ? Page->MaxAddress - Address : WantedSize;
@@ -185,12 +185,12 @@ bool ByteQueue::readFill(size_t Address) {
   return Address < EobPage->MaxAddress;
 }
 
-void ByteQueue::lockPage(QueuePage *Page) {
+void ByteQueue::lock(QueuePage *Page) {
   Page->lock();
   LockedPages.emplace(Page->Index);
 }
 
-void ByteQueue::unlockPage(QueuePage *Page) {
+void ByteQueue::unlock(QueuePage *Page) {
   Page->unlock();
   // Remove smallest page indices from queue that no longer have locks.
   while (!LockedPages.empty()) {

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -226,11 +226,11 @@ bool ReadBackedByteQueue::readFill(size_t Address) {
       }
       continue;
     }
-    QueuePage *Page = new QueuePage(EobPage->MaxAddress);
-    PageMap.push_back(Page);
-    EobPage->Next = Page;
-    Page->Last = EobPage;
-    EobPage = Page;
+    QueuePage *NewPage = new QueuePage(EobPage->MaxAddress);
+    PageMap.push_back(NewPage);
+    EobPage->Next = NewPage;
+    NewPage->Last = EobPage;
+    EobPage = NewPage;
   }
   return true;
 }

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -26,7 +26,7 @@ void ByteQueue::writePageAt(FILE *File, size_t Address) {
   QueuePage *Page = getPage(Address);
   if (Page == nullptr)
     return;
-  size_t Size = pageAddress(Address);
+  size_t Size = Page::address(Address);
   size_t Count = 0;
   for (size_t i = 0; i < Size; ++i, ++Count) {
     if (Count % 16 == 0) {
@@ -121,7 +121,7 @@ uint8_t *ByteQueue::getReadLockedPointer(size_t Address, size_t WantedSize,
   LockedSize =
       (Address + WantedSize > ReadPage->MaxAddress)
       ? ReadPage->MaxAddress - Address : WantedSize;
-  return &ReadPage->Buffer[pageAddress(Address)];
+  return &ReadPage->Buffer[Page::address(Address)];
 }
 
 uint8_t *ByteQueue::getWriteLockedPointer(size_t Address, size_t WantedSize,
@@ -151,7 +151,7 @@ uint8_t *ByteQueue::getWriteLockedPointer(size_t Address, size_t WantedSize,
       (Address + WantedSize > Page->MaxAddress)
       ? Page->MaxAddress - Address : WantedSize;
   dumpPreviousPages(Address);
-  return &Page->Buffer[pageAddress(Address)];
+  return &Page->Buffer[Page::address(Address)];
 }
 
 void ByteQueue::freezeEob(size_t Address) {
@@ -178,7 +178,7 @@ ByteQueue::QueuePage *ByteQueue::getPageAt(size_t PageIndex) const {
 }
 
 ByteQueue::QueuePage *ByteQueue::getPage(size_t Address) const {
-  return getPageAt(page(Address));
+  return getPageAt(Page::index(Address));
 }
 
 bool ByteQueue::readFill(size_t Address) {
@@ -219,7 +219,7 @@ bool ReadBackedByteQueue::readFill(size_t Address) {
   while (Address >= EobPage->MaxAddress) {
     if (size_t SpaceAvailable = EobPage->spaceRemaining()) {
       size_t NumBytes = Reader->read(
-          &(EobPage->Buffer[pageAddress(Address)]), SpaceAvailable);
+          &(EobPage->Buffer[Page::address(Address)]), SpaceAvailable);
       EobPage->MaxAddress += NumBytes;
       if (NumBytes == 0) {
         EobFrozen = true;

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -186,12 +186,12 @@ bool ByteQueue::readFill(size_t Address) {
 }
 
 void ByteQueue::lockPage(QueuePage *Page) {
-  Page->lockPage();
+  Page->lock();
   LockedPages.emplace(Page->PageIndex);
 }
 
 void ByteQueue::unlockPage(QueuePage *Page) {
-  Page->unlockPage();
+  Page->unlock();
   // Remove smallest page indices from queue that no longer have locks.
   while (!LockedPages.empty()) {
     size_t PageIndex = LockedPages.top();

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -43,6 +43,23 @@ void Queue<Base>::dumpFirstPage() {
     FirstPage->Last = nullptr;
 }
 
+template<class Base>
+void Queue<Base>::dumpPreviousPages(size_t Address) {
+  Page *AddrPage = getPage(Address);
+  while (FirstPage != AddrPage) {
+    if (!FirstPage->isLocked())
+      break;
+    if (FirstPage->getMaxAddress() + MinPeekSize < Address)
+      break;
+    dumpFirstPage();
+  }
+}
+
+template<class Base>
+bool Queue<Base>::readFill(size_t Address) {
+  return Address < EobPage->getMaxAddress();
+}
+
 void ByteQueue::writePageAt(FILE *File, size_t Address) {
   Page *P = getPage(Address);
   if (P == nullptr)
@@ -93,17 +110,6 @@ bool ByteQueue::write(size_t &Address, uint8_t *FromBuf, size_t WantedSize) {
     WantedSize -= FoundSize;
   }
   return true;
-}
-
-void ByteQueue::dumpPreviousPages(size_t Address) {
-  Page *AddrPage = getPage(Address);
-  while (FirstPage != AddrPage) {
-    if (!FirstPage->isLocked())
-      break;
-    if (FirstPage->getMaxAddress() + MinPeekSize < Address)
-      break;
-    dumpFirstPage();
-  }
 }
 
 uint8_t *ByteQueue::getReadLockedPointer(size_t Address, size_t WantedSize,
@@ -170,10 +176,6 @@ void ByteQueue::freezeEob(size_t Address) {
   assert(P != nullptr);
   assert(P->Next == nullptr);
   unlock(Address);
-}
-
-bool ByteQueue::readFill(size_t Address) {
-  return Address < EobPage->getMaxAddress();
 }
 
 bool ReadBackedByteQueue::readFill(size_t Address) {

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -132,7 +132,7 @@ uint8_t *ByteQueue::getWriteLockedPointer(size_t Address, size_t WantedSize,
       LockedSize = 0;
       return nullptr;
     }
-    EobPage->MaxAddress = EobPage->MinAddress + PageSize;
+    EobPage->MaxAddress = EobPage->MinAddress + Page::Size;
     if (Address < EobPage->MaxAddress)
       break;
     QueuePage *Page = new QueuePage(EobPage->MaxAddress);

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -166,10 +166,10 @@ void ByteQueue::freezeEob(size_t Address) {
 }
 
 bool ByteQueue::isAddressLocked(size_t Address) const {
-  QueuePage *Page = getPage(Address);
-  if (Page == nullptr)
+  QueuePage *P = getPage(Address);
+  if (P == nullptr)
     return false;
-  return Page->isLocked();
+  return P->isLocked();
 }
 
 ByteQueue::QueuePage *ByteQueue::getPageAt(size_t PageIndex) const {
@@ -184,9 +184,9 @@ bool ByteQueue::readFill(size_t Address) {
   return Address < EobPage->MaxAddress;
 }
 
-void ByteQueue::lock(QueuePage *Page) {
-  Page->lock();
-  LockedPages.emplace(Page->Index);
+void ByteQueue::lock(QueuePage *P) {
+  P->lock();
+  LockedPages.emplace(P->Index);
 }
 
 void ByteQueue::unlock(QueuePage *Page) {

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -23,8 +23,8 @@ namespace wasm {
 namespace decode {
 
 void ByteQueue::writePageAt(FILE *File, size_t Address) {
-  QueuePage *Page = getPage(Address);
-  if (Page == nullptr)
+  QueuePage *P = getPage(Address);
+  if (P == nullptr)
     return;
   size_t Size = Page::address(Address);
   size_t Count = 0;
@@ -35,7 +35,7 @@ void ByteQueue::writePageAt(FILE *File, size_t Address) {
     } else {
       fputc(' ', File);
     }
-    writeInt(File, Page->Buffer[i], ValueFormat::Hexidecimal);
+    writeInt(File, P->Buffer[i], ValueFormat::Hexidecimal);
   }
   fputc('\n', File);
 }

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -135,23 +135,22 @@ uint8_t *ByteQueue::getWriteLockedPointer(size_t Address, size_t WantedSize,
     EobPage->MaxAddress = EobPage->MinAddress + Page::Size;
     if (Address < EobPage->MaxAddress)
       break;
-    QueuePage *Page = new QueuePage(EobPage->MaxAddress);
-    PageMap.push_back(Page);
-    EobPage->Next = Page;
-    Page->Last = EobPage;
-    EobPage = Page;
+    QueuePage *NewPage = new QueuePage(EobPage->MaxAddress);
+    PageMap.push_back(NewPage);
+    EobPage->Next = NewPage;
+    NewPage->Last = EobPage;
+    EobPage = NewPage;
   }
-  QueuePage *Page = getPage(Address);
-  if (Page == nullptr) {
+  QueuePage *P = getPage(Address);
+  if (P == nullptr) {
     LockedSize = 0;
     return nullptr;
   }
-  lock(Page);
-  LockedSize =
-      (Address + WantedSize > Page->MaxAddress)
-      ? Page->MaxAddress - Address : WantedSize;
+  lock(P);
+  LockedSize = (Address + WantedSize > P->MaxAddress)
+      ? P->MaxAddress - Address : WantedSize;
   dumpPreviousPages(Address);
-  return &Page->Buffer[Page::address(Address)];
+  return &P->Buffer[Page::address(Address)];
 }
 
 void ByteQueue::freezeEob(size_t Address) {

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -89,8 +89,8 @@ bool ByteQueue::write(size_t &Address, uint8_t *FromBuf, size_t WantedSize) {
 }
 
 void ByteQueue::dumpPreviousPages(size_t Address) {
-  QueuePage *AddressPage = getPage(Address);
-  while (FirstPage != AddressPage) {
+  QueuePage *AddrPage = getPage(Address);
+  while (FirstPage != AddrPage) {
     if (!FirstPage->isLocked())
       break;
     if (FirstPage->MaxAddress + MinPeekSize < Address)

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -57,6 +57,16 @@ public:
   static constexpr size_t SizeLog2 = 12;
   static constexpr size_t Size = 1 << SizeLog2;
   static constexpr size_t Mask = Size - 1;
+
+  // Page index associated with address in queue.
+  static constexpr size_t index(size_t Address) {
+    return Address >> Page::SizeLog2;
+  }
+
+  // Returns address within a QueuePage that refers to address.
+  static constexpr size_t address(size_t Address) {
+    return Address & Page::Mask;
+  }
 };
 
 class ByteQueue {
@@ -185,7 +195,7 @@ protected:
     QueuePage &operator=(const QueuePage &) = delete;
   public:
     QueuePage(size_t MinAddress)
-        : PageIndex(page(MinAddress)), MinAddress(MinAddress),
+        : PageIndex(Page::index(MinAddress)), MinAddress(MinAddress),
           MaxAddress(MinAddress) {
       std::memset(&Buffer, Page::Size, 0);
     }
@@ -215,7 +225,7 @@ protected:
     QueuePage *Last = nullptr;
     QueuePage *Next = nullptr;
   };
-
+#if 0
   // Page index associated with address in queue.
   static constexpr size_t page(size_t Address) {
     return Address >> Page::SizeLog2;
@@ -225,6 +235,7 @@ protected:
   static constexpr size_t pageAddress(size_t Address) {
     return Address & Page::Mask;
   }
+#endif
 
   // True if end of buffer has been frozen.
   bool EobFrozen = false;

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -188,9 +188,9 @@ protected:
       std::memset(&Buffer, PageSize, 0);
     }
 
-    void lockPage() { ++LockCount; }
+    void lock() { ++LockCount; }
 
-    void unlockPage() {
+    void unlock() {
       assert(LockCount >= 1);
       --LockCount;
     }

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -195,7 +195,7 @@ protected:
     QueuePage &operator=(const QueuePage &) = delete;
   public:
     QueuePage(size_t MinAddress)
-        : PageIndex(Page::index(MinAddress)), MinAddress(MinAddress),
+        : Index(Page::index(MinAddress)), MinAddress(MinAddress),
           MaxAddress(MinAddress) {
       std::memset(&Buffer, Page::Size, 0);
     }
@@ -217,7 +217,7 @@ protected:
     }
 
     uint8_t Buffer[Page::Size];
-    size_t PageIndex;
+    size_t Index;
     // Note: Buffer address range is [MinAddress, MaxAddress).
     size_t MinAddress;
     size_t MaxAddress;
@@ -225,17 +225,6 @@ protected:
     QueuePage *Last = nullptr;
     QueuePage *Next = nullptr;
   };
-#if 0
-  // Page index associated with address in queue.
-  static constexpr size_t page(size_t Address) {
-    return Address >> Page::SizeLog2;
-  }
-
-  // Returns address within a QueuePage that refers to address.
-  static constexpr size_t pageAddress(size_t Address) {
-    return Address & Page::Mask;
-  }
-#endif
 
   // True if end of buffer has been frozen.
   bool EobFrozen = false;

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -166,12 +166,12 @@ public:
 
   // Increments the lock count for Address by 1. Assumes lock is already locked
   // (and hence defined).
-  void lockAddress(size_t Address) { lockPage(getPage(Address)); }
+  void lock(size_t Address) { lockPage(getPage(Address)); }
 
   // Decrements the lock count for Address by 1. Assumes lock was
   // defined by previous (successful) calls to getReadLockedPointer()
   // and getWriteLockedPointer().
-  void unlockAddress(size_t Address) { unlockPage(getPage(Address)); }
+  void unlock(size_t Address) { unlockPage(getPage(Address)); }
 
   // For debugging
   void writePageAt(FILE *File, size_t Address);

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -178,12 +178,12 @@ public:
 
   // Increments the lock count for Address by 1. Assumes lock is already locked
   // (and hence defined).
-  void lock(size_t Address) { lockPage(getPage(Address)); }
+  void lock(size_t Address) { lock(getPage(Address)); }
 
   // Decrements the lock count for Address by 1. Assumes lock was
   // defined by previous (successful) calls to getReadLockedPointer()
   // and getWriteLockedPointer().
-  void unlock(size_t Address) { unlockPage(getPage(Address)); }
+  void unlock(size_t Address) { unlock(getPage(Address)); }
 
   // For debugging
   void writePageAt(FILE *File, size_t Address);
@@ -252,10 +252,10 @@ protected:
   QueuePage *getPageAt(size_t PageIndex) const;
 
   // Increments the lock count on the given page.
-  void lockPage(QueuePage *Page);
+  void lock(QueuePage *Page);
 
   // Decrements the lock count on the given page.
-  void unlockPage(QueuePage *Page);
+  void unlock(QueuePage *Page);
 
   // Fills buffer until we can read 1 or more bytes at the given address.
   // Returns true if successful.

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -41,6 +41,7 @@
 #ifndef DECOMPRESSOR_SRC_STREAM_QUEUE_H
 #define DECOMPRESSOR_SRC_STREAM_QUEUE_H
 
+#include "stream/Page.h"
 #include "stream/RawStream.h"
 
 #include <cstring>
@@ -51,75 +52,6 @@
 namespace wasm {
 
 namespace decode {
-
-class Page {
-  Page(const Page &) = delete;
-  Page &operator=(const Page &) = delete;
-public:
-  static constexpr size_t SizeLog2 = 12;
-  static constexpr size_t Size = 1 << SizeLog2;
-  static constexpr size_t Mask = Size - 1;
-
-  // Page index associated with address in queue.
-  static constexpr size_t index(size_t Address) {
-    return Address >> Page::SizeLog2;
-  }
-
-  // Returns address within a Page that refers to address.
-  static constexpr size_t address(size_t Address) {
-    return Address & Page::Mask;
-  }
-
-  Page(size_t MinAddress)
-      : Index(Page::index(MinAddress)), MinAddress(MinAddress),
-        MaxAddress(MinAddress) {
-    std::memset(&Buffer, Page::Size, 0);
-  }
-
-  void lock() { ++LockCount; }
-
-  void unlock() {
-    assert(LockCount >= 1);
-    --LockCount;
-  }
-
-  bool isLocked() const { return LockCount > 0; }
-
-  size_t spaceRemaining() const {
-    return
-        (MinAddress + Page::Size == MaxAddress)
-        ? 0
-        : (Page::Size - (MaxAddress & Page::Mask));
-  }
-
-  size_t getMinAddress() const {
-    return MinAddress;
-  }
-
-  size_t getMaxAddress() const {
-    return MaxAddress;
-  }
-
-  void setMaxAddress(size_t NewValue) {
-    MaxAddress = NewValue;
-  }
-
-  void incrementMaxAddress(size_t Increment=1) {
-    MaxAddress += Increment;
-  }
-
-  // The contents of the page.
-  uint8_t Buffer[Page::Size];
-  // The page index of the page.
-  size_t Index;
-  Page *Last = nullptr;
-  Page *Next = nullptr;
-protected:
-  // Note: Buffer address range is [MinAddress, MaxAddress).
-  size_t MinAddress;
-  size_t MaxAddress;
-  size_t LockCount = 0;
-};
 
 class ByteQueue {
   ByteQueue(const ByteQueue &) = delete;

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -112,14 +112,13 @@ public:
   uint8_t Buffer[Page::Size];
   // The page index of the page.
   size_t Index;
-  // Note: Buffer address range is [MinAddress, MaxAddress).
-private:
-  size_t MinAddress;
-  size_t MaxAddress;
- public:
-  size_t LockCount = 0;
   Page *Last = nullptr;
   Page *Next = nullptr;
+protected:
+  // Note: Buffer address range is [MinAddress, MaxAddress).
+  size_t MinAddress;
+  size_t MaxAddress;
+  size_t LockCount = 0;
 };
 
 class ByteQueue {

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -252,10 +252,10 @@ protected:
   QueuePage *getPageAt(size_t PageIndex) const;
 
   // Increments the lock count on the given page.
-  void lock(QueuePage *Page);
+  void lock(QueuePage *P);
 
   // Decrements the lock count on the given page.
-  void unlock(QueuePage *Page);
+  void unlock(QueuePage *P);
 
   // Fills buffer until we can read 1 or more bytes at the given address.
   // Returns true if successful.

--- a/src/stream/ByteQueue.h
+++ b/src/stream/ByteQueue.h
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-// Defines a byte queue for hold bit and byte streams.
+// Defines a byte queue to buffer bit and byte streams.
 
 #ifndef DECOMPRESSOR_SRC_STREAM_BYTEQUEUE_H
 #define DECOMPRESSOR_SRC_STREAM_BYTEQUEUE_H

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -26,7 +26,7 @@ bool ReadCursor::fillBuffer() {
     return false;
   size_t BufferSize;
   uint8_t *NewBuffer = Queue->getReadLockedPointer(
-      CurAddress, ByteQueue::PageSize, BufferSize);
+      CurAddress, Page::Size, BufferSize);
   releaseLock();
   if (BufferSize == 0) {
     EobAddress = Queue->currentSize();
@@ -44,7 +44,7 @@ void WriteCursor::fillBuffer() {
     fatal("Write past Eob");
   size_t BufferSize;
   uint8_t *NewBuffer = Queue->getWriteLockedPointer(
-      CurAddress, ByteQueue::PageSize, BufferSize);
+      CurAddress, Page::Size, BufferSize);
   releaseLock();
   if (BufferSize == 0)
     fatal("Write failed!\n");

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -64,7 +64,7 @@ public:
 
   void releaseLock() {
     if (Buffer) {
-      Queue->lockAddress(LockedAddress);
+      Queue->lock(LockedAddress);
       Buffer = nullptr;
       BufferEnd = nullptr;
     }
@@ -107,7 +107,7 @@ protected:
       EobAddress(kUndefinedAddress) {
     // Add local copy of lock, so that lifetime matches cursor.
     if (Buffer)
-      Queue->lockAddress(LockedAddress);
+      Queue->lock(LockedAddress);
   }
 };
 

--- a/src/stream/Page.h
+++ b/src/stream/Page.h
@@ -1,0 +1,186 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Defines a generic base class for pages (of values). It is used to model
+// streams in the WASM decompressor.
+//
+// Associated with pages are locks.  This locking structure allows one to lock
+// "backpatch" addresses, making sure that the pages are not thrown away until
+// all locks have been released.  Locks will also block reads, until the locks
+// are unlocked.
+//
+// Note: Virtual addresses are used, start at index 0, and correspond to a
+// buffer index as if the queue keeps all pages (i.e. doesn't shrink) until the
+// queue is destructed. Therefore, if a byte is written at address N, to read
+// the value you must always use address N.
+//
+// It is assumed that jumping on reads and writes are valid. However, back jumps
+// are only safe if you lock the address before returning to that address.
+//
+// The memory for buffers are divided into pages. This is done so that the
+// underlying data structure does not move once created, making threading a lot
+// simplier to add. The size (i.e. number of bytes) in a page is a power of two,
+// to that simple masking can be used to compute the page index and the byte
+// address within the page.
+//
+// TODO(KarlSchimpf): Locking of reads/writes for threading has not yet been
+// addressed, and the current implementation is NOT thread safe.
+//
+// TODO(KarlSchimpf): bocking not implemented. Currently, reads fail if they try
+// to read from a locked page.
+
+
+#ifndef DECOMPRESSOR_SRC_STREAM_PAGE_H
+#define DECOMPRESSOR_SRC_STREAM_PAGE_H
+
+#include "stream/RawStream.h"
+
+#include <cstring>
+
+namespace wasm {
+
+namespace decode {
+
+class Page {
+  Page(const Page &) = delete;
+  Page &operator=(const Page &) = delete;
+public:
+  static constexpr size_t SizeLog2 = 12;
+  static constexpr size_t Size = 1 << SizeLog2;
+  static constexpr size_t Mask = Size - 1;
+
+  // Page index associated with address in queue.
+  static constexpr size_t index(size_t Address) {
+    return Address >> Page::SizeLog2;
+  }
+
+  // Returns address within a Page that refers to address.
+  static constexpr size_t address(size_t Address) {
+    return Address & Page::Mask;
+  }
+
+  Page(size_t MinAddress)
+      : Index(Page::index(MinAddress)), MinAddress(MinAddress),
+        MaxAddress(MinAddress) {
+    std::memset(&Buffer, Page::Size, 0);
+  }
+
+  void lock() { ++LockCount; }
+
+  void unlock() {
+    assert(LockCount >= 1);
+    --LockCount;
+  }
+
+  bool isLocked() const { return LockCount > 0; }
+
+  size_t spaceRemaining() const {
+    return
+        (MinAddress + Page::Size == MaxAddress)
+        ? 0
+        : (Page::Size - (MaxAddress & Page::Mask));
+  }
+
+  size_t getMinAddress() const {
+    return MinAddress;
+  }
+
+  size_t getMaxAddress() const {
+    return MaxAddress;
+  }
+
+  void setMaxAddress(size_t NewValue) {
+    MaxAddress = NewValue;
+  }
+
+  void incrementMaxAddress(size_t Increment=1) {
+    MaxAddress += Increment;
+  }
+
+  // The contents of the page.
+  uint8_t Buffer[Page::Size];
+  // The page index of the page.
+  size_t Index;
+  Page *Last = nullptr;
+  Page *Next = nullptr;
+protected:
+  // Note: Buffer address range is [MinAddress, MaxAddress).
+  size_t MinAddress;
+  size_t MaxAddress;
+  size_t LockCount = 0;
+};
+
+#if 0
+class Page {
+  Page(const Page &) = delete;
+  Page &operator=(const Page &) = delete;
+ public:
+
+  static constexpr size_t SizeLog2 = 12;
+  static constexpr size_t Size = 1 << SizeLog2;
+  static constexpr size_t PageMask = Size - 1;
+
+  // Page index associated with address in queue.
+  static constexpr size_t index(size_t Address) {
+    return Address >> SizeLog2;
+  }
+
+  // Returns address within a Page that refers to address.
+  static constexpr size_t address(size_t Address) {
+    return Address & PageMask;
+  }
+
+  Page(size_t MinAddress)
+      : Index(index(MinAddress)), MinAddress(MinAddress),
+        MaxAddress(MinAddress) {
+    std::memset(&Buffer, Size, 0);
+  }
+
+  void lock() { ++LockCount; }
+
+  void unlock() {
+    assert(LockCount >= 1);
+    --LockCount;
+  }
+
+  bool isLocked() const { return LockCount > 0; }
+
+  size_t spaceRemaining() const {
+    return
+        (MinAddress + Size == MaxAddress)
+        ? 0
+        : (Size - (MaxAddress & PageMask));
+  }
+
+  // Contents of page.
+  uint8_t Buffer[Size];
+  // Index of page.
+  size_t Index;
+  // Note: Buffer address range is [MinAddress, MaxAddress).
+  size_t MinAddress;
+  size_t MaxAddress;
+  size_t LockCount = 0;
+  Page *Last = nullptr;
+  Page *Next = nullptr;
+};
+#endif
+
+} // end of namespace decode
+
+} // end of namespace wasm
+
+#endif // DECOMPRESSOR_SRC_STREAM_PAGE_H

--- a/src/stream/Queue.h
+++ b/src/stream/Queue.h
@@ -1,0 +1,204 @@
+/* -*- C++ -*- */
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Defines a queue for hold buffers to streams.
+//
+// Associated with queues are locks.  This locking structure allows one to lock
+// "backpatch" addresses, making sure that the pages are not thrown away until
+// all locks have been released.
+//
+// Note: Virtual addresses are used, start at index 0, and correspond to a
+// buffer index as if the queue keeps all pages (i.e. doesn't shrink) until the
+// queue is destructed. Therefore, if a byte is written at address N, to read
+// the value you must always use address N.
+//
+// It is assumed that jumping on reads and writes are valid. However, back jumps
+// are only safe if you lock the address before reading past that address.
+//
+// TODO(KarlSchimpf): Locking of reads/writes for threading has not yet been
+// addressed, and the current implementation is NOT thread safe.
+
+
+#ifndef DECOMPRESSOR_SRC_STREAM_QUEUE_H
+#define DECOMPRESSOR_SRC_STREAM_QUEUE_H
+
+#include "stream/Page.h"
+
+#include <memory>
+#include <queue>
+#include <vector>
+
+namespace wasm {
+
+namespace decode {
+
+template<class Base>
+class Queue {
+  Queue(const Queue &) = delete;
+  Queue &operator=(const Queue &) = delete;
+
+public:
+  Queue();
+
+  virtual ~Queue();
+
+  // Defines the maximum Peek size into the queue when reading. That
+  // is, The minimal number of bytes that the reader can back up without
+  // freezing an address. Defaults to 32.
+  void setMinPeekSize(size_t NewValue) {
+    MinPeekSize = NewValue * sizeof(Base);
+  }
+
+  // Value unknown (returning maximum possible size) until frozen. When
+  // frozen, returns the size of the buffer.
+  size_t currentSize() {
+    return EobFrozen
+        ? EobPage->getMaxAddress() : std::numeric_limits<ssize_t>::max();
+  }
+
+  // Returns the actual size of the buffer (i.e. only those with pages still
+  // in memory).
+  size_t actualSize() const {
+    return EobPage->getMaxAddress() - FirstPage->getMinAddress();
+  }
+
+  // Returns true if Address is locked.
+  bool isAddressLocked(size_t Address) const {
+    Page *P = getPage(Address);
+    if (P == nullptr)
+      return false;
+    return P->isLocked();
+  }
+
+  // Increments the lock count for Address by 1. Assumes lock is already locked
+  // (and hence defined).
+  void lock(size_t Address) { lockPage(getPage(Address)); }
+
+  // Decrements the lock count for Address by 1. Assumes lock was
+  // defined by previous (successful) calls to getReadLockedPointer()
+  // and getWriteLockedPointer().
+  void unlock(size_t Address) { unlockPage(getPage(Address)); }
+
+
+  // The following two methods allows one to lock the memory of the queue
+  // directly, and read/write directly into the buffer. Also locks the
+  // address, which must be released with a call to unlockAddress().
+  //
+  // WARNING: Never access beyond LockedSize elements after the call,
+  // and only while you haven't unlocked the address.  There is no
+  // guarantee that such pointer accesses are vaild, once it has been
+  // unlocked.
+
+  // Returns a pointer into the queue that can be read. Must unlock the address
+  // once reading has been completed.
+  //
+  // @param Address    The address within the queue to Access.
+  // @param WantedSize The number of elements requested to be read
+  //                   locked.  Note: Zero is allowed.
+  // @param LockedSize The actual number of elements locked down (may
+  //                   be smaller than wanted size, due to eob or
+  //                   internal paging).
+  // @result           Pointer to locked address, or nullptr if unable to read
+  //                   lock.
+  Base *getReadLockedPointer(size_t Address, size_t WantedSize,
+                             size_t &LockedSize);
+
+  // Returns a pointer into the queue that can be written to. Must unlock the
+  // address once writing has been completed.
+  //
+  // @param Address    The address within the queue to Access.
+  // @param WantedSize The number of elements requested to bewrite
+  //                   locked.  Note: Zero is allowed, and just locks
+  //                   address.
+  // @param LockedSize The actual number of elements locked down (may
+  //                   be smaller than wanted size, due to eob or
+  //                   internal paging).
+  // @result           Pointer to locked address, or nullptr if unable to write
+  //                   lock.
+  Base *getWriteLockedPointer(size_t Address, size_t WantedSize,
+                              size_t &LockedSize);
+
+  // Freezes eob of the queue. Not valid to read/write past the eob, once set.
+  void freezeEob(size_t Address);
+
+  bool isEobFrozen() const { return EobFrozen; }
+
+protected:
+  // Minimum peek size to maintain. That is, the minimal number of
+  // bytes that the read can back up without freezing an address.
+  size_t MinPeekSize = 32 * sizeof(Base);
+  // True if end of queue buffer has been frozen.
+  bool EobFrozen = false;
+  // First page still in queue.
+  Page *FirstPage;
+  // Page at the current end of buffer.
+  Page *EobPage;
+  // Fast page lookup map (from page index)
+  using PageMapType = std::vector<Page*>;
+  PageMapType PageMap;
+  // Heap to keep track of pages locks, sorted by page index.
+  std::priority_queue<size_t, std::vector<size_t>,
+                      std::less<size_t>> LockedPages;
+
+  // Returns the page in the queue referred to Address, or nullptr if no
+  // such page is in the byte queue.
+  Page *getPage(size_t Address) const {
+    return getPageAt(Page::index(Address));
+  }
+
+  // Returns the page with the given PageIndex, or nullptr if no such
+  // page is in the byte queue.
+  Page *getPageAt(size_t PageIndex) const {
+    return (PageIndex >= PageMap.size()) ? nullptr : PageMap[PageIndex];
+  }
+
+  // Increments the lock count on the given page.
+  void lockPage(Page *P) {
+    P->lock();
+    LockedPages.emplace(P->Index);
+  }
+
+  // Decrements the lock count on the given page.
+  void unlockPage(Page *P) {
+    P->unlock();
+    // Remove smallest page indices from queue that no longer have locks.
+    while (!LockedPages.empty()) {
+      size_t PageIndex = LockedPages.top();
+      Page *P = getPageAt(PageIndex);
+      if (P && P->isLocked())
+        return;
+      LockedPages.pop();
+    }
+  }
+
+  // Dumps and deletes the first page.  Note: Dumping only occurs if a
+  // Writer is provided (see class WriteBackedByteQueue below).
+  virtual void dumpFirstPage();
+
+  // Dumps ununsed pages before the given address to recover memory.
+  void dumpPreviousPages(size_t Address);
+
+  // Fills buffer until we can read 1 or more bytes at the given address.
+  // Returns true if successful.
+  virtual bool readFill(size_t Address);
+};
+
+} // end of namespace decode
+
+} // end of namespace wasm
+
+#endif // DECOMPRESSOR_SRC_STREAM_QUEUE_H

--- a/src/stream/Queue.h
+++ b/src/stream/Queue.h
@@ -32,7 +32,6 @@
 // TODO(KarlSchimpf): Locking of reads/writes for threading has not yet been
 // addressed, and the current implementation is NOT thread safe.
 
-
 #ifndef DECOMPRESSOR_SRC_STREAM_QUEUE_H
 #define DECOMPRESSOR_SRC_STREAM_QUEUE_H
 

--- a/src/stream/QueueImpl.h
+++ b/src/stream/QueueImpl.h
@@ -1,0 +1,145 @@
+/* -*- C++ -*- */
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Implements a queue for hold buffers to streams.
+#ifndef DECOMPRESSOR_SRC_STREAM_QUEUEIMPL_H
+#define DECOMPRESSOR_SRC_STREAM_QUEUEIMPL_H
+
+#include "stream/Queue.h"
+
+namespace wasm {
+
+namespace decode {
+
+template<class Base>
+Queue<Base>::Queue() {
+  EobPage = FirstPage = new Page(0);
+  PageMap.push_back(EobPage);
+  // Double check that we can evenly fit elements of Base in a page.
+  assert(Page::Size % sizeof(Base) == 0);
+}
+
+template<class Base>
+Queue<Base>::~Queue() {
+  while (FirstPage)
+    dumpFirstPage();
+}
+
+template<class Base>
+void Queue<Base>::dumpFirstPage() {
+  Page *TmpPage = FirstPage;
+  FirstPage = FirstPage->Next;
+  delete TmpPage;
+  if (FirstPage)
+    FirstPage->Last = nullptr;
+}
+
+template<class Base>
+void Queue<Base>::dumpPreviousPages(size_t Address) {
+  Page *AddrPage = getPage(Address);
+  while (FirstPage != AddrPage) {
+    if (!FirstPage->isLocked())
+      break;
+    if (FirstPage->getMaxAddress() + MinPeekSize < Address)
+      break;
+    dumpFirstPage();
+  }
+}
+
+template<class Base>
+bool Queue<Base>::readFill(size_t Address) {
+  return Address < EobPage->getMaxAddress();
+}
+
+template<class Base>
+Base *Queue<Base>::getReadLockedPointer(size_t Address, size_t WantedSize,
+                                           size_t &LockedSize) {
+  // Start by read-filling if necessary.
+  if (Address >= EobPage->getMaxAddress()) {
+    if (!readFill(Address)) {
+      LockedSize = 0;
+      return nullptr;
+    }
+  }
+  // Find page associated with Address.
+  Page *ReadPage = getPage(Address);
+  if (ReadPage == nullptr
+      || (!LockedPages.empty() && ReadPage->Index < LockedPages.top())) {
+    LockedSize = 0;
+    return nullptr;
+  }
+  lockPage(ReadPage);
+  dumpPreviousPages(Address);
+  // Compute largest contiguous range of elements available.
+  WantedSize *= sizeof(Base);
+  LockedSize = WantedSize;
+  if (Address + WantedSize > ReadPage->getMaxAddress()) {
+    LockedSize = (ReadPage->getMaxAddress() - Address) / sizeof(Base);
+  }
+  return (Base*)(ReadPage->Buffer + Page::address(Address));
+}
+
+template<class Base>
+Base *Queue<Base>::getWriteLockedPointer(size_t Address, size_t WantedSize,
+                                            size_t &LockedSize) {
+  // Page doesn't exist. Expand queue if necessary.
+  while (Address >= EobPage->getMaxAddress()) {
+    if (EobFrozen) {
+      LockedSize = 0;
+      return nullptr;
+    }
+    EobPage->setMaxAddress(EobPage->getMinAddress() + Page::Size);
+    if (Address < EobPage->getMaxAddress())
+      break;
+    Page *NewPage = new Page(EobPage->getMaxAddress());
+    PageMap.push_back(NewPage);
+    EobPage->Next = NewPage;
+    NewPage->Last = EobPage;
+    EobPage = NewPage;
+  }
+  Page *P = getPage(Address);
+  if (P == nullptr) {
+    LockedSize = 0;
+    return nullptr;
+  }
+  lockPage(P);
+  dumpPreviousPages(Address);
+  // Compute largest contiguous range of bytes available.
+  WantedSize *= sizeof(Base);
+  LockedSize = WantedSize;
+  if (Address + WantedSize > P->getMaxAddress()) {
+    LockedSize = (P->getMaxAddress() - Address) / sizeof(Base);
+  }
+  return (Base*)(P->Buffer + Page::address(Address));
+}
+
+template<class Base>
+void Queue<Base>::freezeEob(size_t Address) {
+  assert(!EobFrozen);
+  size_t LockedSize;
+  // This call zero-fill pages if writing hasn't reached Address yet.
+  assert(getWriteLockedPointer(Address, 0, LockedSize) != nullptr);
+  Page *P = getPage(Address);
+  P->setMaxAddress(Address);
+  unlock(Address);
+}
+
+} // end of decode namespace
+
+} // end of wasm namespace
+
+#endif // DECOMPRESSOR_SRC_STREAM_QUEUEIMPL_H

--- a/test/TestByteQueues.cpp
+++ b/test/TestByteQueues.cpp
@@ -158,8 +158,8 @@ int main(int Argc, char *Argv[]) {
       In += WriteBytesAvailable;
       ReadBytesAvailable -= WriteBytesAvailable;
     }
-    Input.unlockAddress(Address);
-    Output.unlockAddress(Address);
+    Input.unlock(Address);
+    Output.unlock(Address);
     Address = NextAddress;
   }
   return exit_status(EXIT_SUCCESS);


### PR DESCRIPTION
Refactoring of code so that we can use the "page" based model of buffer queues for integer and ast streams.
