### PR TITLE
Clean up handling of Eob/Eof

### DIFF
--- a/src/binary/BinaryWriter.h
+++ b/src/binary/BinaryWriter.h
@@ -43,7 +43,7 @@ class BinaryWriter {
  public:
   BinaryWriter(decode::ByteQueue* Output, SymbolTable& Symtab);
 
-  ~BinaryWriter() { WritePos.freezeEob(); }
+  ~BinaryWriter() { WritePos.freezeEof(); }
 
   void writePreamble();
 

--- a/src/interp/State.cpp
+++ b/src/interp/State.cpp
@@ -378,7 +378,7 @@ void State::decompress() {
 
   while (!ReadPos.atEob())
     decompressSection();
-  WritePos.freezeEob();
+  WritePos.freezeEof();
 }
 
 void State::decompressBlock(const Node* Code) {

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -101,6 +101,8 @@ bool ReadBackedByteQueue::readFill(size_t Address) {
 }
 
 WriteBackedByteQueue::~WriteBackedByteQueue() {
+  // NOTE: we must override the base destructor so that calls to dumpFirstPage
+  // is the one local to this class!
   while (FirstPage)
     dumpFirstPage();
 }

--- a/src/stream/ByteQueue.cpp
+++ b/src/stream/ByteQueue.cpp
@@ -47,7 +47,7 @@ size_t ByteQueue::read(size_t& Address, uint8_t* ToBuf, size_t WantedSize) {
   size_t Count = 0;
   PageCursor Cursor;
   while (WantedSize) {
-    size_t FoundSize = Queue::read(Address, WantedSize, Cursor);
+    size_t FoundSize = readFromPage(Address, WantedSize, Cursor);
     if (FoundSize == 0)
       return Count;
     uint8_t* FromBuf = Cursor.getBufferPtr();
@@ -62,7 +62,7 @@ size_t ByteQueue::read(size_t& Address, uint8_t* ToBuf, size_t WantedSize) {
 bool ByteQueue::write(size_t& Address, uint8_t* FromBuf, size_t WantedSize) {
   PageCursor Cursor;
   while (WantedSize) {
-    size_t FoundSize = Queue::write(Address, WantedSize, Cursor);
+    size_t FoundSize = writeToPage(Address, WantedSize, Cursor);
     if (FoundSize == 0)
       return false;
     uint8_t* ToBuf = Cursor.getBufferPtr();

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -28,16 +28,16 @@ void CursorImpl::jumpToByteAddress(size_t NewAddress) {
     return;
   }
   // Move to the wanted page.
-  Queue->Queue::read(NewAddress, 0, PgCursor);
+  Queue->readFromPage(NewAddress, 0, PgCursor);
 }
 
 bool CursorImpl::readFillBuffer() {
   size_t CurAddress = PgCursor.getCurAddress();
-  if (CurAddress >= EobAddress)
+  if (CurAddress >= getEobAddress())
     return false;
-  size_t BufferSize = Queue->Queue::read(CurAddress, Page::Size, PgCursor);
+  size_t BufferSize = Queue->readFromPage(CurAddress, Page::Size, PgCursor);
   if (BufferSize == 0) {
-    EobAddress = Queue->currentSize();
+    setEobAddress(Queue->currentSize());
     return false;
   }
   return true;
@@ -45,9 +45,9 @@ bool CursorImpl::readFillBuffer() {
 
 void CursorImpl::writeFillBuffer() {
   size_t CurAddress = PgCursor.getCurAddress();
-  if (CurAddress >= EobAddress)
+  if (CurAddress >= getEobAddress())
     fatal("Write past Eob");
-  size_t BufferSize = Queue->Queue::write(CurAddress, Page::Size, PgCursor);
+  size_t BufferSize = Queue->writeToPage(CurAddress, Page::Size, PgCursor);
   if (BufferSize == 0)
     fatal("Write failed!\n");
 }
@@ -55,7 +55,7 @@ void CursorImpl::writeFillBuffer() {
 CursorImpl* CursorImpl::copy(StreamType WantedType) {
   assert(Type == WantedType);
   CursorImpl* Impl = new CursorImpl(WantedType, Queue, PgCursor);
-  Impl->EobAddress = EobAddress;
+  Impl->EobPtr = EobPtr;
   return Impl;
 }
 

--- a/src/stream/Page.h
+++ b/src/stream/Page.h
@@ -62,7 +62,8 @@ class Page : public std::enable_shared_from_this<Page> {
   Page& operator=(const Page&) = delete;
 
  public:
-  static constexpr size_t SizeLog2 = 12;
+  // Allow up to a megabyte per page.
+  static constexpr size_t SizeLog2 = 20;
   static constexpr size_t Size = 1 << SizeLog2;
   static constexpr size_t Mask = Size - 1;
 

--- a/src/stream/Queue.h
+++ b/src/stream/Queue.h
@@ -60,6 +60,9 @@ class BlockEob : public std::enable_shared_from_this<BlockEob> {
   size_t getEobAddress() const { return EobAddress; }
   void setEobAddress(size_t Value) { EobAddress = Value; }
   bool undefinedEob() const { return EobAddress == kUndefinedAddress; }
+  std::shared_ptr<BlockEob> getEnclosingEobPtr() const {
+    return EnclosingEobPtr;
+  }
  private:
   size_t EobAddress;
   std::shared_ptr<BlockEob> EnclosingEobPtr;

--- a/test/TestByteQueues.cpp
+++ b/test/TestByteQueues.cpp
@@ -116,7 +116,7 @@ int main(int Argc, char* Argv[]) {
   PageCursor ReadCursor;
   PageCursor WriteCursor;
   while (Address < Input.currentSize()) {
-    size_t ReadBytesAvailable = Input.Queue::read(Address, BufSize, ReadCursor);
+    size_t ReadBytesAvailable = Input.readFromPage(Address, BufSize, ReadCursor);
     if (ReadBytesAvailable == 0) {
       WriteCursor.setMaxAddress(Address);
       break;
@@ -124,7 +124,7 @@ int main(int Argc, char* Argv[]) {
     size_t NextAddress = Address + ReadBytesAvailable;
     while (ReadBytesAvailable) {
       size_t WriteBytesAvailable =
-          Output.Queue::write(Address, ReadBytesAvailable, WriteCursor);
+          Output.writeToPage(Address, ReadBytesAvailable, WriteCursor);
       if (WriteBytesAvailable == 0) {
         fprintf(stderr, "Unable to write address %d, returned zero bytes",
                 int(Address));


### PR DESCRIPTION
Previous code used different representations for "end of block" and "end of file". Further,  read cursors required maintaining a vector (i.e. stack) of "end of blocks". Changed to a single representation (End of block) using shared pointers to automatically clean up as needed.

Resulting code runs 20% faster.
