### PR TITLE
Clean up more uses of raw pointers

### DIFF
--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -46,12 +46,11 @@ bool BinaryReader::isBinary(const char* Filename) {
 
 BinaryReader::BinaryReader(std::shared_ptr<decode::Queue> Input, SymbolTable& Symtab)
     : Alloc(Symtab.getAllocator()),
+      Reader(std::make_shared<ByteReadStream>()),
       ReadPos(StreamType::Byte, Input),
       Symtab(Symtab),
       SectionSymtab(Symtab),
-      Trace(ReadPos, "BinaryReader") {
-  Reader = Alloc->create<ByteReadStream>();
-}
+      Trace(ReadPos, "BinaryReader") {}
 
 template <class T>
 void BinaryReader::readNullary() {

--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -45,8 +45,7 @@ bool BinaryReader::isBinary(const char* Filename) {
 }
 
 BinaryReader::BinaryReader(std::shared_ptr<decode::Queue> Input, SymbolTable& Symtab)
-    : Alloc(Symtab.getAllocator()),
-      Reader(std::make_shared<ByteReadStream>()),
+    : Reader(std::make_shared<ByteReadStream>()),
       ReadPos(StreamType::Byte, Input),
       Symtab(Symtab),
       SectionSymtab(Symtab),

--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -58,7 +58,6 @@ class BinaryReader {
   void setTraceProgress(bool NewValue) { Trace.setTraceProgress(NewValue); }
 
  private:
-  alloc::Allocator* Alloc;
   std::shared_ptr<interp::ByteReadStream> Reader;
   decode::Cursor ReadPos;
   SymbolTable &Symtab;

--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -59,7 +59,7 @@ class BinaryReader {
 
  private:
   alloc::Allocator* Alloc;
-  interp::ByteReadStream* Reader;
+  std::shared_ptr<interp::ByteReadStream> Reader;
   decode::Cursor ReadPos;
   SymbolTable &Symtab;
   SectionSymbolTable SectionSymtab;

--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -34,12 +34,10 @@ namespace {}  // end of anonymous namespace
 
 BinaryWriter::BinaryWriter(std::shared_ptr<decode::Queue> Output, SymbolTable& Symtab)
     : WritePos(decode::StreamType::Byte, Output),
-      Writer(nullptr),
+      Writer(std::make_shared<ByteWriteStream>()),
       SectionSymtab(Symtab),
       MinimizeBlockSize(false),
-      Trace(WritePos, "BinaryWriter") {
-  Writer = Symtab.getAllocator()->create<ByteWriteStream>();
-}
+      Trace(WritePos, "BinaryWriter") {}
 
 void BinaryWriter::writePreamble() {
   Writer->writeUint32(WasmBinaryMagic, WritePos);

--- a/src/binary/BinaryWriter.h
+++ b/src/binary/BinaryWriter.h
@@ -56,7 +56,7 @@ class BinaryWriter {
 
  private:
   decode::Cursor WritePos;
-  interp::ByteWriteStream* Writer;
+  std::shared_ptr<interp::ByteWriteStream> Writer;
   SectionSymbolTable SectionSymtab;
   bool MinimizeBlockSize;
   interp::TraceClassSexpWriter Trace;

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -31,7 +31,6 @@
 #include <iostream>
 
 using namespace wasm;
-using namespace wasm::alloc;
 using namespace wasm::filt;
 using namespace wasm::decode;
 using namespace wasm::interp;
@@ -99,8 +98,7 @@ void usage(const char* AppName) {
 }
 
 int main(int Argc, char* Argv[]) {
-  // TODO(karlschimpf) Use arena allocator when arena allocator is working.
-  SymbolTable SymTab(std::make_shared<Malloc>());
+  SymbolTable SymTab;
   int Verbose = 0;
   bool TraceIoDifference = false;
   bool MinimizeBlockSize = false;

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -98,7 +98,7 @@ void usage(const char* AppName) {
 }
 
 int main(int Argc, char* Argv[]) {
-  SymbolTable SymTab;
+  SymbolTable Symtab;
   int Verbose = 0;
   bool TraceIoDifference = false;
   bool MinimizeBlockSize = false;
@@ -146,20 +146,20 @@ int main(int Argc, char* Argv[]) {
       return exit_status(EXIT_FAILURE);
     }
   }
-  Node::Trace.setTraceProgress(Verbose >= 4);
+  Symtab.Trace.setTraceProgress(Verbose >= 4);
   for (int i : DefaultIndices) {
     if (Verbose)
       fprintf(stderr, "Loading default: %s\n", Argv[i]);
     if (BinaryReader::isBinary(Argv[i])) {
       std::shared_ptr<RawStream> Stream = std::make_shared<FileReader>(Argv[i]);
       BinaryReader Reader(std::make_shared<ReadBackedQueue>(std::move(Stream)),
-                          SymTab);
+                          Symtab);
       Reader.setTraceProgress(Verbose >= 2);
       if (Reader.readFile()) {
         continue;
       }
     }
-    Driver Parser(SymTab);
+    Driver Parser(Symtab);
     Parser.setTraceParsing(Verbose >= 2);
     Parser.setTraceLexing(Verbose >= 3);
     if (!Parser.parse(Argv[i])) {
@@ -169,7 +169,7 @@ int main(int Argc, char* Argv[]) {
   }
   Interpreter Decompressor(std::make_shared<ReadBackedQueue>(getInput()),
                            std::make_shared<WriteBackedQueue>(getOutput()),
-                           SymTab);
+                           Symtab);
   Decompressor.setTraceProgress(Verbose >= 1, TraceIoDifference);
   Decompressor.setMinimizeBlockSize(MinimizeBlockSize);
   Decompressor.decompress();

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -31,6 +31,7 @@
 #include <iostream>
 
 using namespace wasm;
+using namespace wasm::alloc;
 using namespace wasm::filt;
 using namespace wasm::decode;
 using namespace wasm::interp;
@@ -98,8 +99,8 @@ void usage(const char* AppName) {
 }
 
 int main(int Argc, char* Argv[]) {
-  wasm::alloc::Malloc Allocator;
-  SymbolTable SymTab(&Allocator);
+  // TODO(karlschimpf) Use arena allocator when arena allocator is working.
+  SymbolTable SymTab(std::make_shared<Malloc>());
   int Verbose = 0;
   bool TraceIoDifference = false;
   bool MinimizeBlockSize = false;

--- a/src/exec/decompsexp-wasm.cpp
+++ b/src/exec/decompsexp-wasm.cpp
@@ -29,7 +29,6 @@
 #include <iostream>
 
 using namespace wasm;
-using namespace wasm::alloc;
 using namespace wasm::filt;
 using namespace wasm::decode;
 
@@ -122,8 +121,7 @@ int main(int Argc, char* Argv[]) {
       return exit_status(EXIT_FAILURE);
     }
   }
-  // TODO(karlschimpf) Use arena allocator once working.
-  SymbolTable Symtab(std::make_shared<Malloc>());
+  SymbolTable Symtab;
   Driver Parser(Symtab);
   Parser.setTraceParsing(Verbose >= 2);
   Parser.setTraceLexing(Verbose >= 3);

--- a/src/exec/decompsexp-wasm.cpp
+++ b/src/exec/decompsexp-wasm.cpp
@@ -29,6 +29,7 @@
 #include <iostream>
 
 using namespace wasm;
+using namespace wasm::alloc;
 using namespace wasm::filt;
 using namespace wasm::decode;
 
@@ -122,16 +123,14 @@ int main(int Argc, char* Argv[]) {
     }
   }
   // TODO(karlschimpf) Use arena allocator once working.
-  wasm::alloc::Malloc Allocator;
-  SymbolTable SymTab(&Allocator);
-  Driver Parser(SymTab);
+  SymbolTable Symtab(std::make_shared<Malloc>());
+  Driver Parser(Symtab);
   Parser.setTraceParsing(Verbose >= 2);
   Parser.setTraceLexing(Verbose >= 3);
   if (!Parser.parse(InputFilename)) {
     fprintf(stderr, "Unable to parse s-expressions: %s\n", InputFilename);
     return exit_status(EXIT_FAILURE);
   }
-  SymbolTable Symtab(&Allocator);
   BinaryWriter Writer(std::make_shared<WriteBackedQueue>(getOutput()),
                       Symtab);
   Writer.setTraceProgress(Verbose >= 1);

--- a/src/exec/decompwasm-sexp.cpp
+++ b/src/exec/decompwasm-sexp.cpp
@@ -100,8 +100,7 @@ int main(int Argc, char* Argv[]) {
     }
   }
   // TODO(karlschimpf) Use arena allocator once working.
-  Malloc Allocator;
-  SymbolTable Symtab(&Allocator);
+  SymbolTable Symtab(std::make_shared<Malloc>());
   BinaryReader Reader(std::make_shared<ReadBackedQueue>(getInput()),
                       Symtab);
   Reader.setTraceProgress(Verbose >= 1);

--- a/src/exec/decompwasm-sexp.cpp
+++ b/src/exec/decompwasm-sexp.cpp
@@ -29,7 +29,6 @@
 #include <iostream>
 
 using namespace wasm;
-using namespace wasm::alloc;
 using namespace wasm::filt;
 using namespace wasm::decode;
 
@@ -99,8 +98,7 @@ int main(int Argc, char* Argv[]) {
       return exit_status(EXIT_FAILURE);
     }
   }
-  // TODO(karlschimpf) Use arena allocator once working.
-  SymbolTable Symtab(std::make_shared<Malloc>());
+  SymbolTable Symtab;
   BinaryReader Reader(std::make_shared<ReadBackedQueue>(getInput()),
                       Symtab);
   Reader.setTraceProgress(Verbose >= 1);

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -64,10 +64,9 @@ class Interpreter {
 
  private:
   decode::Cursor ReadPos;
-  ReadStream* Reader;
+  std::shared_ptr<ReadStream> Reader;
   decode::Cursor WritePos;
-  WriteStream* Writer;
-  alloc::Allocator* Alloc;
+  std::shared_ptr<WriteStream> Writer;
   filt::Node* DefaultFormat;
   filt::SymbolTable& Symtab;
   // The magic number of the input.

--- a/src/interp/ReadStream.h
+++ b/src/interp/ReadStream.h
@@ -24,13 +24,15 @@
 #include "stream/Cursor.h"
 #include "utils/Casting.h"
 
+#include <memory>
+
 namespace wasm {
 
 namespace interp {
 
 class State;
 
-class ReadStream {
+class ReadStream : public std::enable_shared_from_this<ReadStream> {
   ReadStream(const ReadStream&) = delete;
   ReadStream& operator=(const ReadStream&) = delete;
 

--- a/src/interp/WriteStream.h
+++ b/src/interp/WriteStream.h
@@ -24,13 +24,15 @@
 #include "stream/Cursor.h"
 #include "utils/Casting.h"
 
+#include <memory>
+
 namespace wasm {
 
 namespace interp {
 
 class State;
 
-class WriteStream {
+class WriteStream : public std::enable_shared_from_this<WriteStream> {
   WriteStream(const WriteStream&) = delete;
   WriteStream& operator=(const WriteStream&) = delete;
 

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -56,8 +56,6 @@ class Driver {
     return Table.getSymbolDefinition(Name);
   }
 
-  std::shared_ptr<alloc::Allocator> getAllocator() { return Alloc; }
-
   // The name of the file being parsed.
   std::string& getFilename() { return Filename; }
 

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -56,7 +56,7 @@ class Driver {
     return Table.getSymbolDefinition(Name);
   }
 
-  alloc::Allocator* getAllocator() { return Alloc; }
+  std::shared_ptr<alloc::Allocator> getAllocator() { return Alloc; }
 
   // The name of the file being parsed.
   std::string& getFilename() { return Filename; }
@@ -100,7 +100,7 @@ class Driver {
 
  private:
   SymbolTable& Table;
-  alloc::Allocator* Alloc;
+  std::shared_ptr<alloc::Allocator> Alloc;
   std::string Filename;
   bool TraceLexing;
   bool TraceParsing;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -113,8 +113,9 @@ std::string SymbolNode::getStringName() const {
   return Str;
 }
 
-SymbolTable::SymbolTable(std::shared_ptr<alloc::Allocator> Alloc) :
-    Alloc(Alloc), NextCreationIndex(0)
+SymbolTable::SymbolTable() :
+    // TODO(karlschimpf) Switch Alloc to an ArenaAllocator once working.
+    Alloc(std::make_shared<Malloc>()), NextCreationIndex(0)
 {
   Error = Alloc->create<ErrorNode>(*this);
 }

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -113,7 +113,7 @@ std::string SymbolNode::getStringName() const {
   return Str;
 }
 
-SymbolTable::SymbolTable(alloc::Allocator* Alloc) :
+SymbolTable::SymbolTable(std::shared_ptr<alloc::Allocator> Alloc) :
     Alloc(Alloc), NextCreationIndex(0)
 {
   Error = Alloc->create<ErrorNode>(*this);

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -79,8 +79,6 @@ const char* getNodeTypeName(NodeType Type) {
   return Name;
 }
 
-TraceClassSexp Node::Trace("filter sexp");
-
 void Node::append(Node*) {
   decode::fatal("Node::append not supported for ast node!");
 }
@@ -115,8 +113,8 @@ std::string SymbolNode::getStringName() const {
 
 SymbolTable::SymbolTable() :
     // TODO(karlschimpf) Switch Alloc to an ArenaAllocator once working.
-    Alloc(std::make_shared<Malloc>()), NextCreationIndex(0)
-{
+    Trace("NodesTable"),
+    Alloc(std::make_shared<Malloc>()), NextCreationIndex(0) {
   Error = Alloc->create<ErrorNode>(*this);
 }
 
@@ -130,7 +128,7 @@ SymbolNode* SymbolTable::getSymbolDefinition(ExternalName& Name) {
 }
 
 void SymbolTable::install(Node* Root) {
-  TRACE_METHOD("install", Node::Trace);
+  TRACE_METHOD("install", Trace);
   // Before starting, clear all known caches.
   VisitedNodesType VisitedNodes;
   NodeVectorType AdditionalNodes;
@@ -165,8 +163,8 @@ void SymbolTable::clearSubtreeCaches(Node* Nd,
                                      NodeVectorType& AdditionalNodes) {
   if (VisitedNodes.count(Nd))
     return;
-  TRACE_METHOD("clearSubtreeCaches", Node::Trace);
-  Node::Trace.traceSexp(Nd);
+  TRACE_METHOD("clearSubtreeCaches", Trace);
+  Trace.traceSexp(Nd);
   VisitedNodes.insert(Nd);
   Nd->clearCaches(AdditionalNodes);
   for (auto* Kid : *Nd)
@@ -178,8 +176,8 @@ void SymbolTable::installSubtreeCaches(Node* Nd,
                                        NodeVectorType& AdditionalNodes) {
   if (VisitedNodes.count(Nd))
     return;
-  TRACE_METHOD("installSubtreeCaches", Node::Trace);
-  Node::Trace.traceSexp(Nd);
+  TRACE_METHOD("installSubtreeCaches", Trace);
+  Trace.traceSexp(Nd);
   VisitedNodes.insert(Nd);
   Nd->installCaches(AdditionalNodes);
   for (auto* Kid : *Nd)
@@ -187,8 +185,8 @@ void SymbolTable::installSubtreeCaches(Node* Nd,
 }
 
 void SymbolTable::installDefinitions(Node* Root) {
-  TRACE_METHOD("installDefinitions", Node::Trace);
-  Node::Trace.traceSexp(Root);
+  TRACE_METHOD("installDefinitions", Trace);
+  Trace.traceSexp(Root);
   if (Root == nullptr)
     return;
   switch (Root->getType()) {
@@ -204,7 +202,7 @@ void SymbolTable::installDefinitions(Node* Root) {
         DefineSymbol->setDefineDefinition(Root->getKid(1));
         return;
       }
-      Node::Trace.errorSexp("Malformed: ", Root);
+      Trace.errorSexp("Malformed: ", Root);
       fatal("Malformed define s-expression found!");
       return;
     }
@@ -216,7 +214,7 @@ void SymbolTable::installDefinitions(Node* Root) {
           return;
         }
       }
-      Node::Trace.errorSexp("Malformed: ", Root);
+      Trace.errorSexp("Malformed: ", Root);
       fatal("Malformed rename s-expression found!");
       return;
     }
@@ -225,7 +223,7 @@ void SymbolTable::installDefinitions(Node* Root) {
         UndefineSymbol->setDefineDefinition(nullptr);
         return;
       }
-      Node::Trace.errorSexp("Can't undefine: ", Root);
+      Trace.errorSexp("Can't undefine: ", Root);
       fatal("Malformed undefine s-expression found!");
     }
   }
@@ -410,12 +408,13 @@ int OpcodeNode::WriteRange::compare(const WriteRange& R) const {
   return 0;
 }
 
-void OpcodeNode::WriteRange::traceInternal(const char* Prefix) const {
-  FILE* Out = Node::Trace.getFile();
-  Node::Trace.indent();
+void OpcodeNode::WriteRange::traceInternal(const char* Prefix,
+                                           TraceClassSexp &Trace) const {
+  FILE* Out = Trace.getFile();
+  Trace.indent();
   fprintf(Out, "[%" PRIxMAX "..%" PRIxMAX "](%" PRIuMAX "):\n", uintmax_t(Min),
           uintmax_t(Max), uintmax_t(ShiftValue));
-  Node::Trace.traceSexp(Case);
+  Trace.traceSexp(Case);
 }
 
 namespace {
@@ -437,7 +436,7 @@ bool getCaseSelectorWidth(const Node* Nd, uint32_t& Width) {
   switch (Nd->getType()) {
     default:
       // Not allowed in opcode cases.
-      Node::Trace.errorSexp("Non-fixed width opcode format: ", Nd);
+      Nd->getTrace().errorSexp("Non-fixed width opcode format: ", Nd);
       return false;
     case OpUint8NoArgs:
       Width = 8;
@@ -457,7 +456,7 @@ bool getCaseSelectorWidth(const Node* Nd, uint32_t& Width) {
   }
   Width = getIntegerValue(Nd->getKid(0));
   if (Width == 0 || Width >= MaxOpcodeWidth) {
-    Node::Trace.errorSexp("Bit size not valid: ", Nd);
+    Nd->getTrace().errorSexp("Bit size not valid: ", Nd);
     return false;
   }
   return true;
@@ -477,7 +476,7 @@ bool collectCaseWidths(IntType Key,
   switch (Nd->getType()) {
     default:
       // Not allowed in opcode cases.
-      Node::Trace.errorSexp("Non-fixed width opcode format: ", Nd);
+      Nd->getTrace().errorSexp("Non-fixed width opcode format: ", Nd);
       return false;
     case OpOpcode:
       if (isa<LastReadNode>(Nd->getKid(0))) {
@@ -491,18 +490,18 @@ bool collectCaseWidths(IntType Key,
             // Already handled by outer case.
             continue;
           if (!collectCaseWidths(CaseKey, CaseBody, CaseWidths)) {
-            Node::Trace.errorSexp("Inside: ", Nd);
+            Nd->getTrace().errorSexp("Inside: ", Nd);
             return false;
           }
         }
       } else {
         uint32_t Width;
         if (!getCaseSelectorWidth(Nd->getKid(0), Width)) {
-          Node::Trace.errorSexp("Inside: ", Nd);
+          Nd->getTrace().errorSexp("Inside: ", Nd);
           return false;
         }
         if (Width >= MaxOpcodeWidth) {
-          Node::Trace.errorSexp("Bit width(s) too big: ", Nd);
+          Nd->getTrace().errorSexp("Bit width(s) too big: ", Nd);
           return false;
         }
         CaseWidths.insert(Width);
@@ -514,13 +513,13 @@ bool collectCaseWidths(IntType Key,
           const Node* CaseBody = Case->getKid(1);
           std::unordered_set<uint32_t> LocalCaseWidths;
           if (!collectCaseWidths(CaseKey, CaseBody, LocalCaseWidths)) {
-            Node::Trace.errorSexp("Inside: ", Nd);
+            Nd->getTrace().errorSexp("Inside: ", Nd);
             return false;
           }
           for (uint32_t CaseWidth : LocalCaseWidths) {
             uint32_t CombinedWidth = Width + CaseWidth;
             if (CombinedWidth >= MaxOpcodeWidth) {
-              Node::Trace.errorSexp("Bit width(s) too big: ", Nd);
+              Nd->getTrace().errorSexp("Bit width(s) too big: ", Nd);
               return false;
             }
             CaseWidths.insert(CombinedWidth);
@@ -553,7 +552,7 @@ void OpcodeNode::clearCaches(NodeVectorType& AdditionalNodes) {
 void OpcodeNode::installCaseRanges() {
   uint32_t InitialWidth;
   if (!getCaseSelectorWidth(getKid(0), InitialWidth)) {
-    Node::Trace.errorSexp("Inside: ", this);
+    getTrace().errorSexp("Inside: ", this);
     fatal("Unable to install caches for opcode s-expression");
   }
   for (int i = 1, NumKids = getNumKids(); i < NumKids; ++i) {
@@ -562,14 +561,14 @@ void OpcodeNode::installCaseRanges() {
     std::unordered_set<uint32_t> CaseWidths;
     IntType Key = getIntegerValue(Case->getKid(0));
     if (!collectCaseWidths(Key, Case->getKid(1), CaseWidths)) {
-      Node::Trace.errorSexp("Inside: ", Case);
-      Node::Trace.errorSexp("Inside: ", this);
+      getTrace().errorSexp("Inside: ", Case);
+      getTrace().errorSexp("Inside: ", this);
       fatal("Unable to install caches for opcode s-expression");
     }
     for (uint32_t NestedWidth : CaseWidths) {
       uint32_t Width = InitialWidth + NestedWidth;
       if (Width > MaxOpcodeWidth) {
-        Node::Trace.errorSexp("Bit width(s) too big: ", this);
+        getTrace().errorSexp("Bit width(s) too big: ", this);
         fatal("Unable to install caches for opcode s-expression");
       }
       IntType Min = Key << NestedWidth;
@@ -584,17 +583,17 @@ void OpcodeNode::installCaseRanges() {
     const WriteRange& R1 = CaseRangeVector[i];
     const WriteRange& R2 = CaseRangeVector[i + 1];
     if (R1.getMax() >= R2.getMin()) {
-      Node::Trace.errorSexp("Range 1: ", R1.getCase());
-      Node::Trace.errorSexp("Range 2: ", R2.getCase());
-      Node::Trace.errorSexp("Inside: ", this);
+      getTrace().errorSexp("Range 1: ", R1.getCase());
+      getTrace().errorSexp("Range 2: ", R2.getCase());
+      getTrace().errorSexp("Inside: ", this);
       fatal("Opcode case ranges not unique");
     }
   }
 }
 
 void OpcodeNode::installCaches(NodeVectorType& AdditionalNodes) {
-  TRACE_METHOD("OpcodeNode::installCaches", Node::Trace);
-  Node::Trace.traceSexp(this);
+  TRACE_METHOD("OpcodeNode::installCaches", getTrace());
+  getTrace().traceSexp(this);
   SelectBaseNode::installCaches(AdditionalNodes);
   installCaseRanges();
 }

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -89,7 +89,7 @@ class SymbolTable {
   SymbolTable& operator=(const SymbolTable&) = delete;
 
  public:
-  explicit SymbolTable(alloc::Allocator* Alloc);
+  explicit SymbolTable(std::shared_ptr<alloc::Allocator> Alloc);
   ~SymbolTable() { clear(); }
   // Gets existing symbol if known. Otherwise returns nullptr.
   SymbolNode* getSymbol(ExternalName& Name) { return SymbolMap[Name]; }
@@ -98,7 +98,7 @@ class SymbolTable {
   SymbolNode* getSymbolDefinition(ExternalName& Name);
   // Install definitions in tree defined by root.
   void install(Node* Root);
-  alloc::Allocator* getAllocator() const { return Alloc; }
+  std::shared_ptr<alloc::Allocator> getAllocator() const { return Alloc; }
   void clear() { SymbolMap.clear(); }
   int getNextCreationIndex() {
     return ++NextCreationIndex;
@@ -110,7 +110,7 @@ class SymbolTable {
   }
 
  private:
-  alloc::Allocator* Alloc;
+  std::shared_ptr<alloc::Allocator> Alloc;
   Node* Error;
   int NextCreationIndex;
   // TODO(KarlSchimpf): Use arena allocator on map.
@@ -328,7 +328,7 @@ class SymbolNode FINAL : public NullaryNode {
 
  public:
   SymbolNode(SymbolTable &Symtab, ExternalName& _Name)
-      : NullaryNode(Symtab, OpSymbol), Name(Symtab.getAllocator()) {
+      : NullaryNode(Symtab, OpSymbol), Name(Symtab.getAllocator().get()) {
     init(_Name);
   }
   ~SymbolNode() OVERRIDE {}
@@ -495,7 +495,7 @@ class NaryNode : public Node {
   ARENA_VECTOR(Node*) Kids;
   NaryNode(SymbolTable &Symtab, NodeType Type)
       : Node(Symtab, Type),
-        Kids(alloc::TemplateAllocator<Node*>(Symtab.getAllocator())) {}
+        Kids(alloc::TemplateAllocator<Node*>(Symtab.getAllocator().get())) {}
 };
 
 #define X(tag)                                                                \

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -1,19 +1,19 @@
-/* -*- C++ -*- */
-/*
- * Copyright 2016 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 // Defines an internal model of filter AST's.
 //
@@ -89,7 +89,7 @@ class SymbolTable {
   SymbolTable& operator=(const SymbolTable&) = delete;
 
  public:
-  explicit SymbolTable(std::shared_ptr<alloc::Allocator> Alloc);
+  explicit SymbolTable();
   ~SymbolTable() { clear(); }
   // Gets existing symbol if known. Otherwise returns nullptr.
   SymbolNode* getSymbol(ExternalName& Name) { return SymbolMap[Name]; }

--- a/src/test/TestParser.cpp
+++ b/src/test/TestParser.cpp
@@ -24,6 +24,7 @@
 
 #include <iostream>
 
+using namespace wasm::alloc;
 using namespace wasm::filt;
 using namespace wasm::decode;
 
@@ -44,8 +45,7 @@ void usage(const char* AppName) {
 
 int main(int Argc, char* Argv[]) {
   // TODO(KarlSchimpf) Figure out why MallocArena doesn't work.
-  wasm::alloc::Malloc Allocator;
-  SymbolTable SymTab(&Allocator);
+  SymbolTable SymTab(std::make_shared<Malloc>());
   Driver Driver(SymTab);
   bool PrintAst = false;
   std::vector<const char*> Files;

--- a/src/test/TestParser.cpp
+++ b/src/test/TestParser.cpp
@@ -24,7 +24,6 @@
 
 #include <iostream>
 
-using namespace wasm::alloc;
 using namespace wasm::filt;
 using namespace wasm::decode;
 
@@ -44,8 +43,7 @@ void usage(const char* AppName) {
 }
 
 int main(int Argc, char* Argv[]) {
-  // TODO(KarlSchimpf) Figure out why MallocArena doesn't work.
-  SymbolTable SymTab(std::make_shared<Malloc>());
+  SymbolTable SymTab;
   Driver Driver(SymTab);
   bool PrintAst = false;
   std::vector<const char*> Files;

--- a/src/utils/Allocator.h
+++ b/src/utils/Allocator.h
@@ -23,8 +23,9 @@
 #include "Defs.h"
 
 #include <cstdlib>
-#include <vector>
+#include <memory>
 #include <utility>
+#include <vector>
 
 namespace wasm {
 
@@ -35,7 +36,7 @@ extern size_t DefaultAllocAlignLog2;
 
 // Defines a virtual base for all allocators. Allows use of generic allocators
 // by using virtual dispatch.
-class Allocator {
+class Allocator : public std::enable_shared_from_this<Allocator> {
   Allocator(const Allocator&) = delete;
   Allocator& operator=(const Allocator&) = delete;
 

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -22,6 +22,7 @@
 
 #include "utils/Defs.h"
 
+#include <memory>
 #include <vector>
 
 #ifdef NDEBUG
@@ -34,7 +35,7 @@ namespace wasm {
 
 namespace utils {
 
-class TraceClass {
+class TraceClass : std::enable_shared_from_this<TraceClass> {
   TraceClass(const TraceClass&) = delete;
   TraceClass& operator=(const TraceClass&) = delete;
 


### PR DESCRIPTION
Converts more raw pointers to shared_ptr. Also moved static field Node::Trace to within the instance of the SymbolTable that creates the node, and changed trace references to use that instance in the SymbolTable
