### PR TITLE
Clean up allocation of s-expressions

### DIFF
--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -61,6 +61,7 @@ class BinaryReader {
   alloc::Allocator* Alloc;
   interp::ByteReadStream* Reader;
   decode::Cursor ReadPos;
+  SymbolTable &Symtab;
   SectionSymbolTable SectionSymtab;
   // The magic number of the input.
   uint32_t MagicNumber;

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -171,7 +171,7 @@ int main(int Argc, char* Argv[]) {
   }
   ReadBackedByteQueue Input(getInput());
   WriteBackedByteQueue Output(getOutput());
-  Interpreter Decompressor(&Input, &Output, &SymTab);
+  Interpreter Decompressor(Input, Output, SymTab);
   Decompressor.setTraceProgress(Verbose >= 1, TraceIoDifference);
   Decompressor.setMinimizeBlockSize(MinimizeBlockSize);
   Decompressor.decompress();

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -48,19 +48,19 @@ static constexpr uint32_t MaxExpectedSectionNameSize = 32;
 
 }  // end of anonymous namespace
 
-Interpreter::Interpreter(ByteQueue* Input,
-                         ByteQueue* Output,
-                         SymbolTable* Algorithms)
-    : ReadPos(StreamType::Byte, Input),
-      WritePos(StreamType::Byte, Output),
+Interpreter::Interpreter(ByteQueue& Input,
+                         ByteQueue& Output,
+                         SymbolTable& Symtab)
+    : ReadPos(StreamType::Byte, &Input),
+      WritePos(StreamType::Byte, &Output),
       Alloc(Allocator::Default),
-      Algorithms(Algorithms),
+      Symtab(Symtab),
       LastReadValue(0),
       MinimizeBlockSize(false),
       Trace(ReadPos, WritePos, "InterpSexp") {
   Reader = Alloc->create<ByteReadStream>();
   Writer = Alloc->create<ByteWriteStream>();
-  DefaultFormat = Alloc->create<Varuint64NoArgsNode>();
+  DefaultFormat = Symtab.create<Varuint64NoArgsNode>();
   CurSectionName.reserve(MaxExpectedSectionNameSize);
 }
 
@@ -565,7 +565,7 @@ void Interpreter::decompressSection() {
           CurSectionName.c_str());
 #endif
   Trace.traceString("name", CurSectionName);
