### PR TITLE
Make cursors a derived class of page cursors.

### DIFF
--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -22,20 +22,20 @@ namespace wasm {
 namespace decode {
 
 void Cursor::jumpToByteAddress(size_t NewAddress) {
-  if (PgCursor.isValidPageAddress(NewAddress)) {
+  if (isValidPageAddress(NewAddress)) {
     // We can reuse the same page, since NewAddress is within the page.
-    PgCursor.setCurAddress(NewAddress);
+    setCurAddress(NewAddress);
     return;
   }
   // Move to the wanted page.
-  Queue->readFromPage(NewAddress, 0, PgCursor);
+  Queue->readFromPage(NewAddress, 0, *this);
 }
 
 bool Cursor::readFillBuffer() {
-  size_t CurAddress = PgCursor.getCurAddress();
+  size_t CurAddress = getCurAddress();
   if (CurAddress >= getEobAddress())
     return false;
-  size_t BufferSize = Queue->readFromPage(CurAddress, Page::Size, PgCursor);
+  size_t BufferSize = Queue->readFromPage(CurAddress, Page::Size, *this);
   if (BufferSize == 0) {
     setEobAddress(Queue->currentSize());
     return false;
@@ -44,16 +44,12 @@ bool Cursor::readFillBuffer() {
 }
 
 void Cursor::writeFillBuffer() {
-  size_t CurAddress = PgCursor.getCurAddress();
+  size_t CurAddress = getCurAddress();
   if (CurAddress >= getEobAddress())
     fatal("Write past Eob");
-  size_t BufferSize = Queue->writeToPage(CurAddress, Page::Size, PgCursor);
+  size_t BufferSize = Queue->writeToPage(CurAddress, Page::Size, *this);
   if (BufferSize == 0)
     fatal("Write failed!\n");
-}
-
-void Cursor::writeCurPage(FILE* File) {
-  Queue->writePageAt(File, PgCursor.getCurAddress());
 }
 
 }  // end of namespace decode


### PR DESCRIPTION
Make general read/write cursors a derived class of page cursors.

This allow for the inheritance of common methods.
