### PR TITLE
Small clean ups in s-expression modeling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,6 +542,10 @@ test-parser: $(TEST_EXECDIR)/TestParser
 	$< -w $(SEXP_DEFAULTS) | diff - $(TEST_SRCS_DIR)/defaults.df
 	$< --expect-fail $(TEST_SRCS_DIR)/MismatchedParens.df 2>&1 | \
 		diff - $(TEST_SRCS_DIR)/MismatchedParens.df-out
+	$< -w -f $(TEST_SRCS_DIR)/defaults.dff | \
+		diff - $(TEST_SRCS_DIR)/defaults.dff
+	$< -w $(TEST_SRCS_DIR)/defaults.df | \
+		diff - $(TEST_SRCS_DIR)/defaults.df
 	@echo "*** parser tests passed ***"
 
 .PHONY: test-parser

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -214,6 +214,7 @@ id ({letter}|{digit}|[_.])*
 [\n]+             Driver.extendLocationLines(yyleng); Driver.stepLocation();
 ")"               return Parser::make_CLOSEPAREN(Driver.getLoc());
 "("               return Parser::make_OPENPAREN(Driver.getLoc());
+"."               return Parser::make_DOT(Driver.getLoc());
 "and"             return Parser::make_AND(Driver.getLoc());
 "ast"             return Parser::make_AST(Driver.getLoc());
 "block"           return Parser::make_BLOCK(Driver.getLoc());
@@ -242,7 +243,6 @@ id ({letter}|{digit}|[_.])*
 "section"         return Parser::make_SECTION(Driver.getLoc());
 "select"          return Parser::make_SELECT(Driver.getLoc());
 "seq"             return Parser::make_SEQ(Driver.getLoc());