-  SymbolNode* Sym = Algorithms->getSymbol(CurSectionName);
+  SymbolNode* Sym = Symtab.getSymbol(CurSectionName);
   decompressBlock(Sym ? Sym->getDefineDefinition() : nullptr);
 }
 

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -45,9 +45,9 @@ class Interpreter {
 
  public:
   // TODO(kschimpf): Add Output.
-  Interpreter(decode::ByteQueue* Input,
-              decode::ByteQueue* Output,
-              filt::SymbolTable* Algorithms);
+  Interpreter(decode::ByteQueue& Input,
+              decode::ByteQueue& Output,
+              filt::SymbolTable& Symtab);
 
   ~Interpreter() {}
 
@@ -69,7 +69,7 @@ class Interpreter {
   WriteStream* Writer;
   alloc::Allocator* Alloc;
   filt::Node* DefaultFormat;
-  filt::SymbolTable* Algorithms;
+  filt::SymbolTable& Symtab;
   // The magic number of the input.
   uint32_t MagicNumber;
   // The version of the input.

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -49,7 +49,7 @@ class Driver {
 
   template <typename T, typename... Args>
   T* create(Args&&... args) {
-    return Alloc->create<T>(std::forward<Args>(args)...);
+    return Table.create<T>(std::forward<Args>(args)...);
   }
 
   SymbolNode* getSymbolDefinition(ExternalName& Name) {

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -79,60 +79,6 @@ const char* getNodeTypeName(NodeType Type) {
   return Name;
 }
 
-namespace {
-
-inline Ordering convertToOrdering(int i) {
-  if (i < 0)
-    return Ordering::LessThan;
-  if (i > 0)
-    return Ordering::GreaterThan;
-  return Ordering::Equal;
-}
-
-} // end of anonymous namespace
-
-Ordering Node::compare(const Node &N) const {
-  return convertToOrdering(int(Type) - int(N.Type));
-}
-
-/*
-bool operator<(const Node &N1, const Node &N2) {
-  switch (N1.compare(N2)) {
-    case Ordering::LessThan:
-      return true;
-    case Ordering::Equal:
-    case Ordering::GreaterThan:
-      return false;
-    case Ordering::NotComparable:
-      return N1 < N2;
-  }
-}
-
-bool operator<=(const Node &N1, const Node &N2) {
-  switch (N1.compare(N2)) {
-    case Ordering::LessThan:
-    case Ordering::Equal:
-      return true;
-    case Ordering::GreaterThan:
-      return false;
-    case Ordering::NotComparable:
-      return N1.CreationIndex < N2.CreationIndex;
-  }
-}
-
-bool operator<=(const Node &N1, const Node &N2) {
-  switch (N1.compare(N2)) {
-    case Ordering::LessThan:
-    case Ordering::Equal:
-      return true;
-    case Ordering::GreaterThan:
-      return false;
-    case Ordering::NotComparable:
-      return &N1 < &N2;
-  }
-}
-*/
-
 TraceClassSexp Node::Trace("filter sexp");
 
 void Node::append(Node*) {

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -100,7 +100,7 @@ class SymbolTable {
   void install(Node* Root);
   alloc::Allocator* getAllocator() const { return Alloc; }
   void clear() { SymbolMap.clear(); }
-  size_t getNextCreationIndex() {
+  int getNextCreationIndex() {
     return ++NextCreationIndex;
   }
 
@@ -112,7 +112,7 @@ class SymbolTable {
  private:
   alloc::Allocator* Alloc;
   Node* Error;
-  size_t NextCreationIndex;
+  int NextCreationIndex;
   // TODO(KarlSchimpf): Use arena allocator on map.
   std::map<ExternalName, SymbolNode*> SymbolMap;
   void installDefinitions(Node* Root);
@@ -183,7 +183,7 @@ class Node {
   // WARNING: Only supported if underlying type allows.
   virtual void append(Node* Kid);
 
-  virtual Ordering compare(const Node &N) const;
+  int getCreationIndex() const { return CreationIndex; }
 
   // General iterators for walking kids.
   Iterator begin() const { return Iterator(this, 0); }
@@ -195,19 +195,12 @@ class Node {
 
  protected:
   NodeType Type;
-  size_t CreationIndex;
+  int CreationIndex;
   Node(SymbolTable &Symtab, NodeType Type)
       : Type(Type), CreationIndex(Symtab.getNextCreationIndex()) {}
   virtual void clearCaches(NodeVectorType& AdditionalNodes);
   virtual void installCaches(NodeVectorType& AdditionalNodes);
 };
-
-bool operator<(const Node &N1, const Node &N2);
-bool operator<=(const Node &N1, const Node &N2);
-bool operator==(const Node &N1, const Node& N2);
-bool operator>=(const Node &N1, const Node& N2);
-bool operator>(const Node &N1, const Node& N2);
-bool operator!=(const Node& N1, const Node& N2);
 
 class NullaryNode : public Node {
   NullaryNode(const NullaryNode&) = delete;

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -81,6 +81,7 @@ static constexpr size_t kBitsInIntType = 64;
 
 enum class StreamType : uint8_t { Bit, Byte, Int, Ast };
 const char* getName(StreamType Type);
+Ordering compare(StreamType S1, StreamType S2);
 
 enum class StreamKind : uint8_t { Input, Output };
 const char* getName(StreamKind Type);

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -69,13 +69,14 @@ constexpr T const_maximum(T V, Args... args) {
 static constexpr uint32_t WasmBinaryMagic = 0x6d736100;
 static constexpr uint32_t WasmBinaryVersion = 0x0b;
 
+enum class Ordering : int { LessThan = -1, Equal = 0, GreaterThan = 1, NotComparable = 2 };
+
 namespace decode {
 
 typedef uint64_t IntType;
 typedef int64_t SignedIntType;
 
 #define PRI_IntType PRIu64
-
 static constexpr size_t kBitsInIntType = 64;
 
 enum class StreamType : uint8_t { Bit, Byte, Int, Ast };


### PR DESCRIPTION
The code now ensures that the same allocator is used to generate all nodes associated with a parse/decompression. This will allow the simple insertion of a single arena allocator (when working). When fixed, memory for s-expressions should no longer leak.
