### PR TITLE
Add ability to parse multi-byte opcode

### DIFF
--- a/new-default.df
+++ b/new-default.df
@@ -1,0 +1,207 @@
+# Copyright 2015 WebAssembly Community Group participants
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This file defines the default algorithms for decompressing a WASM
+# module.
+
+# TODO(kschimpf) Generate AST's.
+
+(section 'filter'
+  (version 0)
+
+  (default 'code'
+    (loop (varuint32 6)          # Number of function bodies.
+      (eval 'code.function'))
+  )
+
+  (default 'code.address'
+    (varuint32 6)                # alignment
+    (varuint32 6)                # offset
+  )
+
+  (default 'code.br_table'
+    (uint8)                      # table arity.
+    (loop (varuint32 6)          # number of targets.
+       (uint32 6))               # target depth.
+    (uint32 6)                   # default target depth.
+  )
+
+  (default 'code.br_target'
+     (uint8)                     # br arity.
+     (varuint32 6)               # relative depth
+  )
+
+  (default 'code.call_args'
+    (varuint32 6)                # function arity.
+    (varuint32 6)                # function index
+  )
+
+  (default 'code.function'
+    (block
+      # block implicitly reads   # bytes using (varuint32) on byte stream.
+      (loop (varuint32 6)        # number of locals in function.
+        (eval 'code.local'))
+      (loop.unbounded
+        (eval 'code.opcode')     # reads instruction opcode
+        (eval 'code.inst'))      # selects/parses corresponding instruction.
+      # Insert 0xFFFFFFFF eob opcode if not byte stream.
+      (if (and (is.byte.in) (not (is.byte.out)))
+        (map (i32.const 0xffffffff) (uint32)))
+    )
+  )
+
+  (default 'code.local'
+    (varuint32 6)                # number of locals with type
+    (uint8 3)                    # type of locals.
+  )
+
+  (default 'code.inst'
+    (select (read)
+      # TODO(kschimpf) build asts based on arity of opcodes?
+      (void)                                 # simple one byte opcode.
+      # control flow operators.
+      (case 0x06 (eval 'code.br_target'))    # br
+      (case 0x07 (eval 'code.br_target'))    # br_if
+      (case 0x08 (eval 'code.br_table'))     # br_table
+      (case 0x09 (uint8))                    # return arity
+      # basic operators
+      (case 0x10 (varint32 6))               # i32.const value
+      (case 0x11 (varint64 6))               # i64.const value
+      (case 0x12 (uint64))                   # f64.const value
+      (case 0x13 (uint32))                   # f32.const value
+      (case 0x14 (varuint32 6))              # get_local index
+      (case 0x15 (varuint32 6))              # set_local index
+      (case 0x16 (eval 'code.call_args'))    # call
+      (case 0x17 (eval 'code.call_args'))    # call_indirect
+      (case 0x18 (eval 'code.call_args'))    # call_import
+      # Memory-related operators
+      (case 0x20 (eval 'code.address'))      # i32.load8_s address
+      (case 0x21 (eval 'code.address'))      # i32.load8_u address
+      (case 0x22 (eval 'code.address'))      # i32.load16_s address
+      (case 0x23 (eval 'code.address'))      # i32.load16_u address
+      (case 0x24 (eval 'code.address'))      # i64.load8_s address
+      (case 0x25 (eval 'code.address'))      # i64.load8_u address
+      (case 0x26 (eval 'code.address'))      # i64.load16_s address
+      (case 0x27 (eval 'code.address'))      # i64.load16_u address
+      (case 0x28 (eval 'code.address'))      # i64.load32_s address
+      (case 0x29 (eval 'code.address'))      # i64.load32_u address
+      (case 0x2a (eval 'code.address'))      # i32.load address
+      (case 0x2b (eval 'code.address'))      # i64.load address
+      (case 0x2c (eval 'code.address'))      # f32.load address
+      (case 0x2d (eval 'code.address'))      # f64.load address
+      (case 0x2e (eval 'code.address'))      # i32.store8 address
+      (case 0x2f (eval 'code.address'))      # i32.store16 address
+      (case 0x30 (eval 'code.address'))      # i64.store8 address
+      (case 0x31 (eval 'code.address'))      # i64.store16 address
+      (case 0x32 (eval 'code.address'))      # i64.store32 address
+      (case 0x33 (eval 'code.address'))      # i32.store address
+      (case 0x34 (eval 'code.address'))      # i64.store address
+      (case 0x35 (eval 'code.address'))      # f32.store address
+      (case 0x36 (eval 'code.address'))      # f64.store address
+      (case 0xFFFFFFFF (block.end))          # end function block
+    )
+  )
+
+  (default 'code.opcode'
+    (opcode (uint8)
+      (case 0xffffffff (read))      # EOF marker (non-byte stream only)
+    )
+  )
+
+  (default 'data'
+    (loop (varuint32 6)        # number of data segments.
+      (eval 'data.segment'))
+  )
+
+  (default 'data.segment'
+    # The offset in linear memory at which to store the data.
+     (varuint32 6)
+    # The data
+    (loop (varuint32 6) (uint8))
+  )
+
+  (default 'export'
+    (loop (varuint32 6)        # number of exports
+      (eval 'export.entry'))
+  )
+
+  (default 'export.entry'
+    (varuint32 6)              # function index
+    (eval 'export.symbol')     # funtion name
+  )
+
+  (default 'export.symbol'     # reads in a function name
+    (loop (varuint32 6) (uint8))
+  )
+
+  (default 'function'
+    (loop (varuint32 6)        # Number of type signatures.
+       (varuint32 6))          # type signature index
+  )
+
+  (default 'import'
+    (loop (varuint32 6) (eval 'import.entry'))
+  )
+
+  (default 'import.entry'
+    (varuint32 6)              # signature index of the import
+    (eval 'import.symbol')     # module name
+    (eval 'import.symbol')     # function name
+  )
+
+  (default 'import.symbol'
+    (loop (varuint32 6) (uint8))
+  )
+
+  (default 'memory'
+    (varuint32 6)              # Initial memory suze
+    (varuint32 6)              # maximum memory size
+    (uint8)                    # 1 if the memory is visible outside the module
+  )
+
+  (default 'name'
+    (loop (varuint32 6)        # function name count.
+      (eval 'name.function'))
+  )
+
+  (default 'name.function'
+    (eval 'name.symbol')       # function name
+    (loop (varuint32 6)        # number of local names.
+      (eval 'name.symbol'))    # local name
+  )
+
+  (default 'name.symbol' # reads in a symbol name
+    (loop (varuint32 6) (uint8))
+  )
+
+  (default 'start'
+    (varuint32 6)              # start function index.
+  )
+
+  (default 'table'
+    (loop (varuint32 6)        # Number of table entries.
+       (varuint32 6))          # function index.
+  )
+
+  (default 'type'
+    (loop (varuint32 6)        # number of signatures.
+      (uint8)                  # type form (0x040)
+      (loop (varuint32 6)      # number of parameters parameters
+        (uint8))               # parameter type.
+      (loop (varuint32 6)      # number of return types.
+        (uint8))               # return type.
+    )
+  )
+)

