### PR TITLE
Add tool to convert filter s-expressions to binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,17 @@ TL_OBJS=$(patsubst %.cpp, $(OBJDIR)/%.o, $(TL_SRCS))
 
 TL_LIB = $(LIBDIR)/$(LIBPREFIX)tl.a
 
+###### Binary generation objects and locations ######
+
+BINARY_DIR = $(SRCDIR)/binary
+BINARY_OBJDIR = $(OBJDIR)/binary
+BINARY_SRCS = \
+	BinGen.cpp
+
+BINARY_OBJS=$(patsubst %.cpp, $(BINARY_OBJDIR)/%.o, $(BINARY_SRCS))
+
+BINARY_LIB = $(LIBDIR)/$(LIBPREFIX)binary.a
+
 ###### Parse objects and locations ######
 
 PARSER_DIR = $(SRCDIR)/sexp-parser
@@ -124,7 +135,8 @@ TEST_SRCS_DIR = $(TEST_DIR)/test-sources
 
 ###### General compilation definitions ######
 
-LIBS = $(TL_LIB) $(PARSER_LIB) $(SEXP_LIB) $(INTERP_LIB) $(STRM_LIB)
+LIBS = $(TL_LIB) $(PARSER_LIB) $(BINARY_LIB) $(INTERP_LIB) $(SEXP_LIB) \
+       $(STRM_LIB)
 
 $(info -----------------------------------------------)
 $(info Using CPP_COMPILER = $(CPP_COMPILER))
@@ -139,15 +151,15 @@ CXXFLAGS := -std=gnu++11 -Wall -Wextra -O2 -g -pedantic -MP -MD -Werror \
 
 ###### Default Rule ######
 
-all: tl-objs parser-objs sexp-objs strm-objs interp-objs libs execs \
-     test-execs
+all: libs execs test-execs
 
 .PHONY: all
 
 ###### Cleaning Rules #######
 
 clean: clean-tl-objs clean-parser clean-sexp-objs clean-strm-objs \
-       clean-interp-objs clean-execs clean-libs clean-test-execs
+       clean-interp-objs clean-bingen-objs clean-execs clean-libs \
+       clean-test-execs
 
 .PHONY: clean
 
@@ -160,6 +172,11 @@ clean-libs:
 	rm -f $(LIBS)
 
 .PHONY: clean-libs
+
+clean bingen-objs:
+	rm -f $(BINARY_OBJS)
+
+.PHONY: bingen-objs
 
 clean-tl-objs:
 	rm -f $(TL_OBJS)
@@ -213,9 +230,28 @@ gen-lexer: $(PARSER_DIR)/Lexer.cpp
 
 gen-parser: $(PARSER_DIR)/Parser.tab.cpp
 
-.PHONY: ge-parser
+.PHONY: gen-parser
 
-###### Compiliing Sources ######
+###### Compiliing binary generation Sources ######
+
+bingen-objs: $(BINARY_OBJS)
+
+.PHONY: bingen-objs
+
+$(BINARY_OBJS): | $(BINARY_OBJDIR)
+
+$(BINARY_OBJDIR):
+	mkdir -p $@
+
+-include $(foreach dep,$(BINARY_SRCS:.cpp=.d),$(BINARY_OBJDIR)/$(dep))
+
+$(BINARY_OBJS): $(BINARY_OBJDIR)/%.o: $(BINARY_DIR)/%.cpp
+	$(CXX) -c $(CXXFLAGS) $< -o $@
+
+$(BINARY_LIB): $(BINARY_OBJS)
+	ar -rs $@ $(BINARY_OBJS)
+
+###### Compiliing top-level Sources ######
 
 tl-objs: $(TL_OBJS)
 

