### PR TITLE
Simplify wasm2sexp translation.

### DIFF
--- a/src/binary/BinGen.cpp
+++ b/src/binary/BinGen.cpp
@@ -41,16 +41,6 @@ IntType getIntegerValue(Node *N) {
 
 } // end of anonymous namespace
 
-BinGen::BinGen(decode::ByteQueue *Output, Allocator *Alloc) :
-    WritePos(Output), SectionSymtab(Alloc) {
-  Writer = Alloc->create<ByteWriteStream>();
-}
-
-BinGen::~BinGen() {
-  WritePos.freezeEob();
-  delete TraceWriter;
-}
-
 void BinGen::setTraceProgress(bool NewValue) {
   TraceProgress = NewValue;
 }
@@ -85,6 +75,16 @@ void BinGen::enterInternal(const char *Name, bool AddNewline) {
 void BinGen::exitInternal(const char *Name) {
   IndentEnd();
   fprintf(stderr, "<- %s\n", Name);
+}
+
+BinGen::BinGen(decode::ByteQueue *Output, Allocator *Alloc) :
+    WritePos(Output), SectionSymtab(Alloc) {
+  Writer = Alloc->create<ByteWriteStream>();
+}
+
+BinGen::~BinGen() {
+  WritePos.freezeEob();
+  delete TraceWriter;
 }
 
 void BinGen::writePreamble() {
@@ -126,10 +126,10 @@ void BinGen::writeNode(const Node *Nd) {
     }
     case OpAnd:
     case OpBlock:
+    case OpBlockEndNoArgs:
     case OpByteToByte:
     case OpOr:
     case OpNot:
-    case OpBlockEndNoArgs:
     case OpError:
     case OpIfThen:
     case OpIfThenElse:

--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -76,6 +76,20 @@ private:
   void readSymbolTable();
   void readNode();
 
+  // General ast readers.
+  template<class T> void readNullary();
+  template<class T> void readUnary();
+  template<class T> void readUnarySymbol();
+  template<class T> void readUnaryUint8();
+  template<class T> void readUnaryVarint32();
+  template<class T> void readUnaryVarint64();
+  template<class T> void readUnaryVaruint32();
+  template<class T> void readUnaryVaruint64();
+  template<class T> void readBinary();
+  template<class T> void readBinarySymbol();
+  template<class T> void readTernary();
+  template<class T> void readNary();
+
   // The following are for tracing progress duing binary translation.
   int IndentLevel = 0;
   bool TraceProgress = false;


### PR DESCRIPTION
Add several template methods for constructing each type of node, and then replace construction code chunks with a call to the corresponding template method.