--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -409,6 +409,7 @@ void BinaryReader::readNode() {
       break;
     case OpInteger:
     case OpFile:
+    case OpLastRead:
     case OpOpcode:
     case OpOpcodeCase:
     case OpSection:

--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -409,6 +409,8 @@ void BinaryReader::readNode() {
       break;
     case OpInteger:
     case OpFile:
+    case OpOpcode:
+    case OpOpcodeCase:
     case OpSection:
     case OpSymbol:
     case OpUnknownSection:

--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -71,6 +71,7 @@ void BinaryWriter::writeNode(const Node* Nd) {
   Trace.traceSexp(Nd);
   switch (NodeType Type = Nd->getType()) {
     case OpUnknownSection:
+    case OpLastRead:
     case OpOpcode:
     case OpOpcodeCase:
     case OpInteger: {

--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -71,6 +71,8 @@ void BinaryWriter::writeNode(const Node* Nd) {
   Trace.traceSexp(Nd);
   switch (NodeType Type = Nd->getType()) {
     case OpUnknownSection:
+    case OpOpcode:
+    case OpOpcodeCase:
     case OpInteger: {
       // TODO(kschimpf) Fix this list.
       fprintf(stderr, "Misplaced s-expression: %s\n", getNodeTypeName(Type));

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -103,7 +103,7 @@ int main(int Argc, char* Argv[]) {
       ExpectExitFail = true;
     } else if (Argv[i] == std::string("-h") ||
                Argv[i] == std::string("--help")) {
-      usage(Argv[i]);
+      usage(Argv[0]);
       return exit_status(EXIT_SUCCESS);
     } else if (Argv[i] == std::string("-i")) {
       if (++i >= Argc) {

--- a/src/interp/State.cpp
+++ b/src/interp/State.cpp
@@ -83,6 +83,8 @@ IntType State::eval(const Node* Nd) {
     case OpByteToByte:
     case OpFilter:
     case OpBlockEndNoArgs:
+    case OpOpcode:
+    case OpOpcodeCase:
     case OpSymbol:
       // TODO(kschimpf): Fix above cases.
       fprintf(stderr, "Not implemented: %s\n", getNodeTypeName(Type));

--- a/src/interp/State.cpp
+++ b/src/interp/State.cpp
@@ -82,6 +82,7 @@ IntType State::eval(const Node* Nd) {
   switch (NodeType Type = Nd->getType()) {
     case OpByteToByte:
     case OpFilter:
+    case OpLastRead:
     case OpBlockEndNoArgs:
     case OpOpcode:
     case OpOpcodeCase:

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -233,6 +233,7 @@ id ({letter}|{digit}|[_.])*
 "loop"            return Parser::make_LOOP(Driver.getLoc());
 "map"             return Parser::make_MAP(Driver.getLoc());
 "not"             return Parser::make_NOT(Driver.getLoc());
+"opcode"          return Parser::make_OPCODE(Driver.getLoc());
 "or"              return Parser::make_OR(Driver.getLoc());
 "peek"            return Parser::make_PEEK(Driver.getLoc());
 "read"            return Parser::make_READ(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -126,6 +126,7 @@ struct IntegerValue {
 %type <wasm::filt::Node *> case
 %type <wasm::filt::SelectNode *> case_list
 %type <wasm::filt::Node *> case_stmt_list
+%type <wasm::filt::Node *> constant_expression
 %type <wasm::filt::Node *> declaration
 %type <wasm::filt::SectionNode *> declaration_list
 %type <wasm::filt::Node *> declaration_stmt_list
@@ -189,6 +190,21 @@ case_stmt_list
           }
         ;
 
+constant_expression
+        : "(" "i32.const" integer ")" {
+            $$ = Driver.create<I32ConstNode>($3);
+          }
+        | "(" "i64.const" integer ")" {
+            $$ = Driver.create<I64ConstNode>($3);
+          }
+        | "(" "u32.const" integer ")" {
+            $$ = Driver.create<U32ConstNode>($3);
+          }
+        | "(" "u64.const" integer ")" {
+            $$ = Driver.create<U64ConstNode>($3);
+          }
+        ;
+
 declaration
         : "(" declaration_stmt_list ")" {
             $$ = $2;
@@ -249,6 +265,7 @@ block_stmt_list
 
 expression
         : format_directive { $$ = $1; }
+        | constant_expression { $$ = $1; }
         | "(" "and" expression expression ")" {
             $$ = Driver.create<AndNode>($3, $4);
           }
@@ -270,12 +287,6 @@ expression
         | "(" "is.byte.out" ")" {
             $$ = Driver.create<IsByteOutNode>();
           }
-        | "(" "i32.const" integer ")" {
-            $$ = Driver.create<I32ConstNode>($3);
-          }
-        | "(" "i64.const" integer ")" {
-            $$ = Driver.create<I64ConstNode>($3);
-          }
         | "(" "map" expression expression ")" {
             $$ = Driver.create<MapNode>($3, $4);
           }
@@ -288,17 +299,11 @@ expression
         | "(" "peek" expression ")" {
             $$ = Driver.create<PeekNode>($3);
           }
+        | "(" "read" ")" {
+            $$ = Driver.create<LastReadNode>();
+          }
         | "(" "read" expression ")" {
             $$ = Driver.create<ReadNode>($3);
-          }
-        | "(" "u32.const" integer ")" {
-            $$ = Driver.create<U32ConstNode>($3);
-          }
-        | "(" "u64.const" integer ")" {
-            $$ = Driver.create<U64ConstNode>($3);
-          }
-        | "(" "void" ")" {
-            $$ = Driver.create<VoidNode>();
           }
         ;
 
@@ -346,7 +351,10 @@ format_directive
         ;
 
 fixed_format_directive
-        : "(" "uint8" ")" {
+        : "(" "void" ")" {
+            $$ = Driver.create<VoidNode>();
+          }
+        | "(" "uint8" ")" {
             $$ = Driver.create<Uint8NoArgsNode>();
           }
         | "(" "uint8" integer ")" {
@@ -371,8 +379,9 @@ fixed_format_directive
             $$ = Driver.create<Uint64OneArgNode>($3);
           }
         ;
+
 opcode_expression
-        : fixed_format_directive {
+        : expression {
             $$ = Driver.create<OpcodeNode>();
             $$->append($1);
           }
@@ -383,22 +392,9 @@ opcode_expression
         ;
 
 opcode_case
-        : "(" "case" integer fixed_format_directive ")" {
+        : "(" "case" integer expression  ")" {
             $$ = Driver.create<OpcodeCaseNode>($3, $4);
-
           }
-        | "(" "case" integer "(" "read" ")"  ")" {
-            $$ = Driver.create<OpcodeCaseNode>($3, Driver.create<VoidNode>());
-          }
-        | "(" "case" integer "(" "write" ")"  ")" {
-            $$ = Driver.create<OpcodeCaseNode>($3, Driver.create<VoidNode>());
-          }
-        | "(" "case" integer "(" "opcode" opcode_expression ")" ")" {
-            $$ = Driver.create<OpcodeCaseNode>($3, $6);
-          }
-        | "(" "void" ")" {
-            $$ = Driver.create<VoidNode>();
-         }
         ;
 
 version : "(" "version" integer ")" {

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -94,9 +94,10 @@ struct IntegerValue {
 %token I64_CONST     "i64.const"
 %token LOOP          "loop"
 %token LOOP_UNBOUNDED "loop.unbounded"
-%token OPENPAREN     "("
 %token NOT           "not"
 %token MAP           "map"
+%token OPCODE        "opcode"
+%token OPENPAREN     "("
 %token OR            "or"
 %token PEEK          "peek"
 %token READ          "read"
@@ -130,11 +131,15 @@ struct IntegerValue {
 %type <wasm::filt::Node *> declaration_stmt_list
 %type <wasm::filt::Node *> expression
 %type <wasm::filt::Node *> file
+%type <wasm::filt::Node *> fixed_format_directive
+%type <wasm::filt::Node *> format_directive
 %type <wasm::filt::IntegerNode *> integer
+%type <wasm::filt::Node *> loop_body
+%type <wasm::filt::Node *> opcode_case
+%type <wasm::filt::Node *> opcode_expression
 %type <wasm::filt::Node *> stream_conv
 %type <wasm::filt::Node *> stream_conv_list
 %type <wasm::filt::Node *> stream_conv_stmt_list
-%type <wasm::filt::Node *> loop_body
 %type <wasm::filt::Node *> section
 %type <wasm::filt::Node *> section_list
 %type <wasm::filt::Node *> seq_stmt_list
@@ -243,7 +248,8 @@ block_stmt_list
         ;
 
 expression
-        : "(" "and" expression expression ")" {
+        : format_directive { $$ = $1; }
+        | "(" "and" expression expression ")" {
             $$ = Driver.create<AndNode>($3, $4);
           }
         | "(" "block.end" ")" {
@@ -285,36 +291,19 @@ expression
         | "(" "read" expression ")" {
             $$ = Driver.create<ReadNode>($3);
           }
-        | "(" "uint8" ")" {
-            $$ = Driver.create<Uint8NoArgsNode>();
-          }
-        | "(" "uint8" integer ")" {
-            if ($3->getValue() > 8)
-              Driver.error("uint8 bitsize > 8");
-            $$ = Driver.create<Uint8OneArgNode>($3);
-          }
-        | "(" "uint32" ")" {
-            $$ = Driver.create<Uint32NoArgsNode>();
-          }
-        | "(" "uint32" integer ")"  {
-            if ($3->getValue() > 32)
-              Driver.error("uint32 bitsize > 32");
-            $$ = Driver.create<Uint32OneArgNode>($3);
-          }
-        | "(" "uint64" ")" {
-            $$ = Driver.create<Uint64NoArgsNode>();
-          }
-        | "(" "uint64" integer ")"  {
-            if ($3->getValue() > 64)
-              Driver.error("uint64 bitsize > 64");
-            $$ = Driver.create<Uint64OneArgNode>($3);
-          }
         | "(" "u32.const" integer ")" {
             $$ = Driver.create<U32ConstNode>($3);
           }
         | "(" "u64.const" integer ")" {
             $$ = Driver.create<U64ConstNode>($3);
           }
+        | "(" "void" ")" {
+            $$ = Driver.create<VoidNode>();
+          }
+        ;
+
+format_directive
+        : fixed_format_directive { $$ = $1; }
         | "(" "varint32" ")" {
             $$ = Driver.create<Varint32NoArgsNode>();
           }
@@ -351,9 +340,65 @@ expression
               Driver.error("varuint64 expects 2 <= bitsize <= 64");
             $$ = Driver.create<Varuint64OneArgNode>($3);
           }
+        | "(" "opcode" opcode_expression ")" {
+            $$ = $3;
+          }
+        ;
+
+fixed_format_directive
+        : "(" "uint8" ")" {
+            $$ = Driver.create<Uint8NoArgsNode>();
+          }
+        | "(" "uint8" integer ")" {
+            if ($3->getValue() > 8)
+              Driver.error("uint8 bitsize > 8");
+            $$ = Driver.create<Uint8OneArgNode>($3);
+          }
+        | "(" "uint32" ")" {
+            $$ = Driver.create<Uint32NoArgsNode>();
+          }
+        | "(" "uint32" integer ")"  {
+            if ($3->getValue() > 32)
+              Driver.error("uint32 bitsize > 32");
+            $$ = Driver.create<Uint32OneArgNode>($3);
+          }
+        | "(" "uint64" ")" {
+            $$ = Driver.create<Uint64NoArgsNode>();
+          }
+        | "(" "uint64" integer ")"  {
+            if ($3->getValue() > 64)
+              Driver.error("uint64 bitsize > 64");
+            $$ = Driver.create<Uint64OneArgNode>($3);
+          }
+        ;
+opcode_expression
+        : fixed_format_directive {
+            $$ = Driver.create<OpcodeNode>();
+            $$->append($1);
+          }
+        | opcode_expression opcode_case {
+            $$ = $1;
+            $$->append($2);
+          }
+        ;
+
+opcode_case
+        : "(" "case" integer fixed_format_directive ")" {
+            $$ = Driver.create<OpcodeCaseNode>($3, $4);
+
+          }
+        | "(" "case" integer "(" "read" ")"  ")" {
+            $$ = Driver.create<OpcodeCaseNode>($3, Driver.create<VoidNode>());
+          }
+        | "(" "case" integer "(" "write" ")"  ")" {
+            $$ = Driver.create<OpcodeCaseNode>($3, Driver.create<VoidNode>());
+          }
+        | "(" "case" integer "(" "opcode" opcode_expression ")" ")" {
+            $$ = Driver.create<OpcodeCaseNode>($3, $6);
+          }
         | "(" "void" ")" {
             $$ = Driver.create<VoidNode>();
-          }
+         }
         ;
 
 version : "(" "version" integer ")" {

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -89,6 +89,7 @@
 /*  X(Postorder,         0x44, "postorder",        nullptr,           1, 0) */ \
 /*  X(Preorder,          0x45, "preorder",         nullptr,           1, 0) */ \
   X(Read,              0x46, "read",             nullptr,           1, 0)      \
+  X(LastRead,          0x47, "read",             "lastRead",        0, 0)      \
                                                                                \
   /* Streams */                                                                \
 /*  X(AstToAst,          0x50, "ast.to.ast",       nullptr,           0, 0) */ \
@@ -126,6 +127,7 @@
   X(Error)                                                                     \
   X(IsByteIn)                                                                  \
   X(IsByteOut)                                                                 \
+  X(LastRead)                                                                \
   X(Uint8NoArgs)                                                               \
   X(Uint32NoArgs)                                                              \
   X(Uint64NoArgs)                                                              \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -71,6 +71,8 @@
   X(Varuint32OneArg,   0x2b, "varuint32",        "varuint32OneArg", 1, 0)      \
   X(Varuint64NoArgs,   0x2c, "varuint64",        "varuint64NoArgs", 0, 0)      \
   X(Varuint64OneArg,   0x2d, "varuint64",        "varuint64OneArg", 1, 0)      \
+  X(Opcode,            0x2e, "opcode",           nullptr,           1, 0)      \
+  X(OpcodeCase,        0x2f, "case",             "opcodeCase",      1, 1)      \
                                                                                \
   /* Boolean tests */                                                          \
   X(And,               0x30, "and",              nullptr,           2, 0)      \
@@ -185,12 +187,14 @@
   X(IfThen)                                                                    \
   X(Loop)                                                                      \
   X(Map)                                                                       \
-  X(Or)                                                                       \
+  X(OpcodeCase)                                                                \
+  X(Or)                                                                        \
 
 //#define X(tag)
 #define AST_NARYNODE_TABLE                                                     \
   X(File)                                                                      \
   X(Filter)                                                                    \
+  X(Opcode)                                                                    \
   X(Section)                                                                   \
   X(Sequence)                                                                  \
 
@@ -249,6 +253,8 @@
 /*  X(IntToInt)                                                             */ \
   X(Loop)                                                                      \
   X(LoopUnbounded)                                                             \
+  X(Opcode)                                                                    \
+  X(OpcodeCase)                                                                \
   X(Select)                                                                    \
   X(Sequence)                                                                  \
   X(Section)                                                                   \

--- a/src/stream/WriteUtils.cpp
+++ b/src/stream/WriteUtils.cpp
@@ -91,7 +91,7 @@ void writeInt(FILE* File, IntType Value, ValueFormat Format) {
       fputc('0', File);
       fputc('x', File);
       while (Shift > 0) {
-        Shift >>= BitsInHex;
+        Shift -= BitsInHex;
         decode::IntType Digit = (Value >> Shift);
         if (StartPrinting || Digit != 0) {
           StartPrinting = true;


### PR DESCRIPTION
This CL introduces the first step in separating out opcodes from select statements. The intent is to allow a new form of formatting that is based on the concept of multi-byte opcodes.

It also simplifies extending instruction selection, since it no longer needs to encode the parsing rules of the opcode as well.

The file new-defaults.df shows an example of this refactoring, and will replace defaults.df once completely implemented.