--- a/src/binary/BinGen.cpp
+++ b/src/binary/BinGen.cpp
@@ -1,0 +1,255 @@
+/* -*- C++ -*- */
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Implements a binary generator for filter s-expressions.
+
+#include "sexp/Ast.h"
+#include "sexp/TextWriter.h"
+#include "binary/BinGen.h"
+#include "interp/State.h"
+
+namespace wasm {
+
+using namespace alloc;
+using namespace decode;
+using namespace interp;
+
+namespace filt {
+
+namespace {
+
+IntType getIntegerValue(Node *N) {
+  if (auto *IntVal = dyn_cast<IntegerNode>(N))
+    return IntVal->getValue();
+  fatal("Integer value expected but not found");
+  return 0;
+}
+
+} // end of anonymous namespace
+
+BinGen::BinGen(decode::ByteQueue *Output) :
+    WritePos(Output), Alloc(Allocator::Default) {
+  Writer = Alloc->create<ByteWriteStream>();
+}
+
+BinGen::~BinGen() {
+  WritePos.freezeEob();
+  delete TraceWriter;
+}
+
+void BinGen::setTraceProgress(bool NewValue) {
+  TraceProgress = NewValue;
+}
+
+TextWriter *BinGen::getTraceWriter() {
+  if (TraceWriter == nullptr)
+    TraceWriter = new TextWriter();
+  return TraceWriter;
+}
+
+void BinGen::writeIndent() {
+  for (int i = 0; i < IndentLevel; ++i)
+    fprintf(stderr, "  ");
+  fprintf(stderr, "@%" PRIuMAX " ", intmax_t(WritePos.getCurAddress()));
+}
+
+template<class Type>
+Type BinGen::returnValue(const char *Name, Type Value) {
+  if (!TraceProgress)
+    return Value;
+  IndentEnd();
+  fprintf(stderr, "<- %s = %d\n", Name, int(Value));
+  return Value;
+}
+
+void BinGen::enter(const char *Name, bool AddNewline) {
+  IndentBegin();
+  fprintf(stderr, "-> %s", Name);
+  if (AddNewline)
+    fputc('\n', stderr);
+  else
+    fputc(' ', stderr);
+}
+
+void BinGen::exit(const char *Name) {
+  IndentEnd();
+  fprintf(stderr, "<- %s\n", Name);
+}
+
+void BinGen::writePreamble() {
+  Writer->writeUint32(WasmBinaryMagic, WritePos);
+  Writer->writeUint32(WasmBinaryVersion, WritePos);
+}
+
+void BinGen::writeFile(const FileNode *File) {
+  if (TraceProgress) {
+    enter("writeFile");
+  }
+  writeNode(File);
+  exit("writeFile");
+}
+
+void BinGen::writeSection(const SectionNode *Section) {
+  if (TraceProgress) {
+    enter("writeSection", false);
+    getTraceWriter()->writeAbbrev(stderr, Section);
+  }
+  writeNode(Section);
+  exit("writeSection");
+}
+
+void BinGen::writeNode(const Node *Nd) {
+  if (TraceProgress) {
+    enter("writeNode", false);
+    getTraceWriter()->writeAbbrev(stderr, Nd);
+  }
+  switch (NodeType Type = Nd->getType()) {
+    case OpInteger: {
+      // TODO(kschimpf) Fix this list.
+      fprintf(stderr, "Misplaced s-expression: %s\n", getNodeTypeName(Type));
+      fatal("Unable to write filter s-expression");
+      break;
+    }
+    case OpAnd:
+    case OpBlock:
+    case OpByteToByte:
+    case OpOr:
+    case OpNot:
+    case OpBlockEndNoArgs:
+    case OpDefault:
+    case OpDefine:
+    case OpError:
+    case OpEval:
+    case OpEvalDefault:
+    case OpIfThen:
+    case OpIfThenElse:
+    case OpIsByteIn:
+    case OpIsByteOut:
+    case OpLoop:
+    case OpLoopUnbounded:
+    case OpMap:
+    case OpPeek:
+    case OpRead:
+    case OpUint32NoArgs:
+    case OpUint64NoArgs:
+    case OpUint8NoArgs:
+    case OpUndefine:
+    case OpVarint32NoArgs:
+    case OpVarint64NoArgs:
+    case OpVaruint32NoArgs:
+    case OpVaruint64NoArgs:
+    case OpVoid: {
+      // Operations that are written out in postorder, with a fixed number of
+      // arguments.
+      for (const auto *Kid : *Nd)
+        writeNode(Kid);
+      Writer->writeUint8(Type, WritePos);
+      break;
+    }
+    case OpCase: {
+      writeNode(Nd->getKid(1));
+      Writer->writeUint8(Type, WritePos);
+      Writer->writeVaruint32(getIntegerValue(Nd->getKid(0)), WritePos);
+      break;
+    }
+    case OpFile: {
+      for (const auto *Kid : *Nd)
+        writeNode(Kid);
+      break;
+    }
+    case OpSection: {
+      writeNode(Nd->getKid(0)); // name of section
+      writeBlock(
+          [&]() {
+            for (int i = 1, len = Nd->getNumKids(); i < len; ++i)
+              writeNode(Nd->getKid(i));
+          });
+      break;
+    }
+    case OpFilter:
+    case OpSelect:
+    case OpSequence: {
+      // Operations that are written out in postorder, and have a variable
+      // number of arguments.
+      for (const auto *Kid : *Nd)
+        writeNode(Kid);
+      Writer->writeUint8(Type, WritePos);
+      Writer->writeVaruint32(Nd->getNumKids(), WritePos);
+      break;
+    }
+    case OpSymbol: {
+      const SymbolNode *Sym = cast<SymbolNode>(Nd);
+      InternalName SymName = Sym->getName();
+      Writer->writeVaruint32(SymName.size(), WritePos);
+      for (size_t i = 0, len = SymName.size(); i < len; ++i)
+        Writer->writeUint8(SymName[i], WritePos);
+      break;
+    }
+    case OpUint32OneArg:
+    case OpUint64OneArg:
+    case OpUint8OneArg:
+    case OpU32Const:
+    case OpU64Const:
+    case OpVarint32OneArg:
+    case OpVarint64OneArg:
+    case OpVaruint32OneArg:
+    case OpVaruint64OneArg:
+    case OpVersion: {
+      // Operations that get an unsigned integer argument.
+      Writer->writeUint8(Type, WritePos);
+      Writer->writeVaruint32(getIntegerValue(Nd->getKid(0)), WritePos);
+      break;
+    }
+    case OpI32Const:
+    case OpI64Const: {
+      // Operations that get a signed integer argument.
+      Writer->writeUint8(Type, WritePos);
+      Writer->writeVarint32(getIntegerValue(Nd->getKid(0)), WritePos);
+      break;
+    }
+  }
+  exit("writeNode");
+}
+
+void BinGen::writeBlock(std::function<void()> ApplyFn) {
+  WriteCursor BlockPos(WritePos);
+  Writer->writeFixedVaruint32(0, WritePos);
+  size_t SizeAfterSizeWrite = WritePos.getCurAddress();
+  ApplyFn();
+  const size_t NewSize =
+      WritePos.getCurAddress() - (BlockPos.getCurAddress() +
+                                  ByteWriteStream::ChunksInWord);
+  if (!MinimizeBlockSize) {
+    Writer->writeFixedVaruint32(NewSize, BlockPos);
+  } else {
+    Writer->writeVaruint32(NewSize, BlockPos);
+    size_t SizeAfterBackPatch = BlockPos.getCurAddress();
+    size_t Diff = SizeAfterSizeWrite - SizeAfterBackPatch;
+    if (Diff) {
+      size_t End = WritePos.getCurAddress() - Diff;
+      ReadCursor CopyPos(WritePos.getQueue());
+      CopyPos.jumpToAddress(SizeAfterSizeWrite);
+      for (size_t i = SizeAfterBackPatch; i < End; ++ i)
+        BlockPos.writeByte(CopyPos.readByte());
+      WritePos.jumpToAddress(BlockPos.getCurAddress());
+    }
+  }
+}
+
+} // end of namespace filt
+
+} // end of namespace wasm

