### PR TITLE
Clean up the way that internal ast caches work.

### DIFF
--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -185,6 +185,7 @@ FileNode* BinaryReader::readFile() {
   while (!ReadPos.atEob())
     File->append(readSection());
   Trace.traceSexp(File);
+  SectionSymtab.install(File);
   return File;
 }
 
@@ -344,11 +345,9 @@ void BinaryReader::readNode() {
       break;
     case OpOpcode:
       readNary<OpcodeNode>();
-      cast<OpcodeNode>(NodeStack.back())->installFastLookup();
       break;
     case OpSelect:
       readNary<SelectNode>();
-      cast<SelectNode>(NodeStack.back())->installFastLookup();
       break;
     case OpSequence:
       readNary<SequenceNode>();

--- a/src/binary/SectionSymbolTable.h
+++ b/src/binary/SectionSymbolTable.h
@@ -52,6 +52,7 @@ class SectionSymbolTable {
   }
   SymbolNode* getIndexSymbol(IndexType Index);
   bool empty() const { return IndexLookup.empty(); }
+  void install(Node* Root) { Symtab.install(Root); }
 
  private:
   // Cache that holds the set of uniquified symbols.

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -83,13 +83,17 @@ void usage(const char* AppName) {
     fprintf(stderr,
             "  -v | --verbose\t"
             "Show progress (can be repeated for more detail).\n");
-    fprintf(stderr, "\t\t\t-v          : "
+    fprintf(stderr,
+            "\t\t\t-v          : "
             "Trace progress of decompression.\n");
-    fprintf(stderr, "\t\t\t-v -v       : "
+    fprintf(stderr,
+            "\t\t\t-v -v       : "
             "Add progress of parsing default files.\n");
-    fprintf(stderr, "\t\t\t-v -v -v    : "
+    fprintf(stderr,
+            "\t\t\t-v -v -v    : "
             "Add progress of lexing default files.\n");
-    fprintf(stderr, "\t\t\t-v -v -v -v : "
+    fprintf(stderr,
+            "\t\t\t-v -v -v -v : "
             "Add progress of installing filter sections.\n");
   }
 }
@@ -135,9 +139,8 @@ int main(int Argc, char* Argv[]) {
       OutputFilename = Argv[i];
     } else if (Argv[i] == std::string("-s")) {
       UseFileStreams = true;
-    } else if (isDebug() &&
-               (Argv[i] == std::string("-v") ||
-                Argv[i] == std::string("--verbose"))) {
+    } else if (isDebug() && (Argv[i] == std::string("-v") ||
+                             Argv[i] == std::string("--verbose"))) {
       ++Verbose;
     } else {
       fprintf(stderr, "Unrecognized option: %s\n", Argv[i]);

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -154,8 +154,7 @@ int main(int Argc, char* Argv[]) {
       ReadBackedByteQueue Input(std::move(Stream));
       BinaryReader Reader(&Input, SymTab);
       Reader.setTraceProgress(Verbose >= 2);
-      if (FileNode* File = Reader.readFile()) {
-        SymTab.install(File);
+      if (Reader.readFile()) {
         continue;
       }
     }

--- a/src/exec/decompsexp-wasm.cpp
+++ b/src/exec/decompsexp-wasm.cpp
@@ -66,10 +66,8 @@ void usage(const char* AppName) {
             "Show progress (can be repeated for more detail).\n");
     fprintf(stderr,
             "\t\t\t-v       : Show progress of writing out wasm file.\n");
-    fprintf(stderr,
-            "\t\t\t-v -v    : Add tracing of parsing s-expressions.\n");
-    fprintf(stderr,
-            "\t\t\t-v -v -v : Add tracing of lexing s-expressions.\n");
+    fprintf(stderr, "\t\t\t-v -v    : Add tracing of parsing s-expressions.\n");
+    fprintf(stderr, "\t\t\t-v -v -v : Add tracing of lexing s-expressions.\n");
   }
 }
 
@@ -115,9 +113,8 @@ int main(int Argc, char* Argv[]) {
       OutputSpecified = true;
     } else if (Argv[i] == std::string("-s")) {
       UseFileStreams = true;
-    } else if (isDebug() &&
-               (Argv[i] == std::string("-v") ||
-                (Argv[i] == std::string("--verbose")))) {
+    } else if (isDebug() && (Argv[i] == std::string("-v") ||
+                             (Argv[i] == std::string("--verbose")))) {
       ++Verbose;
     } else {
       fprintf(stderr, "Unrecognized option: %s\n", Argv[i]);

--- a/src/exec/decompwasm-sexp.cpp
+++ b/src/exec/decompwasm-sexp.cpp
@@ -91,9 +91,8 @@ int main(int Argc, char* Argv[]) {
       OutputFilename = Argv[i];
     } else if (Argv[i] == std::string("-s")) {
       UseFileStreams = true;
-    } else if (isDebug() &&
-               (Argv[i] == std::string("-v") ||
-                Argv[i] == std::string("--verbose"))) {
+    } else if (isDebug() && (Argv[i] == std::string("-v") ||
+                             Argv[i] == std::string("--verbose"))) {
       ++Verbose;
     } else {
       fprintf(stderr, "Unrecognized option: %s\n", Argv[i]);

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -346,7 +346,6 @@ format_directive
             $$ = Driver.create<Varuint64OneArgNode>($3);
           }
         | "(" "opcode" opcode_expression ")" {
-            $3->installFastLookup();
             $$ = $3;
           }
         ;
@@ -467,7 +466,6 @@ statement
         | "(" loop_body ")" { $$ = $2; }
         | "(" "select" case_list ")" {
             $$ = $3;
-            $3->installFastLookup();
           }
         | "(" "seq" seq_stmt_list ")" { $$ = $3; }
         ;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -369,16 +369,10 @@ bool NaryNode::implementsClass(NodeType Type) {
   }
 }
 
-void NaryNode::forceCompilation() {
-}
-
 #define X(tag) \
   void tag##Node::forceCompilation() {}
 AST_NARYNODE_TABLE
 #undef X
-
-void SelectBaseNode::forceCompilation() {
-}
 
 const CaseNode* SelectBaseNode::getCase(IntType Key) const {
   if (LookupMap.count(Key))
@@ -386,8 +380,8 @@ const CaseNode* SelectBaseNode::getCase(IntType Key) const {
   return nullptr;
 }
 
-void SelectBaseNode::installFastLookup() {
-  TextWriter Writer;
+void SelectBaseNode::installCaches(NodeVectorType &AdditionalNodes) {
+  // TextWriter Writer;
   for (auto* Kid : *this) {
     if (const auto* Case = dyn_cast<CaseNode>(Kid)) {
       if (const auto* Key = dyn_cast<IntegerNode>(Case->getKid(0))) {
@@ -607,6 +601,7 @@ void OpcodeNode::installCaseRanges() {
 void OpcodeNode::installCaches(NodeVectorType &AdditionalNodes) {
   TRACE_METHOD("OpcodeNode::installCaches", Node::Trace);
   Node::Trace.traceSexp(this);
+  SelectBaseNode::installCaches(AdditionalNodes);
   installCaseRanges();
 }
 

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -81,37 +81,29 @@ const char* getNodeTypeName(NodeType Type) {
 
 TraceClassSexp Node::Trace("filter sexp");
 
-void Node::forceCompilation() {
-}
-
 void Node::append(Node*) {
   decode::fatal("Node::append not supported for ast node!");
 }
 
-void Node::clearCaches(NodeVectorType &AdditionalNodes) {}
+void Node::clearCaches(NodeVectorType& AdditionalNodes) {
+}
 
-void Node::installCaches(NodeVectorType &AdditionalNodes) {}
+void Node::installCaches(NodeVectorType& AdditionalNodes) {
+}
 
 // Note: we create duumy virtual forceCompilation() to force legal
 // class definitions to be compiled in here. Classes not explicitly
 // instantiated here will not link. This used to force an error if
 // a node type is not defined with the correct template class.
 
-void IntegerNode::forceCompilation() {
-}
-
-void SymbolNode::forceCompilation() {
-}
-
-
-void SymbolNode::clearCaches(NodeVectorType &AdditionalNodes) {
+void SymbolNode::clearCaches(NodeVectorType& AdditionalNodes) {
   if (DefineDefinition)
     AdditionalNodes.push_back(DefineDefinition);
   if (DefaultDefinition)
     AdditionalNodes.push_back(DefaultDefinition);
 }
 
-void SymbolNode::installCaches(NodeVectorType &AdditionalNodes) {
+void SymbolNode::installCaches(NodeVectorType& AdditionalNodes) {
   if (DefineDefinition)
     AdditionalNodes.push_back(DefineDefinition);
   if (DefaultDefinition)
@@ -157,61 +149,60 @@ SymbolNode* SymbolTable::getSymbolDefinition(ExternalName& Name) {
   return Node;
 }
 
-void SymbolTable::install(Node *Root) {
+void SymbolTable::install(Node* Root) {
   TRACE_METHOD("install", Node::Trace);
   // Before starting, clear all known caches.
   VisitedNodesType VisitedNodes;
   NodeVectorType AdditionalNodes;
-  for (const auto &Pair : SymbolMap)
+  for (const auto& Pair : SymbolMap)
     clearSubtreeCaches(Pair.second, VisitedNodes, AdditionalNodes);
   clearSubtreeCaches(Root, VisitedNodes, AdditionalNodes);
   NodeVectorType MoreNodes;
   while (!AdditionalNodes.empty()) {
     MoreNodes.swap(AdditionalNodes);
     while (!MoreNodes.empty()) {
-      Node *Nd = MoreNodes.back();
+      Node* Nd = MoreNodes.back();
       MoreNodes.pop_back();
       clearSubtreeCaches(Nd, VisitedNodes, AdditionalNodes);
     }
   }
   VisitedNodes.clear();
   installDefinitions(Root);
-  for (const auto &Pair : SymbolMap)
+  for (const auto& Pair : SymbolMap)
     installSubtreeCaches(Pair.second, VisitedNodes, AdditionalNodes);
   while (!AdditionalNodes.empty()) {
     MoreNodes.swap(AdditionalNodes);
     while (!MoreNodes.empty()) {
-      Node *Nd = MoreNodes.back();
+      Node* Nd = MoreNodes.back();
       MoreNodes.pop_back();
       installSubtreeCaches(Nd, VisitedNodes, AdditionalNodes);
     }
   }
 }
 
-void SymbolTable::clearSubtreeCaches(Node *Nd,
-                                     VisitedNodesType &VisitedNodes,
-                                     NodeVectorType &AdditionalNodes) {
+void SymbolTable::clearSubtreeCaches(Node* Nd,
+                                     VisitedNodesType& VisitedNodes,
+                                     NodeVectorType& AdditionalNodes) {
   if (VisitedNodes.count(Nd))
     return;
   TRACE_METHOD("clearSubtreeCaches", Node::Trace);
   Node::Trace.traceSexp(Nd);
   VisitedNodes.insert(Nd);
   Nd->clearCaches(AdditionalNodes);
-  for (auto *Kid : *Nd)
+  for (auto* Kid : *Nd)
     AdditionalNodes.push_back(Kid);
 }
 
-
-void SymbolTable::installSubtreeCaches(Node *Nd,
-                                       VisitedNodesType &VisitedNodes,
-                                       NodeVectorType &AdditionalNodes) {
+void SymbolTable::installSubtreeCaches(Node* Nd,
+                                       VisitedNodesType& VisitedNodes,
+                                       NodeVectorType& AdditionalNodes) {
   if (VisitedNodes.count(Nd))
     return;
   TRACE_METHOD("installSubtreeCaches", Node::Trace);
   Node::Trace.traceSexp(Nd);
   VisitedNodes.insert(Nd);
   Nd->installCaches(AdditionalNodes);
-  for (auto *Kid : *Nd)
+  for (auto* Kid : *Nd)
     AdditionalNodes.push_back(Kid);
 }
 
@@ -380,8 +371,11 @@ const CaseNode* SelectBaseNode::getCase(IntType Key) const {
   return nullptr;
 }
 
-void SelectBaseNode::installCaches(NodeVectorType &AdditionalNodes) {
-  // TextWriter Writer;
+void SelectBaseNode::clearCaches(NodeVectorType& AdditionalNodes) {
+  LookupMap.clear();
+}
+
+void SelectBaseNode::installCaches(NodeVectorType& AdditionalNodes) {
   for (auto* Kid : *this) {
     if (const auto* Case = dyn_cast<CaseNode>(Kid)) {
       if (const auto* Key = dyn_cast<IntegerNode>(Case->getKid(0))) {
@@ -391,7 +385,7 @@ void SelectBaseNode::installCaches(NodeVectorType &AdditionalNodes) {
   }
 }
 
-int OpcodeNode::WriteRange::compare(const WriteRange &R) const {
+int OpcodeNode::WriteRange::compare(const WriteRange& R) const {
   if (Min < R.Min)
     return -1;
   if (Min > R.Min)
@@ -410,8 +404,8 @@ int OpcodeNode::WriteRange::compare(const WriteRange &R) const {
 void OpcodeNode::WriteRange::traceInternal(const char* Prefix) const {
   FILE* Out = Node::Trace.getFile();
   Node::Trace.indent();
-  fprintf(Out, "[%" PRIxMAX "..%" PRIxMAX "](%" PRIuMAX"):\n",
-          uintmax_t(Min), uintmax_t(Max), uintmax_t(ShiftValue));
+  fprintf(Out, "[%" PRIxMAX "..%" PRIxMAX "](%" PRIuMAX "):\n", uintmax_t(Min),
+          uintmax_t(Max), uintmax_t(ShiftValue));
   Node::Trace.traceSexp(Case);
 }
 
@@ -430,7 +424,7 @@ IntType getIntegerValue(Node* N) {
   return 0;
 }
 
-bool getCaseSelectorWidth(const Node *Nd, uint32_t &Width) {
+bool getCaseSelectorWidth(const Node* Nd, uint32_t& Width) {
   switch (Nd->getType()) {
     default:
       // Not allowed in opcode cases.
@@ -460,8 +454,7 @@ bool getCaseSelectorWidth(const Node *Nd, uint32_t &Width) {
   return true;
 }
 
-bool addFormatWidth(const Node *Nd,
-                         std::unordered_set<uint32_t> &CaseWidths) {
+bool addFormatWidth(const Node* Nd, std::unordered_set<uint32_t>& CaseWidths) {
   uint32_t Width;
   if (!getCaseSelectorWidth(Nd, Width))
     return false;
@@ -469,8 +462,9 @@ bool addFormatWidth(const Node *Nd,
   return true;
 }
 
-bool collectCaseWidths(IntType Key, const Node *Nd,
-                       std::unordered_set<uint32_t> &CaseWidths) {
+bool collectCaseWidths(IntType Key,
+                       const Node* Nd,
+                       std::unordered_set<uint32_t>& CaseWidths) {
   switch (Nd->getType()) {
     default:
       // Not allowed in opcode cases.
@@ -479,11 +473,11 @@ bool collectCaseWidths(IntType Key, const Node *Nd,
     case OpOpcode:
       if (isa<LastReadNode>(Nd->getKid(0))) {
         for (int i = 1, NumKids = Nd->getNumKids(); i < NumKids; ++i) {
-          Node *Kid = Nd->getKid(i);
+          Node* Kid = Nd->getKid(i);
           assert(isa<CaseNode>(Kid));
-          const CaseNode *Case = cast<CaseNode>(Kid);
+          const CaseNode* Case = cast<CaseNode>(Kid);
           IntType CaseKey = getIntegerValue(Case->getKid(0));
-          const Node *CaseBody = Case->getKid(1);
+          const Node* CaseBody = Case->getKid(1);
           if (CaseKey == Key)
             // Already handled by outer case.
             continue;
@@ -504,17 +498,17 @@ bool collectCaseWidths(IntType Key, const Node *Nd,
         }
         CaseWidths.insert(Width);
         for (int i = 1, NumKids = Nd->getNumKids(); i < NumKids; ++i) {
-          Node *Kid = Nd->getKid(i);
+          Node* Kid = Nd->getKid(i);
           assert(isa<CaseNode>(Kid));
-          const CaseNode *Case = cast<CaseNode>(Kid);
+          const CaseNode* Case = cast<CaseNode>(Kid);
           IntType CaseKey = getIntegerValue(Case->getKid(0));
-          const Node *CaseBody = Case->getKid(1);
+          const Node* CaseBody = Case->getKid(1);
           std::unordered_set<uint32_t> LocalCaseWidths;
           if (!collectCaseWidths(CaseKey, CaseBody, LocalCaseWidths)) {
             Node::Trace.errorSexp("Inside: ", Nd);
             return false;
           }
-          for (uint32_t CaseWidth: LocalCaseWidths) {
+          for (uint32_t CaseWidth : LocalCaseWidths) {
             uint32_t CombinedWidth = Width + CaseWidth;
             if (CombinedWidth >= MaxOpcodeWidth) {
               Node::Trace.errorSexp("Bit width(s) too big: ", Nd);
@@ -533,25 +527,22 @@ bool collectCaseWidths(IntType Key, const Node *Nd,
     case OpUint64OneArg:
       return addFormatWidth(Nd, CaseWidths);
     case OpEval:
-      if (auto *Sym = dyn_cast<SymbolNode>(Nd->getKid(0)))
-        return collectCaseWidths(Key, Sym->getDefineDefinition(),
-                                 CaseWidths);
+      if (auto* Sym = dyn_cast<SymbolNode>(Nd->getKid(0)))
+        return collectCaseWidths(Key, Sym->getDefineDefinition(), CaseWidths);
       Node::Trace.errorSexp("Inside: ", Nd);
       return false;
   }
 }
 
-} // end of anonymous namespace
+}  // end of anonymous namespace
 
 #define X(tag) \
   void tag##Node::forceCompilation() {}
 AST_SELECTNODE_TABLE
 #undef X
 
-void OpcodeNode::forceCompilation() {
-}
-
-void OpcodeNode::clearCaches(NodeVectorType &AdditionalNodes) {
+void OpcodeNode::clearCaches(NodeVectorType& AdditionalNodes) {
+  SelectBaseNode::clearCaches(AdditionalNodes);
   CaseRangeVector.clear();
 }
 
@@ -561,13 +552,12 @@ void OpcodeNode::installCaseRanges() {
     Node::Trace.errorSexp("Inside: ", this);
     fatal("Unable to install caches for opcode s-expression");
   }
-  for (int i = 1, NumKids = getNumKids(); i < NumKids; ++ i) {
+  for (int i = 1, NumKids = getNumKids(); i < NumKids; ++i) {
     assert(isa<CaseNode>(Kids[i]));
-    const CaseNode *Case = cast<CaseNode>(Kids[i]);
+    const CaseNode* Case = cast<CaseNode>(Kids[i]);
     std::unordered_set<uint32_t> CaseWidths;
     IntType Key = getIntegerValue(Case->getKid(0));
-    if (!collectCaseWidths(Key, Case->getKid(1),
-                           CaseWidths)) {
+    if (!collectCaseWidths(Key, Case->getKid(1), CaseWidths)) {
       Node::Trace.errorSexp("Inside: ", Case);
       Node::Trace.errorSexp("Inside: ", this);
       fatal("Unable to install caches for opcode s-expression");
@@ -586,9 +576,9 @@ void OpcodeNode::installCaseRanges() {
   }
   // Validate that ranges are not overlapping.
   std::sort(CaseRangeVector.begin(), CaseRangeVector.end());
-  for (size_t i = 0, Last=CaseRangeVector.size() - 1; i < Last; ++i) {
-    const WriteRange &R1 = CaseRangeVector[i];
-    const WriteRange &R2 = CaseRangeVector[i+1];
+  for (size_t i = 0, Last = CaseRangeVector.size() - 1; i < Last; ++i) {
+    const WriteRange& R1 = CaseRangeVector[i];
+    const WriteRange& R2 = CaseRangeVector[i + 1];
     if (R1.getMax() >= R2.getMin()) {
       Node::Trace.errorSexp("Range 1: ", R1.getCase());
       Node::Trace.errorSexp("Range 2: ", R2.getCase());
@@ -598,23 +588,22 @@ void OpcodeNode::installCaseRanges() {
   }
 }
 
-void OpcodeNode::installCaches(NodeVectorType &AdditionalNodes) {
+void OpcodeNode::installCaches(NodeVectorType& AdditionalNodes) {
   TRACE_METHOD("OpcodeNode::installCaches", Node::Trace);
   Node::Trace.traceSexp(this);
   SelectBaseNode::installCaches(AdditionalNodes);
   installCaseRanges();
 }
 
-const CaseNode *OpcodeNode::getWriteCase(decode::IntType Value,
-                                         uint32_t &SelShift,
-                                         IntType &CaseMask) const {
+const CaseNode* OpcodeNode::getWriteCase(decode::IntType Value,
+                                         uint32_t& SelShift,
+                                         IntType& CaseMask) const {
   // TODO(kschimf): Find a faster lookup (use at least binary search).
-  for (const auto &Range : CaseRangeVector) {
+  for (const auto& Range : CaseRangeVector) {
     if (Value < Range.getMin()) {
       SelShift = 0;
       return nullptr;
-    }
-    else if (Value <= Range.getMax()) {
+    } else if (Value <= Range.getMax()) {
       SelShift = Range.getShiftValue();
       CaseMask = getWidthMask(SelShift);
       return Range.getCase();

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -100,8 +100,9 @@ class Node {
   Node(const Node&) = delete;
   Node& operator=(const Node&) = delete;
   Node() = delete;
-  void forceCompilation();
   friend class SymbolTable;
+ protected:
+  virtual void forceCompilation();
  public:
   typedef size_t IndexType;
   class Iterator {
@@ -193,7 +194,8 @@ class NullaryNode : public Node {
   class tag##Node FINAL : public NullaryNode {                             \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-    virtual void forceCompilation() FINAL;                                 \
+   protected:                                                              \
+    void forceCompilation() OVERRIDE;                                      \
                                                                            \
    public:                                                                 \
     tag##Node() : NullaryNode(alloc::Allocator::Default, Op##tag) {}       \
@@ -209,7 +211,8 @@ class IntegerNode FINAL : public NullaryNode {
   IntegerNode(const IntegerNode&) = delete;
   IntegerNode& operator=(const IntegerNode&) = delete;
   IntegerNode() = delete;
-  virtual void forceCompilation() FINAL;
+ protected:
+  virtual void forceCompilation() OVERRIDE;
 
  public:
   // Note: ValueFormat provided so that we can echo back out same
@@ -238,7 +241,8 @@ class SymbolNode FINAL : public NullaryNode {
   SymbolNode(const SymbolNode&) = delete;
   SymbolNode& operator=(const SymbolNode&) = delete;
   SymbolNode() = delete;
-  virtual void forceCompilation() FINAL;
+ protected:
+  void forceCompilation() OVERRIDE;
 
  public:
   explicit SymbolNode(ExternalName& _Name)
@@ -333,7 +337,8 @@ class UnaryNode : public Node {
   class tag##Node FINAL : public UnaryNode {                               \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-    virtual void forceCompilation() FINAL;                                 \
+   protected:                                                              \
+    void forceCompilation() OVERRIDE;                                      \
                                                                            \
    public:                                                                 \
     explicit tag##Node(Node* Kid)                                          \
@@ -379,7 +384,8 @@ class BinaryNode : public Node {
   class tag##Node FINAL : public BinaryNode {                              \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-    virtual void forceCompilation() FINAL;                                 \
+   protected:                                                              \
+    void forceCompilation() OVERRIDE;                                      \
                                                                            \
    public:                                                                 \
     tag##Node(Node* Kid1, Node* Kid2) : BinaryNode(Op##tag, Kid1, Kid2) {} \
@@ -430,7 +436,8 @@ class TernaryNode : public Node {
   class tag##Node FINAL : public TernaryNode {                             \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-    virtual void forceCompilation() FINAL;                                 \
+   protected:                                                              \
+    void forceCompilation() OVERRIDE;                                      \
                                                                            \
    public:                                                                 \
     tag##Node(Node* Kid1, Node* Kid2, Node* Kid3)                          \
@@ -446,7 +453,6 @@ AST_TERNARYNODE_TABLE
 class NaryNode : public Node {
   NaryNode(const NaryNode&) = delete;
   NaryNode& operator=(const NaryNode&) = delete;
-  virtual void forceCompilation();
 
  public:
   int getNumKids() const OVERRIDE FINAL { return Kids.size(); }
@@ -471,7 +477,8 @@ class NaryNode : public Node {
   class tag##Node FINAL : public NaryNode {                                   \
     tag##Node(const tag##Node&) = delete;                                     \
     tag##Node& operator=(const tag##Node&) = delete;                          \
-    virtual void forceCompilation() FINAL;                                    \
+   protected:                                                                 \
+    void forceCompilation() OVERRIDE;                                         \
                                                                               \
    public:                                                                    \
     tag##Node() : NaryNode(Op##tag) {}                                        \
@@ -485,10 +492,9 @@ AST_NARYNODE_TABLE
 class SelectBaseNode : public NaryNode {
   SelectBaseNode(const SelectBaseNode&) = delete;
   SelectBaseNode& operator=(const SelectBaseNode&) = delete;
-  virtual void forceCompilation();
 
  public:
-  void installFastLookup();
+  void installCaches(NodeVectorType &AdditionalNodes) OVERRIDE;
   const CaseNode* getCase(decode::IntType Key) const;
 
  protected:
@@ -504,7 +510,8 @@ class SelectBaseNode : public NaryNode {
   class tag##Node FINAL : public SelectBaseNode {                          \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-    virtual void forceCompilation() FINAL;                                 \
+   protected:                                                              \
+    void forceCompilation() OVERRIDE;                                      \
                                                                            \
    public:                                                                 \
     tag##Node() : SelectBaseNode(Op##tag) {}                               \
@@ -518,7 +525,8 @@ AST_SELECTNODE_TABLE
 class OpcodeNode FINAL : public SelectBaseNode {
   OpcodeNode(const OpcodeNode&) = delete;
   OpcodeNode& operator=(const OpcodeNode&) = delete;
-  virtual void forceCompilation() FINAL;
+ protected:
+  void forceCompilation() OVERRIDE;
 
  public:
   OpcodeNode() : SelectBaseNode(OpOpcode) {}

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -17,12 +17,12 @@
 
 // Defines an internal model of filter AST's.
 //
-// NOTE: Many classes define  virtual:
+// NOTE: template classes define  virtual:
 //
-//    virtual void forceCompilation() FINAL;
+//    virtual void forceCompilation();
 //
 // This is done to force the compilation of virtuals associated with the
-// class in file Ast.cpp.
+// class to be put in file Ast.cpp.
 //
 // Note: Classes allow an optional allocator as the first argument. This
 // allows the creator to decide what allocator will be used internally.
@@ -101,8 +101,7 @@ class Node {
   Node& operator=(const Node&) = delete;
   Node() = delete;
   friend class SymbolTable;
- protected:
-  virtual void forceCompilation();
+
  public:
   typedef size_t IndexType;
   class Iterator {
@@ -167,8 +166,8 @@ class Node {
  protected:
   NodeType Type;
   Node(alloc::Allocator*, NodeType Type) : Type(Type) {}
-  virtual void clearCaches(NodeVectorType &AdditionalNodes);
-  virtual void installCaches(NodeVectorType &AdditionalNodes);
+  virtual void clearCaches(NodeVectorType& AdditionalNodes);
+  virtual void installCaches(NodeVectorType& AdditionalNodes);
 };
 
 class NullaryNode : public Node {
@@ -194,8 +193,7 @@ class NullaryNode : public Node {
   class tag##Node FINAL : public NullaryNode {                             \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-   protected:                                                              \
-    void forceCompilation() OVERRIDE;                                      \
+    virtual void forceCompilation();                                       \
                                                                            \
    public:                                                                 \
     tag##Node() : NullaryNode(alloc::Allocator::Default, Op##tag) {}       \
@@ -211,8 +209,6 @@ class IntegerNode FINAL : public NullaryNode {
   IntegerNode(const IntegerNode&) = delete;
   IntegerNode& operator=(const IntegerNode&) = delete;
   IntegerNode() = delete;
- protected:
-  virtual void forceCompilation() OVERRIDE;
 
  public:
   // Note: ValueFormat provided so that we can echo back out same
@@ -241,8 +237,6 @@ class SymbolNode FINAL : public NullaryNode {
   SymbolNode(const SymbolNode&) = delete;
   SymbolNode& operator=(const SymbolNode&) = delete;
   SymbolNode() = delete;
- protected:
-  void forceCompilation() OVERRIDE;
 
  public:
   explicit SymbolNode(ExternalName& _Name)
@@ -277,8 +271,8 @@ class SymbolNode FINAL : public NullaryNode {
     DefaultDefinition = nullptr;
     IsDefineUsingDefault = true;
   }
-  void clearCaches(NodeVectorType &AdditionalNodes) OVERRIDE;
-  void installCaches(NodeVectorType &AdditionalNodes) OVERRIDE;
+  void clearCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
+  void installCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
 };
 
 class SymbolTable {
@@ -304,10 +298,12 @@ class SymbolTable {
   // TODO(KarlSchimpf): Use arena allocator on map.
   std::map<ExternalName, SymbolNode*> SymbolMap;
   void installDefinitions(Node* Root);
-  void clearSubtreeCaches(Node *Nd, VisitedNodesType &VisitedNodes,
-                          NodeVectorType &AdditionalNodes);
-  void installSubtreeCaches(Node *Nd, VisitedNodesType &VisitedNoes,
-                            NodeVectorType &AdditionalNodes);
+  void clearSubtreeCaches(Node* Nd,
+                          VisitedNodesType& VisitedNodes,
+                          NodeVectorType& AdditionalNodes);
+  void installSubtreeCaches(Node* Nd,
+                            VisitedNodesType& VisitedNoes,
+                            NodeVectorType& AdditionalNodes);
 };
 
 class UnaryNode : public Node {
@@ -337,8 +333,7 @@ class UnaryNode : public Node {
   class tag##Node FINAL : public UnaryNode {                               \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-   protected:                                                              \
-    void forceCompilation() OVERRIDE;                                      \
+    virtual void forceCompilation();                                       \
                                                                            \
    public:                                                                 \
     explicit tag##Node(Node* Kid)                                          \
@@ -384,8 +379,7 @@ class BinaryNode : public Node {
   class tag##Node FINAL : public BinaryNode {                              \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-   protected:                                                              \
-    void forceCompilation() OVERRIDE;                                      \
+    virtual void forceCompilation();                                       \
                                                                            \
    public:                                                                 \
     tag##Node(Node* Kid1, Node* Kid2) : BinaryNode(Op##tag, Kid1, Kid2) {} \
@@ -436,8 +430,7 @@ class TernaryNode : public Node {
   class tag##Node FINAL : public TernaryNode {                             \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-   protected:                                                              \
-    void forceCompilation() OVERRIDE;                                      \
+    virtual void forceCompilation();                                       \
                                                                            \
    public:                                                                 \
     tag##Node(Node* Kid1, Node* Kid2, Node* Kid3)                          \
@@ -477,8 +470,7 @@ class NaryNode : public Node {
   class tag##Node FINAL : public NaryNode {                                   \
     tag##Node(const tag##Node&) = delete;                                     \
     tag##Node& operator=(const tag##Node&) = delete;                          \
-   protected:                                                                 \
-    void forceCompilation() OVERRIDE;                                         \
+    virtual void forceCompilation();                                          \
                                                                               \
    public:                                                                    \
     tag##Node() : NaryNode(Op##tag) {}                                        \
@@ -494,7 +486,8 @@ class SelectBaseNode : public NaryNode {
   SelectBaseNode& operator=(const SelectBaseNode&) = delete;
 
  public:
-  void installCaches(NodeVectorType &AdditionalNodes) OVERRIDE;
+  void clearCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
+  void installCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
   const CaseNode* getCase(decode::IntType Key) const;
 
  protected:
@@ -510,8 +503,7 @@ class SelectBaseNode : public NaryNode {
   class tag##Node FINAL : public SelectBaseNode {                          \
     tag##Node(const tag##Node&) = delete;                                  \
     tag##Node& operator=(const tag##Node&) = delete;                       \
-   protected:                                                              \
-    void forceCompilation() OVERRIDE;                                      \
+    virtual void forceCompilation();                                       \
                                                                            \
    public:                                                                 \
     tag##Node() : SelectBaseNode(Op##tag) {}                               \
@@ -525,18 +517,17 @@ AST_SELECTNODE_TABLE
 class OpcodeNode FINAL : public SelectBaseNode {
   OpcodeNode(const OpcodeNode&) = delete;
   OpcodeNode& operator=(const OpcodeNode&) = delete;
- protected:
-  void forceCompilation() OVERRIDE;
 
  public:
   OpcodeNode() : SelectBaseNode(OpOpcode) {}
   explicit OpcodeNode(alloc::Allocator* Alloc)
       : SelectBaseNode(Alloc, OpOpcode) {}
   static bool implementsClass(NodeType Type) { return OpOpcode == Type; }
-  const CaseNode *getWriteCase(decode::IntType Value,
-                               uint32_t &SelShift,
-                               decode::IntType &CaseMask) const;
-private:
+  const CaseNode* getWriteCase(decode::IntType Value,
+                               uint32_t& SelShift,
+                               decode::IntType& CaseMask) const;
+
+ private:
   // Associates Opcode Case's with range [Min, Max].
   //
   // Note: Code assumes that shift value and case key is implicitly
@@ -544,19 +535,20 @@ private:
   // comparison.
   class WriteRange {
     WriteRange() = delete;
+
    public:
-    WriteRange(const CaseNode *Case, decode::IntType Min,
-               decode::IntType Max, uint32_t ShiftValue)
+    WriteRange(const CaseNode* Case,
+               decode::IntType Min,
+               decode::IntType Max,
+               uint32_t ShiftValue)
         : Case(Case), Min(Min), Max(Max), ShiftValue(ShiftValue) {}
     ~WriteRange() {}
     const CaseNode* getCase() const { return Case; }
     decode::IntType getMin() const { return Min; }
     decode::IntType getMax() const { return Max; }
     uint32_t getShiftValue() const { return ShiftValue; }
-    int compare(const WriteRange &R) const;
-    bool operator<(const WriteRange &R) const {
-      return compare(R) < 0;
-    }
+    int compare(const WriteRange& R) const;
+    bool operator<(const WriteRange& R) const { return compare(R) < 0; }
     void trace() const {
       if (Trace.getTraceProgress())
         traceInternal("");
@@ -565,15 +557,16 @@ private:
       if (Trace.getTraceProgress())
         traceInternal(Prefix);
     }
+
    private:
-    const CaseNode *Case;
+    const CaseNode* Case;
     decode::IntType Min;
     decode::IntType Max;
     uint32_t ShiftValue;
     void traceInternal(const char* Prefix) const;
   };
-  void clearCaches(NodeVectorType &AdditionalNodes) OVERRIDE;
-  void installCaches(NodeVectorType &AdditionalNodes) OVERRIDE;
+  void clearCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
+  void installCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
   typedef std::vector<WriteRange> CaseRangeVectorType;
   CaseRangeVectorType CaseRangeVector;
   void installCaseRanges();

--- a/src/sexp/TraceSexp.cpp
+++ b/src/sexp/TraceSexp.cpp
@@ -46,13 +46,13 @@ TextWriter* TraceClassSexp::getNewTextWriter() {
   return new TextWriter();
 }
 
-void TraceClassSexp::traceSexpInternal(const char *Prefix, const Node* Node) {
+void TraceClassSexp::traceSexpInternal(const char* Prefix, const Node* Node) {
   indent();
   fprintf(File, "%s", Prefix);
   getTextWriter()->writeAbbrev(File, Node);
 }
 
-void TraceClassSexp::errorSexp(const char *Prefix, const Node* Node) {
+void TraceClassSexp::errorSexp(const char* Prefix, const Node* Node) {
   fprintf(File, "%s", Prefix);
   getTextWriter()->write(File, Node);
 }

--- a/src/sexp/TraceSexp.h
+++ b/src/sexp/TraceSexp.h
@@ -44,20 +44,18 @@ class TraceClassSexp : public utils::TraceClass {
       traceSexpInternal("", Nd);
   }
 
-  void traceSexp(const char *Prefix, const Node* Nd) {
+  void traceSexp(const char* Prefix, const Node* Nd) {
     if (getTraceProgress())
       traceSexpInternal(Prefix, Nd);
   }
 
-  void errorSexp(const char *Prefix, const Node* Nd);
+  void errorSexp(const char* Prefix, const Node* Nd);
 
-  void errorSexp(const Node* Nd) {
-    errorSexp("", Nd);
-  }
+  void errorSexp(const Node* Nd) { errorSexp("", Nd); }
 
  protected:
   TextWriter* Writer;
-  void traceSexpInternal(const char *Prefix, const Node* Nd);
+  void traceSexpInternal(const char* Prefix, const Node* Nd);
 
   TextWriter* getTextWriter() {
     if (Writer == nullptr)

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -31,11 +31,19 @@
 namespace wasm {
 
 #ifdef NDEBUG
-inline bool isRelease() { return true; }
-inline bool isDebug() { return false; }
+inline bool isRelease() {
+  return true;
+}
+inline bool isDebug() {
+  return false;
+}
 #else
-inline bool isRelease() { return false; }
-inline bool isDebug() { return true; }
+inline bool isRelease() {
+  return false;
+}
+inline bool isDebug() {
+  return true;
+}
 #endif
 
 template <class T, size_t N>


### PR DESCRIPTION
All internal AST caches are now done once, immediately after reading the defaults filter section.