-"stream"          return Parser::make_STREAM(Driver.getLoc());
 "uint8"           return Parser::make_UINT8(Driver.getLoc());
 "uint32"          return Parser::make_UINT32(Driver.getLoc());
 "uint64"          return Parser::make_UINT64(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -85,6 +85,7 @@ struct IntegerValue {
 %token CLOSEPAREN    ")"
 %token DEFAULT       "default"
 %token DEFINE        "define"
+%token DOT           "."
 %token ERROR         "error"
 %token EVAL          "eval"
 %token EVAL_DEFAULT  "eval.default"
@@ -106,7 +107,6 @@ struct IntegerValue {
 %token SECTION       "section"
 %token SELECT        "select"
 %token SEQ           "seq"
-%token STREAM        "stream"
 %token UINT8         "uint8"
 %token UINT32        "uint32"
 %token UINT64        "uint64"
@@ -142,8 +142,9 @@ struct IntegerValue {
 %type <wasm::filt::Node *> format_directive
 %type <wasm::filt::Node *> loop_body
 %type <wasm::filt::Node *> opcode_case
-%type <wasm::filt::Node *> opcode_selector
-%type <wasm::filt::OpcodeNode *> opcode_expression
+%type <wasm::filt::Node *> opcode_case_expr
+%type <wasm::filt::Node *> opcode_expression
+%type <wasm::filt::OpcodeNode *> opcode_expr_list
 %type <wasm::filt::Node *> stream
 %type <wasm::filt::Node *> stream_conv
 %type <wasm::filt::Node *> stream_conv_list
@@ -320,6 +321,7 @@ expression
 
 format_directive
         : fixed_format_directive { $$ = $1; }
+        | opcode_expression { $$ = $1; }
         | "(" "varint32" ")" {
             $$ = Driver.create<Varint32NoArgsNode>();
           }
@@ -388,28 +390,30 @@ fixed_format_directive
         ;
 
 opcode_expression
-        : opcode_selector {
+        : "(" "opcode" opcode_expr_list ")" {
+            $$ = $3;
+          }
+        ;
+
+opcode_expr_list
+        : fixed_format_directive {
             $$ = Driver.create<OpcodeNode>();
             $$->append($1);
           }
-        | opcode_expression opcode_case {
+        | opcode_expr_list opcode_case {
             $$ = $1;
             $$->append($2);
           }
         ;
 
-opcode_selector
-        : fixed_format_directive { $$ = $1; }
-        | "(" "eval" symbol ")" {
-            /* TODO(karlschimpf): Should we allow this? */
-            $$ = Driver.create<EvalNode>($3);
-          }
-        ;
-
 opcode_case
-        : "(" "case" constant_expression expression  ")" {
+        : "(" "case" constant_expression opcode_case_expr  ")" {
             $$ = Driver.create<CaseNode>($3, $4);
           }
+
+opcode_case_expr
+        : fixed_format_directive { $$ = $1; }
+        | opcode_expression { $$ = $1; }
         ;
 
 version : "(" "version" INTEGER ")" {
@@ -482,8 +486,8 @@ statement
         ;
 
 stream
-        : "(" "stream" stream_kind stream_type ")" {
-            $$ = Driver.create<StreamNode>($3, $4);
+        : stream_kind "." stream_type {
+            $$ = Driver.create<StreamNode>($1, $3);
           }
         ;
 

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -128,6 +128,7 @@ struct IntegerValue {
 
 // Nonterminal classes.
 %type <wasm::filt::Node *> block_stmt_list
+%type <wasm::filt::Node *> bool_expression
 %type <wasm::filt::Node *> case
 %type <wasm::filt::SelectNode *> case_list
 %type <wasm::filt::Node *> case_stmt_list
@@ -141,6 +142,7 @@ struct IntegerValue {
 %type <wasm::filt::Node *> format_directive
 %type <wasm::filt::Node *> loop_body
 %type <wasm::filt::Node *> opcode_case
+%type <wasm::filt::Node *> opcode_selector
 %type <wasm::filt::OpcodeNode *> opcode_expression
 %type <wasm::filt::Node *> stream
 %type <wasm::filt::Node *> stream_conv
@@ -273,12 +275,23 @@ block_stmt_list
           }
         ;
 
+bool_expression
+        : "(" "and" expression expression ")" {
+            $$ = Driver.create<AndNode>($3, $4);
+          }
+        | stream { $$ = $1; }
+        | "(" "not" expression ")" {
+            $$ = Driver.create<NotNode>($3);
+          }
+        | "(" "or" expression expression ")" {
+            $$ = Driver.create<OrNode>($3, $4);
+          }
+        ;
+
 expression
         : format_directive { $$ = $1; }
         | constant_expression { $$ = $1; }
-        | "(" "and" expression expression ")" {
-            $$ = Driver.create<AndNode>($3, $4);
-          }
+        | bool_expression { $$ = $1; }
         | "(" "block.end" ")" {
             $$ = Driver.create<BlockEndNoArgsNode>();
           }
@@ -291,15 +304,8 @@ expression
         | "(" "eval.default" symbol ")" {
             $$ = Driver.create<EvalDefaultNode>($3);
           }
-        | stream { $$ = $1; }
         | "(" "write" expression expression ")" {
             $$ = Driver.create<WriteNode>($3, $4);
-          }
-        | "(" "not" expression ")" {
-            $$ = Driver.create<NotNode>($3);
-          }
-        | "(" "or" expression expression ")" {
-            $$ = Driver.create<OrNode>($3, $4);
           }
         | "(" "peek" expression ")" {
             $$ = Driver.create<PeekNode>($3);
@@ -382,13 +388,21 @@ fixed_format_directive
         ;
 
 opcode_expression
-        : expression {
+        : opcode_selector {
             $$ = Driver.create<OpcodeNode>();
             $$->append($1);
           }
         | opcode_expression opcode_case {
             $$ = $1;
             $$->append($2);
+          }
+        ;
+
+opcode_selector
+        : fixed_format_directive { $$ = $1; }
+        | "(" "eval" symbol ")" {
+            /* TODO(karlschimpf): Should we allow this? */
+            $$ = Driver.create<EvalNode>($3);
           }
         ;
 

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -543,11 +543,6 @@ bool collectCaseWidths(IntType Key,
     case OpUint64NoArgs:
     case OpUint64OneArg:
       return addFormatWidth(Nd, CaseWidths);
-    case OpEval:
-      if (auto* Sym = dyn_cast<SymbolNode>(Nd->getKid(0)))
-        return collectCaseWidths(Key, Sym->getDefineDefinition(), CaseWidths);
-      Node::Trace.errorSexp("Inside: ", Nd);
-      return false;
   }
 }
 

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -186,9 +186,9 @@ void TextWriter::writeNode(const Node* Nd,
       return;
     }
     case OpStream: {
-      Parenthesize _(this, Type, AddNewline);
+      Indent _(this, AddNewline);
       const auto* Stream = cast<StreamNode>(Nd);
-      fprintf(File, " %s %s", getName(Stream->getStreamKind()),
+      fprintf(File, "%s.%s", getName(Stream->getStreamKind()),
               getName(Stream->getStreamType()));
       LineEmpty = false;
       return;

--- a/src/sexp/defaults.df
+++ b/src/sexp/defaults.df
@@ -57,7 +57,7 @@
         (eval 'code.opcode')     # reads instruction opcode
         (eval 'code.inst'))      # selects/parses corresponding instruction.
       # Insert 0xFFFFFFFF eob opcode if not byte stream.
-      (if (and (stream in byte) (not (stream out byte)))
+      (if (and in.byte (not out.byte))
         (write (u32.const 0xffffffff) (uint32)))
     )
   )

--- a/test/test-sources/defaults.df
+++ b/test/test-sources/defaults.df
@@ -27,7 +27,7 @@
         (eval 'code.opcode')
         (eval 'code.inst')
       )
-      (if (and (stream in byte) (not (stream out byte)))
+      (if (and in.byte (not out.byte))
         (write (u32.const 4294967295) (uint32))
       )
     )

--- a/test/test-sources/defaults.dff
+++ b/test/test-sources/defaults.dff
@@ -27,7 +27,7 @@
         (eval 'code.opcode')
         (eval 'code.inst')
       )
-      (if (and (stream in byte) (not (stream out byte)))
+      (if (and in.byte (not out.byte))
         (write (u32.const 0xffffffff) (uint32))
       )
     )


### PR DESCRIPTION
1) Extract out boolean expressions in the parser.

2) Clean up what is allowed when parsing multibyte opcodes.

3) Simplify surface syntax for stream descriptors.