--- a/src/binary/BinGen.h
+++ b/src/binary/BinGen.h
@@ -1,0 +1,90 @@
+/* -*- C++ -*- */
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Defines a binary generator for filter s-expressions.
+
+#ifndef DECOMPRESSOR_SRC_BINARY_BINGEN_H
+#define DECOMPRESSOR_SRC_BINARY_BINGEN_H
+
+#include "sexp/Ast.h"
+#include "stream/ByteQueue.h"
+#include "stream/Cursor.h"
+#include "interp/ReadStream.h"
+#include "interp/WriteStream.h"
+
+#include <functional>
+
+namespace wasm {
+
+namespace filt {
+
+class TextWriter;
+
+class BinGen {
+  BinGen() = delete;
+  BinGen(const BinGen &) = delete;
+  BinGen &operator=(const BinGen &) = delete;
+public:
+  BinGen(decode::ByteQueue *Output);
+
+  ~BinGen();
+
+  void writePreamble();
+
+  void writeFile(const FileNode *File);
+  void writeSection(const SectionNode *Section);
+
+  void setTraceProgress(bool NewValue);
+
+  void setMinimizeBlockSize(bool NewValue) {
+    MinimizeBlockSize = NewValue;
+  }
+
+private:
+  decode::WriteCursor WritePos;
+  interp::ByteWriteStream *Writer;
+  alloc::Allocator *Alloc;
+  bool MinimizeBlockSize = false;
+  bool TraceProgress = false;
+  int IndentLevel = 0;
+
+  void writeNode(const Node *Symbol);
+  void writeBlock(std::function<void()> ApplyFn);
+
+  // The following are for tracing progress duing binary translation.
+  TextWriter *TraceWriter = nullptr;
+  TextWriter *getTraceWriter();
+  void writeIndent();
+  void IndentBegin() {
+    writeIndent();
+    ++IndentLevel;
+  }
+  void IndentEnd() {
+    --IndentLevel;
+    writeIndent();
+  }
+  void enter(const char *Name, bool AddNewline=true);
+  void exit(const char *Name);
+  template<class Type>
+  Type returnValue(const char *Name, Type Value);
+};
+
+} // end of namespace filt
+
+} // end of namespace wasm
+
+#endif // DECOMPRESSOR_SRC_BINARY_BINGEN_H

