### PR TITLE
Update read function to handle opcode selectors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,23 +472,19 @@ test: all test-parser test-raw-streams test-byte-queues test-decompress \
 
 .PHONY: test
 
-test-compiler:
+test-all:
 	$(MAKE) DEBUG=0 RELEASE=1 test
 	$(MAKE)  DEBUG=1 RELEASE=0 test
-
-test-all:
-	$(MAKE)  DEBUG=1 RELEASE=0 test-compiler CXX=g++
-	$(MAKE) DEBUG=0 RELEASE=1 test-compiler CXX=clang++
 	@echo "*** all tests passed on both debug and release builds ***"
 
 .PHONY: test-all
 
 presubmit:
 	$(MAKE) clean-all
-	$(MAKE)  DEBUG=1 RELEASE=0 test-compiler CXX=g++
+	$(MAKE) test-all CXX=g++
 	$(MAKE) clean-all
-	$(MAKE) DEBUG=0 RELEASE=1 test-compiler CXX=clang++
-	@echo "*** all tests passed on both debug and release builds ***"
+	$(MAKE) test-all CXX=clang++
+	@echo "*** Presubmit tests passed ***"
 
 .PHONY: presubmit
 

--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -343,6 +343,7 @@ void BinaryReader::readNode() {
     case OpRead:
       readUnary<ReadNode>();
       break;
+    case OpOpcode:
     case OpSelect:
       readNary<SelectNode>();
       cast<SelectNode>(NodeStack.back())->installFastLookup();
@@ -407,12 +408,12 @@ void BinaryReader::readNode() {
     case OpVoid:
       readNullary<VoidNode>();
       break;
+    case OpLastRead:
+      readNullary<LastReadNode>();
+      break;
     case NO_SUCH_NODETYPE:
     case OpInteger:
     case OpFile:
-    case OpLastRead:
-    case OpOpcode:
-    case OpOpcodeCase:
     case OpSection:
     case OpSymbol:
     case OpUnknownSection:

--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -76,7 +76,6 @@ void BinaryWriter::writeNode(const Node* Nd) {
     case OpUnknownSection:
     case OpLastRead:
     case OpOpcode:
-    case OpOpcodeCase:
     case OpInteger: {
       // TODO(kschimpf) Fix this list.
       fprintf(stderr, "Misplaced s-expression: %s\n", getNodeTypeName(Type));

--- a/src/interp/State.h
+++ b/src/interp/State.h
@@ -94,6 +94,12 @@ class State {
   // Writes to output the given value, using format defined by Nd.
   // For convenience, returns written value.
   decode::IntType write(decode::IntType Value, const filt::Node* Nd);
+  decode::IntType readOpcode(const filt::Node* Sel,
+                             decode::IntType PrefixValue,
+                             uint32_t NumOpcodes);
+  // Reads opcode selector into Value. Returns the Bitsize to the (fixed) number
+  // of bits used to read the opcode selector. Otherwise returns zero.
+  uint32_t readOpcodeSelector(const filt::Node* Nd, decode::IntType &Value);
 };
 
 }  // end of namespace interp.

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -137,7 +137,7 @@ struct IntegerValue {
 %type <wasm::filt::IntegerNode *> integer
 %type <wasm::filt::Node *> loop_body
 %type <wasm::filt::Node *> opcode_case
-%type <wasm::filt::Node *> opcode_expression
+%type <wasm::filt::OpcodeNode *> opcode_expression
 %type <wasm::filt::Node *> stream_conv
 %type <wasm::filt::Node *> stream_conv_list
 %type <wasm::filt::Node *> stream_conv_stmt_list
@@ -347,6 +347,7 @@ format_directive
           }
         | "(" "opcode" opcode_expression ")" {
             $$ = $3;
+            $3->installFastLookup();
           }
         ;
 
@@ -393,7 +394,7 @@ opcode_expression
 
 opcode_case
         : "(" "case" integer expression  ")" {
-            $$ = Driver.create<OpcodeCaseNode>($3, $4);
+            $$ = Driver.create<CaseNode>($3, $4);
           }
         ;
 

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -288,16 +288,21 @@ bool NaryNode::implementsClass(NodeType Type) {
 void NaryNode::forceCompilation() {
 }
 
-void SelectNode::forceCompilation() {
+#define X(tag) \
+  void tag##Node::forceCompilation() {}
+AST_NARYNODE_TABLE
+#undef X
+
+void SelectBaseNode::forceCompilation() {
 }
 
-const Node* SelectNode::getCase(IntType Key) const {
+const Node* SelectBaseNode::getCase(IntType Key) const {
   if (LookupMap.count(Key))
     return LookupMap.at(Key);
   return nullptr;
 }
 
-void SelectNode::installFastLookup() {
+void SelectBaseNode::installFastLookup() {
   TextWriter Writer;
   for (auto* Kid : *this) {
     if (const auto* Case = dyn_cast<CaseNode>(Kid)) {
@@ -310,7 +315,7 @@ void SelectNode::installFastLookup() {
 
 #define X(tag) \
   void tag##Node::forceCompilation() {}
-AST_NARYNODE_TABLE
+AST_SELECTNODE_TABLE
 #undef X
 
 }  // end of namespace filt

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -72,7 +72,6 @@
   X(Varuint64NoArgs,   0x2c, "varuint64",        "varuint64NoArgs", 0, 0)      \
   X(Varuint64OneArg,   0x2d, "varuint64",        "varuint64OneArg", 1, 0)      \
   X(Opcode,            0x2e, "opcode",           nullptr,           1, 0)      \
-  X(OpcodeCase,        0x2f, "case",             "opcodeCase",      1, 1)      \
                                                                                \
   /* Boolean tests */                                                          \
   X(And,               0x30, "and",              nullptr,           2, 0)      \
@@ -189,14 +188,17 @@
   X(IfThen)                                                                    \
   X(Loop)                                                                      \
   X(Map)                                                                       \
-  X(OpcodeCase)                                                                \
   X(Or)                                                                        \
+
+//#define X(tag)
+#define AST_SELECTNODE_TABLE                                                   \
+  X(Select)                                                                    \
+  X(Opcode)                                                                    \
 
 //#define X(tag)
 #define AST_NARYNODE_TABLE                                                     \
   X(File)                                                                      \
   X(Filter)                                                                    \
-  X(Opcode)                                                                    \
   X(Section)                                                                   \
   X(Sequence)                                                                  \
 
@@ -256,7 +258,6 @@
   X(Loop)                                                                      \
   X(LoopUnbounded)                                                             \
   X(Opcode)                                                                    \
-  X(OpcodeCase)                                                                \
   X(Select)                                                                    \
   X(Sequence)                                                                  \
   X(Section)                                                                   \


### PR DESCRIPTION
Note: Have not yet implemented write function. Need to build fast cache to help speed up writes of opcode selectors.

Also, the building of the cache can also verify (upfront) whether the opcode selector is valid. This will force fail fast behavior, rather than waiting for first malformed use.