--- a/src/interp/State.h
+++ b/src/interp/State.h
@@ -20,6 +20,7 @@
 #ifndef DECOMPRESSOR_SRC_INTERP_INTERPSTATE_H
 #define DECOMPRESSOR_SRC_INTERP_INTERPSTATE_H
 
+#include "stream/ByteQueue.h"
 #include "stream/Cursor.h"
 #include "interp/ReadStream.h"
 #include "interp/WriteStream.h"
@@ -32,6 +33,9 @@ class TextWriter;
 
 namespace interp {
 
+static constexpr uint32_t WasmBinaryMagic = 0x6d736100;
+static constexpr uint32_t WasmBinaryVersion = 0x0b;
+
 class State {
   State() = delete;
   State(const State &) = delete;
@@ -40,6 +44,8 @@ public:
   // TODO(kschimpf): Add Output.
   State(decode::ByteQueue *Input, decode::ByteQueue *Output,
         filt::SymbolTable *Algorithms);
+
+  ~State();
 
   // Processes each section in input, and decompresses it (if applicable)
   // to the corresponding output.
@@ -84,7 +90,7 @@ private:
   // The remaining methods and fields are for tracing progress.
   bool TraceProgress = false;
   int IndentLevel = 0;
-  filt::TextWriter *TraceWriter;
+  filt::TextWriter *TraceWriter = nullptr;
 
   void writeIndent();
   void IndentBegin() {
@@ -97,12 +103,12 @@ private:
   }
   void enter(const char *Name, bool AddNewline=true);
   void exit(const char *Name);
-  IntType returnValue(const char *Name, IntType Value) {
+  decode::IntType returnValue(const char *Name, decode::IntType Value) {
     if (!TraceProgress)
       return Value;
     return returnValueInternal(Name, Value);
   }
-  IntType returnValueInternal(const char *Name, IntType Value);
+  decode::IntType returnValueInternal(const char *Name, decode::IntType Value);
   void traceStreamLocs();
 };
 

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -223,7 +223,6 @@ id ({letter}|{digit}|[_.])*
 "is.byte.out"     return Parser::make_IS_BYTE_OUT(Driver.getLoc());
 "i32.const"       return Parser::make_I32_CONST(Driver.getLoc());
 "i64.const"       return Parser::make_I64_CONST(Driver.getLoc());
-"lit"             return Parser::make_LIT(Driver.getLoc());
 "loop.unbounded"  return Parser::make_LOOP_UNBOUNDED(Driver.getLoc());
 "loop"            return Parser::make_LOOP(Driver.getLoc());
 "map"             return Parser::make_MAP(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -92,7 +92,6 @@ struct IntegerValue {
 %token IS_BYTE_OUT   "is.byte.out"
 %token I32_CONST     "i32.const"
 %token I64_CONST     "i64.const"
-%token LIT           "lit"
 %token LOOP          "loop"
 %token LOOP_UNBOUNDED "loop.unbounded"
 %token OPENPAREN     "("
@@ -174,12 +173,12 @@ case_stmt_list
           }
         | case_stmt_list statement { // remaining statements of case.
             $$ = $1;
-            Node *StmtList = $1->getKid(1);
+            Node *StmtList = $1->getLastKid();
             auto *Seq = dyn_cast<SequenceNode>(StmtList);
             if (Seq == nullptr) {
               Seq = Driver.create<SequenceNode>();
               Seq->append(StmtList);
-              $1->setKid(1, Seq);
+              $1->setLastKid(Seq);
             }
             Seq->append($2);
           }
@@ -203,12 +202,12 @@ declaration_stmt_list
           }
         | declaration_stmt_list statement {
             $$ = $1;
-            Node *StmtList = $1->getKid(1);
+            Node *StmtList = $1->getLastKid();
             auto *Seq = dyn_cast<SequenceNode>(StmtList);
             if (Seq == nullptr) {
               Seq = Driver.create<SequenceNode>();
               Seq->append(StmtList);
-              $1->setKid(1, Seq);
+              $1->setLastKid(Seq);
             }
             Seq->append($2);
           }
@@ -232,12 +231,12 @@ block_stmt_list
           }
         | block_stmt_list statement {
             $$ = $1;
-            Node *StmtList = $1->getKid(0);
+            Node *StmtList = $1->getLastKid();
             auto *Seq = dyn_cast<SequenceNode>(StmtList);
             if (Seq == nullptr) {
               Seq = Driver.create<SequenceNode>();
               Seq->append(StmtList);
-              $1->setKid(0, Seq);
+              $1->setLastKid(Seq);
             }
             Seq->append($2);
           }
@@ -270,9 +269,6 @@ expression
           }
         | "(" "i64.const" integer ")" {
             $$ = Driver.create<I64ConstNode>($3);
-          }
-        | "(" "lit" integer ")" {
-            $$ = Driver.create<LitNode>($3);
           }
         | "(" "map" expression expression ")" {
             $$ = Driver.create<MapNode>($3, $4);
@@ -372,16 +368,22 @@ integer : INTEGER {
           }
 
 loop_body
-        : "loop" expression {
-           $$ = Driver.create<LoopNode>();
-            $$->append($2);
+        : "loop" expression statement {
+            $$ = Driver.create<LoopNode>($2, $3);
           }
-        | "loop.unbounded" {
-            $$ = Driver.create<LoopUnboundedNode>();
+        | "loop.unbounded" statement {
+            $$ = Driver.create<LoopUnboundedNode>($2);
           }
         | loop_body statement {
             $$ = $1;
-            $$->append($2);
+            Node *StmtList = $1->getLastKid();
+            auto *Seq = dyn_cast<SequenceNode>(StmtList);
+            if (Seq == nullptr) {
+              Seq = Driver.create<SequenceNode>();
+              Seq->append(StmtList);
+              $1->setLastKid(Seq);
+            }
+            Seq->append($2);
           }
         ;
 
@@ -450,12 +452,12 @@ stream_conv_stmt_list
           }
         | stream_conv_stmt_list statement {
             $$ = $1;
-            Node *StmtList = $1->getKid(0);
+            Node *StmtList = $1->getLastKid();
             auto *Seq = dyn_cast<SequenceNode>(StmtList);
             if (Seq == nullptr) {
               Seq = Driver.create<SequenceNode>();
               Seq->append(StmtList);
-              $1->setKid(0, Seq);
+              $1->setLastKid(Seq);
             }
             Seq->append($2);
           }

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -27,6 +27,7 @@
 namespace wasm {
 
 using namespace alloc;
+using namespace decode;
 
 namespace filt {
 

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -57,18 +57,18 @@
   /* Formatting */                                                             \
   X(Uint32NoArgs,      0x20, "uint32",           "uint32NoArgs",    0, 0)      \
   X(Uint32OneArg,      0x21, "uint32",           "uint32OneArg",    1, 0)      \
-  X(Uint8NoArgs,       0x22, "uint8",            "uint8NoArgs",     0, 0)      \
-  X(Uint8OneArg,       0x23, "uint8",            "uint8OneArg",     1, 0)      \
-  X(Uint64NoArgs,      0x24, "uint64",           "uint64NoArgs",    0, 0)      \
-  X(Uint64OneArg,      0x25, "uint64",           "uint64OneArg",    1, 0)      \
+  X(Uint64NoArgs,      0x22, "uint64",           "uint64NoArgs",    0, 0)      \
+  X(Uint64OneArg,      0x23, "uint64",           "uint64OneArg",    1, 0)      \
+  X(Uint8NoArgs,       0x24, "uint8",            "uint8NoArgs",     0, 0)      \
+  X(Uint8OneArg,       0x25, "uint8",            "uint8OneArg",     1, 0)      \
   X(Varint32NoArgs,    0x26, "varint32",         "varint32NoArgs",  0, 0)      \
   X(Varint32OneArg,    0x27, "varint32",         "varint32OneArg",  1, 0)      \
   X(Varint64NoArgs,    0x28, "varint64",         "varint64NoArgs",  0, 0)      \
   X(Varint64OneArg,    0x29, "varint64",         "varint64OneArg",  1, 0)      \
-  X(Varuint32NoArgs,   0x2c, "varuint32",        "varuint32NoArgs", 0, 0)      \
-  X(Varuint32OneArg,   0x2d, "varuint32",        "varuint32OneArg", 1, 0)      \
-  X(Varuint64NoArgs,   0x2e, "varuint64",        "varuint64NoArgs", 0, 0)      \
-  X(Varuint64OneArg,   0x2f, "varuint64",        "varuint64OneArg", 1, 0)      \
+  X(Varuint32NoArgs,   0x2a, "varuint32",        "varuint32NoArgs", 0, 0)      \
+  X(Varuint32OneArg,   0x2b, "varuint32",        "varuint32OneArg", 1, 0)      \
+  X(Varuint64NoArgs,   0x2c, "varuint64",        "varuint64NoArgs", 0, 0)      \
+  X(Varuint64OneArg,   0x2d, "varuint64",        "varuint64OneArg", 1, 0)      \
                                                                                \
   /* Boolean tests */                                                          \
   X(And,               0x30, "and",              nullptr,           2, 0)      \
@@ -78,14 +78,13 @@
   X(IsByteOut,         0x34, "is.byte.out",      nullptr,           0, 0)      \
                                                                                \
   /* I/O (and tree) operations  */                                             \
+  X(Map,               0x42, "map",              nullptr,           2, 0)      \
+  X(Peek,              0x43, "peek",             nullptr,           1, 0)      \
 /*  X(AppendNoArgs,      0x40, "append",           "appendNoArgs",    0, 0) */ \
 /*  X(AppendOneArg,      0x41, "append",           "appendOneArg",    1, 0) */ \
-  X(Lit,               0x42, "lit",              nullptr,           1, 0)      \
-  X(Map,               0x43, "map",              nullptr,           2, 0)      \
-  X(Peek,              0x44, "peek",             nullptr,           1, 0)      \
-/*  X(Postorder,         0x45, "postorder",        nullptr,           1, 0) */ \
-/*  X(Preorder,          0x46, "preorder",         nullptr,           1, 0) */ \
-  X(Read,              0x47, "read",             nullptr,           1, 0)      \
+/*  X(Postorder,         0x44, "postorder",        nullptr,           1, 0) */ \
+/*  X(Preorder,          0x45, "preorder",         nullptr,           1, 0) */ \
+  X(Read,              0x46, "read",             nullptr,           1, 0)      \
                                                                                \
   /* Streams */                                                                \
 /*  X(AstToAst,          0x50, "ast.to.ast",       nullptr,           0, 0) */ \
@@ -157,7 +156,7 @@
 /*  X(IntToInt)                                                             */ \
   X(I32Const)                                                                  \
   X(I64Const)                                                                  \
-  X(Lit)                                                                       \
+  X(LoopUnbounded)                                                             \
   X(Not)                                                                       \
   X(Peek)                                                                      \
 /*  X(Postorder)                                                            */ \
@@ -182,6 +181,7 @@
   X(Default)                                                                   \
   X(Define)                                                                    \
   X(IfThen)                                                                    \
+  X(Loop)                                                                      \
   X(Map)                                                                       \
   X(Or)                                                                       \
 
@@ -189,8 +189,6 @@
 #define AST_NARYNODE_TABLE                                                     \
   X(File)                                                                      \
   X(Filter)                                                                    \
-  X(Loop)                                                                      \
-  X(LoopUnbounded)                                                             \
   X(Section)                                                                   \
   X(Sequence)                                                                  \
 
@@ -216,6 +214,8 @@
   X(Case)                                                                      \
   X(Define)                                                                    \
   X(Default)                                                                   \
+  X(Loop)                                                                      \
+  X(LoopUnbounded)                                                             \
 /*  X(IntToAst)                                                             */ \
 /*  X(IntToBit)                                                             */ \
 /*  X(IntToByte)                                                            */ \

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -48,8 +48,6 @@
 
 namespace wasm {
 
-using namespace decode;
-
 namespace filt {
 
 using ExternalName = std::string;
@@ -148,6 +146,10 @@ public:
 
   virtual void setKid(int Index, Node *N) = 0;
 
+  void setLastKid(Node *N) {
+    setKid(getNumKids() - 1, N);
+  }
+
   Node *getLastKid() const {
     if (int Size = getNumKids())
       return getKid(Size-1);
@@ -214,17 +216,18 @@ class IntegerNode final : public NullaryNode {
 public:
   // Note: ValueFormat provided so that we can echo back out same
   // representation as when lexing s-expressions.
-  IntegerNode(decode::IntType Value, ValueFormat Format = ValueFormat::Decimal) :
+  IntegerNode(decode::IntType Value,
+              decode::ValueFormat Format = decode::ValueFormat::Decimal) :
       NullaryNode(alloc::Allocator::Default, OpInteger),
       Value(Value),
       Format(Format) {}
   IntegerNode(alloc::Allocator *Alloc, decode::IntType Value,
-              ValueFormat Format = ValueFormat::Decimal) :
+              decode::ValueFormat Format = decode::ValueFormat::Decimal) :
       NullaryNode(Alloc, OpInteger),
       Value(Value),
       Format(Format) {}
   ~IntegerNode() override {}
-  ValueFormat getFormat() const {
+  decode::ValueFormat getFormat() const {
     return Format;
   }
   decode::IntType getValue() const {
@@ -235,7 +238,7 @@ public:
 
 private:
   decode::IntType Value;
-  ValueFormat Format;
+  decode::ValueFormat Format;
 };
 
 class SymbolNode final : public NullaryNode {
@@ -257,7 +260,6 @@ public:
   const InternalName &getName() const {
     return Name;
   }
-  const std::string getStringName() const;
   const Node *getDefineDefinition() const {
     return DefineDefinition;
   }
@@ -479,10 +481,10 @@ public:
       : NaryNode(Alloc, OpSelect) {}
   static bool implementsClass(NodeType Type) { return OpSelect == Type; }
   void installFastLookup();
-  const Node *getCase(IntType Key) const;
+  const Node *getCase(decode::IntType Key) const;
 private:
   // TODO(kschimpf) Hook this up to allocator.
-  std::unordered_map<IntType, Node *> LookupMap;
+  std::unordered_map<decode::IntType, Node *> LookupMap;
 };
 
 #define X(tag)                                                                 \

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -247,7 +247,6 @@ void TextWriter::writeNodeKidsAbbrev(const Node *Nd, bool EmbeddedInParent) {
     KidsSameLine = MaxKidCountSameLine[int(Type)];
   Node *LastKid = Nd->getLastKid();
   int HasHiddenSeq = HasHiddenSeqSet.count(Type);
-  bool ForceNewline = false;
   for (auto *Kid : *Nd) {
     if ((HasHiddenSeq && Kid == LastKid && isa<SequenceNode>(LastKid))
         || NeverSameLine.count(Kid->getType())) {
@@ -262,7 +261,6 @@ void TextWriter::writeNodeKidsAbbrev(const Node *Nd, bool EmbeddedInParent) {
     }
     if (Count == KidsSameLine) {
       writeSpace();
-      ForceNewline = Count < NumKids;
       writeNode(Kid, false);
       if (Kid != LastKid)
         fprintf(File, " ...");
@@ -272,7 +270,10 @@ void TextWriter::writeNodeKidsAbbrev(const Node *Nd, bool EmbeddedInParent) {
       fprintf(File, " ...");
       return;
     }
+    writeSpace();
     writeNode(Kid, false);
+    if (Kid != LastKid)
+      fprintf(File, " ...");
     return;
   }
 }


### PR DESCRIPTION
Create initial implementation of converting filter section s-expressions into binary form.

Note: Current binary form not that compressed. The major issue is that symbol names take most of the space in the binary format.
