### PR TITLE
Separate out read and write cursors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,10 +143,12 @@ STRM_SRCS = \
 	Cursor.cpp \
 	Page.cpp \
 	Queue.cpp \
+	ReadCursor.cpp \
 	ReadBackedQueue.cpp \
 	StreamReader.cpp \
 	StreamWriter.cpp \
 	WriteBackedQueue.cpp \
+	WriteCursor.cpp \
 	WriteUtils.cpp
 
 STRM_OBJS=$(patsubst %.cpp, $(STRM_OBJDIR)/%.o, $(STRM_SRCS))

--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -23,10 +23,10 @@
 #include "binary/SectionSymbolTable.h"
 #include "interp/ReadStream.h"
 #include "interp/TraceSexpReader.h"
-#include "stream/Queue.h"
 #include "sexp/Ast.h"
 #include "sexp/TextWriter.h"
-#include "stream/Cursor.h"
+#include "stream/Queue.h"
+#include "stream/ReadCursor.h"
 #include "utils/Defs.h"
 
 #include <functional>
@@ -60,7 +60,7 @@ class BinaryReader {
 
  private:
   std::shared_ptr<interp::ReadStream> Reader;
-  decode::Cursor ReadPos;
+  decode::ReadCursor ReadPos;
   std::shared_ptr<SymbolTable> Symtab;
   SectionSymbolTable SectionSymtab;
   // The magic number of the input.

--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -205,7 +205,7 @@ void BinaryWriter::writeNode(const Node* Nd) {
 }
 
 void BinaryWriter::writeBlock(std::function<void()> ApplyFn) {
-  Cursor BlockStart(WritePos);
+  WriteCursor BlockStart(WritePos);
   Writer->writeFixedBlockSize(WritePos, 0);
   size_t SizeAfterSizeWrite = Writer->getStreamAddress(WritePos);
   ApplyFn();

--- a/src/binary/BinaryWriter.h
+++ b/src/binary/BinaryWriter.h
@@ -22,7 +22,7 @@
 
 #include "binary/SectionSymbolTable.h"
 #include "stream/Queue.h"
-#include "stream/Cursor.h"
+#include "stream/WriteCursor.h"
 #include "interp/TraceSexpWriter.h"
 #include "interp/WriteStream.h"
 #include "utils/Defs.h"
@@ -56,7 +56,7 @@ class BinaryWriter {
   void setMinimizeBlockSize(bool NewValue) { MinimizeBlockSize = NewValue; }
 
  private:
-  decode::Cursor WritePos;
+  decode::WriteCursor WritePos;
   std::shared_ptr<interp::WriteStream> Writer;
   SectionSymbolTable SectionSymtab;
   bool MinimizeBlockSize;

--- a/src/interp/ByteReadStream.cpp
+++ b/src/interp/ByteReadStream.cpp
@@ -23,7 +23,7 @@ namespace {
 using namespace wasm::decode;
 
 template <class Type>
-Type readFixed(Cursor& Pos) {
+Type readFixed(ReadCursor& Pos) {
   Type Value = 0;
   constexpr uint32_t WordSize = sizeof(Type);
   uint32_t Shift = 0;
@@ -35,7 +35,7 @@ Type readFixed(Cursor& Pos) {
 }
 
 template <class Type>
-Type readLEB128Loop(Cursor& Pos, uint32_t& Shift, uint8_t& Chunk) {
+Type readLEB128Loop(ReadCursor& Pos, uint32_t& Shift, uint8_t& Chunk) {
   Type Value = 0;
   Shift = 0;
   while (true) {
@@ -49,14 +49,14 @@ Type readLEB128Loop(Cursor& Pos, uint32_t& Shift, uint8_t& Chunk) {
 }
 
 template <class Type>
-Type readLEB128(Cursor& Pos) {
+Type readLEB128(ReadCursor& Pos) {
   uint32_t Shift;
   uint8_t Chunk;
   return readLEB128Loop<Type>(Pos, Shift, Chunk);
 }
 
 template <class Type>
-Type readSignedLEB128(Cursor& Pos) {
+Type readSignedLEB128(ReadCursor& Pos) {
   uint32_t Shift;
   uint8_t Chunk;
   Type Value = readLEB128Loop<Type>(Pos, Shift, Chunk);
@@ -71,41 +71,41 @@ namespace wasm {
 
 namespace interp {
 
-uint8_t ByteReadStream::readUint8Bits(Cursor& Pos, uint32_t /*NumBits*/) {
+uint8_t ByteReadStream::readUint8Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return Pos.readByte();
 }
 
-uint32_t ByteReadStream::readUint32Bits(Cursor& Pos, uint32_t /*NumBits*/) {
+uint32_t ByteReadStream::readUint32Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return readFixed<uint32_t>(Pos);
 }
 
-int32_t ByteReadStream::readVarint32Bits(Cursor& Pos, uint32_t /*NumBits*/) {
+int32_t ByteReadStream::readVarint32Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return readSignedLEB128<uint32_t>(Pos);
 }
 
-int64_t ByteReadStream::readVarint64Bits(Cursor& Pos, uint32_t /*NumBits*/) {
+int64_t ByteReadStream::readVarint64Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return readSignedLEB128<uint64_t>(Pos);
 }
 
-uint64_t ByteReadStream::readUint64Bits(Cursor& Pos, uint32_t /*NumBits*/) {
+uint64_t ByteReadStream::readUint64Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return readFixed<uint64_t>(Pos);
 }
 
-uint32_t ByteReadStream::readVaruint32Bits(Cursor& Pos, uint32_t /*NumBits*/) {
+uint32_t ByteReadStream::readVaruint32Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return readLEB128<uint32_t>(Pos);
 }
 
-uint64_t ByteReadStream::readVaruint64Bits(Cursor& Pos, uint32_t /*NumBits*/) {
+uint64_t ByteReadStream::readVaruint64Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return readLEB128<uint64_t>(Pos);
 }
 
-void ByteReadStream::alignToByte(Cursor& /*Pos*/) {}
+void ByteReadStream::alignToByte(ReadCursor& /*Pos*/) {}
 
-size_t ByteReadStream::readBlockSize(decode::Cursor& Pos) {
+size_t ByteReadStream::readBlockSize(decode::ReadCursor& Pos) {
   return readVaruint32(Pos);
 }
 
-void ByteReadStream::pushEobAddress(decode::Cursor& Pos, size_t Address) {
+void ByteReadStream::pushEobAddress(decode::ReadCursor& Pos, size_t Address) {
   Pos.pushEobAddress(Pos.getCurByteAddress() + Address);
 }
 

--- a/src/interp/ByteReadStream.h
+++ b/src/interp/ByteReadStream.h
@@ -31,16 +31,16 @@ class ByteReadStream FINAL : public ReadStream {
 
  public:
   ByteReadStream() : ReadStream(decode::StreamType::Byte) {}
-  uint8_t readUint8Bits(decode::Cursor& Pos, uint32_t NumBits) OVERRIDE;
-  uint32_t readUint32Bits(decode::Cursor& Pos, uint32_t NumBits) OVERRIDE;
-  uint64_t readUint64Bits(decode::Cursor& Pos, uint32_t NumBits) OVERRIDE;
-  int32_t readVarint32Bits(decode::Cursor& Pos, uint32_t NumBits) OVERRIDE;
-  int64_t readVarint64Bits(decode::Cursor& Pos, uint32_t NumBits) OVERRIDE;
-  uint32_t readVaruint32Bits(decode::Cursor& Pos, uint32_t NumBits) OVERRIDE;
-  uint64_t readVaruint64Bits(decode::Cursor& Pos, uint32_t NumBits) OVERRIDE;
-  void alignToByte(decode::Cursor& Pos) OVERRIDE;
-  size_t readBlockSize(decode::Cursor& Pos) OVERRIDE;
-  void pushEobAddress(decode::Cursor& Pos, size_t BlockSize) OVERRIDE;
+  uint8_t readUint8Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
+  uint32_t readUint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
+  uint64_t readUint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
+  int32_t readVarint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
+  int64_t readVarint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
+  uint32_t readVaruint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
+  uint64_t readVaruint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
+  void alignToByte(decode::ReadCursor& Pos) OVERRIDE;
+  size_t readBlockSize(decode::ReadCursor& Pos) OVERRIDE;
+  void pushEobAddress(decode::ReadCursor& Pos, size_t BlockSize) OVERRIDE;
   static bool implementsClass(decode::StreamType RtClassID) {
     return RtClassID == decode::StreamType::Byte;
   }

--- a/src/interp/ByteWriteStream.cpp
+++ b/src/interp/ByteWriteStream.cpp
@@ -18,6 +18,7 @@
 // Implements defaults for stream writers.
 
 #include "interp/ByteWriteStream.h"
+#include "stream/ReadCursor.h"
 
 #include <iostream>
 
@@ -28,13 +29,6 @@ using namespace decode;
 namespace interp {
 
 namespace {
-
-#if 0
-static constexpr uint32_t BitsInWord = sizeof(uint32_t) * CHAR_BIT;
-static constexpr uint32_t ChunkSize = CHAR_BIT - 1;
-static constexpr uint32_t ChunksInWord =
-    (BitsInWord + ChunkSize - 1) / ChunkSize;
-#endif
 
 // Define LEB128 writers.
 #ifdef LEB128_LOOP_UNTIL
@@ -164,7 +158,7 @@ size_t ByteWriteStream::getBlockSize(decode::WriteCursor& StartPos,
 
 void ByteWriteStream::moveBlock(decode::WriteCursor& Pos, size_t StartAddress,
                                 size_t Size) {
-  WriteCursor CopyPos(StreamType::Byte, Pos.getQueue());
+  ReadCursor CopyPos(StreamType::Byte, Pos.getQueue());
   CopyPos.jumpToByteAddress(StartAddress);
   for (size_t i = 0; i < Size; ++i)
     Pos.writeByte(CopyPos.readByte());

--- a/src/interp/ByteWriteStream.cpp
+++ b/src/interp/ByteWriteStream.cpp
@@ -53,22 +53,22 @@ static constexpr uint32_t ChunksInWord =
   } while (true)
 
 template <class Type>
-void writeLEB128(Type Value, Cursor& Pos) {
+void writeLEB128(Type Value, WriteCursor& Pos) {
   LEB128_LOOP_UNTIL(Value == 0);
 }
 
 template <class Type>
-void writePositiveLEB128(Type Value, Cursor& Pos) {
+void writePositiveLEB128(Type Value, WriteCursor& Pos) {
   LEB128_LOOP_UNTIL(Value == 0 && !(Byte & 0x40));
 }
 
 template <class Type>
-void writeNegativeLEB128(Type Value, Cursor& Pos) {
+void writeNegativeLEB128(Type Value, WriteCursor& Pos) {
   LEB128_LOOP_UNTIL(Value == -1 && (Byte & 0x40));
 }
 
 template <class Type>
-void writeFixedLEB128(Type Value, Cursor& Pos) {
+void writeFixedLEB128(Type Value, WriteCursor& Pos) {
   constexpr uint32_t BitsInWord = sizeof(Type) * CHAR_BIT;
   constexpr uint32_t ChunkSize = CHAR_BIT - 1;
   constexpr uint32_t ChunksInWord = (BitsInWord + ChunkSize - 1) / ChunkSize;
@@ -81,7 +81,7 @@ void writeFixedLEB128(Type Value, Cursor& Pos) {
 #endif
 
 template <class Type>
-void writeFixed(Type Value, Cursor& Pos) {
+void writeFixed(Type Value, WriteCursor& Pos) {
   constexpr uint32_t WordSize = sizeof(Type);
   constexpr Type Mask = (Type(1) << CHAR_BIT) - 1;
   for (uint32_t i = 0; i < WordSize; ++i) {
@@ -93,25 +93,25 @@ void writeFixed(Type Value, Cursor& Pos) {
 }  // end of anonymous namespace
 
 void ByteWriteStream::writeUint8Bits(uint8_t Value,
-                                     Cursor& Pos,
+                                     WriteCursor& Pos,
                                      uint32_t /*NumBits*/) {
   Pos.writeByte(uint8_t(Value));
 }
 
 void ByteWriteStream::writeUint32Bits(uint32_t Value,
-                                      Cursor& Pos,
+                                      WriteCursor& Pos,
                                       uint32_t /*NumBits*/) {
   writeFixed<uint32_t>(Value, Pos);
 }
 
 void ByteWriteStream::writeUint64Bits(uint64_t Value,
-                                      Cursor& Pos,
+                                      WriteCursor& Pos,
                                       uint32_t /*NumBits*/) {
   writeFixed<uint64_t>(Value, Pos);
 }
 
 void ByteWriteStream::writeVarint32Bits(int32_t Value,
-                                        Cursor& Pos,
+                                        WriteCursor& Pos,
                                         uint32_t /*NumBits*/) {
   if (Value < 0)
     writeNegativeLEB128<int32_t>(Value, Pos);
@@ -120,7 +120,7 @@ void ByteWriteStream::writeVarint32Bits(int32_t Value,
 }
 
 void ByteWriteStream::writeVarint64Bits(int64_t Value,
-                                        Cursor& Pos,
+                                        WriteCursor& Pos,
                                         uint32_t /*NumBits*/) {
   if (Value < 0)
     writeNegativeLEB128<int64_t>(Value, Pos);
@@ -129,42 +129,42 @@ void ByteWriteStream::writeVarint64Bits(int64_t Value,
 }
 
 void ByteWriteStream::writeVaruint32Bits(uint32_t Value,
-                                         Cursor& Pos,
+                                         WriteCursor& Pos,
                                          uint32_t /*NumBits*/) {
   writeLEB128<uint32_t>(Value, Pos);
 }
 
 void ByteWriteStream::writeVaruint64Bits(uint64_t Value,
-                                         Cursor& Pos,
+                                         WriteCursor& Pos,
                                          uint32_t /*NumBits*/) {
   writeLEB128<uint64_t>(Value, Pos);
 }
 
-void ByteWriteStream::alignToByte(decode::Cursor& Pos) {}
+void ByteWriteStream::alignToByte(decode::WriteCursor& Pos) {}
 
-size_t ByteWriteStream::getStreamAddress(Cursor& Pos) {
+size_t ByteWriteStream::getStreamAddress(WriteCursor& Pos) {
   return Pos.getCurByteAddress();
 }
 
-void ByteWriteStream::writeFixedBlockSize(Cursor& Pos,
+void ByteWriteStream::writeFixedBlockSize(WriteCursor& Pos,
                                           size_t BlockSize) {
   writeFixedLEB128<uint32_t>(BlockSize, Pos);
 }
 
-void ByteWriteStream::writeVarintBlockSize(decode::Cursor& Pos,
+void ByteWriteStream::writeVarintBlockSize(decode::WriteCursor& Pos,
                                            size_t BlockSize) {
   writeVaruint32(BlockSize, Pos);
 }
 
-size_t ByteWriteStream::getBlockSize(decode::Cursor& StartPos,
-                                     decode::Cursor& EndPos) {
+size_t ByteWriteStream::getBlockSize(decode::WriteCursor& StartPos,
+                                     decode::WriteCursor& EndPos) {
   return EndPos.getCurByteAddress() -
       (StartPos.getCurByteAddress() + ChunksInWord);
 }
 
-void ByteWriteStream::moveBlock(decode::Cursor& Pos, size_t StartAddress,
+void ByteWriteStream::moveBlock(decode::WriteCursor& Pos, size_t StartAddress,
                                 size_t Size) {
-  Cursor CopyPos(StreamType::Byte, Pos.getQueue());
+  WriteCursor CopyPos(StreamType::Byte, Pos.getQueue());
   CopyPos.jumpToByteAddress(StartAddress);
   for (size_t i = 0; i < Size; ++i)
     Pos.writeByte(CopyPos.readByte());

--- a/src/interp/ByteWriteStream.h
+++ b/src/interp/ByteWriteStream.h
@@ -38,33 +38,33 @@ class ByteWriteStream FINAL : public WriteStream {
       (BitsInWord + ChunkSize - 1) / ChunkSize;
   ByteWriteStream() : WriteStream(decode::StreamType::Byte) {}
   void writeUint8Bits(uint8_t Value,
-                      decode::Cursor& Pos,
+                      decode::WriteCursor& Pos,
                       uint32_t NumBits) OVERRIDE;
   void writeUint32Bits(uint32_t Value,
-                       decode::Cursor& Pos,
+                       decode::WriteCursor& Pos,
                        uint32_t NumBits) OVERRIDE;
   void writeUint64Bits(uint64_t Value,
-                       decode::Cursor& Pos,
+                       decode::WriteCursor& Pos,
                        uint32_t NumBits) OVERRIDE;
   void writeVarint32Bits(int32_t Value,
-                         decode::Cursor& Pos,
+                         decode::WriteCursor& Pos,
                          uint32_t NumBits) OVERRIDE;
   void writeVarint64Bits(int64_t Value,
-                         decode::Cursor& Pos,
+                         decode::WriteCursor& Pos,
                          uint32_t NumBits) OVERRIDE;
   void writeVaruint32Bits(uint32_t Value,
-                          decode::Cursor& Pos,
+                          decode::WriteCursor& Pos,
                           uint32_t NumBits) OVERRIDE;
   void writeVaruint64Bits(uint64_t Value,
-                          decode::Cursor& Pos,
+                          decode::WriteCursor& Pos,
                           uint32_t NumBits) OVERRIDE;
-  void alignToByte(decode::Cursor& Pos) OVERRIDE;
-  size_t getStreamAddress(decode::Cursor& Pos) OVERRIDE;
-  void writeFixedBlockSize(decode::Cursor& Pos, size_t BlockSize) OVERRIDE;
-  void writeVarintBlockSize(decode::Cursor& Pos, size_t BlockSIze) OVERRIDE;
-  size_t getBlockSize(decode::Cursor& StartPos,
-                      decode::Cursor& EndPos) OVERRIDE;
-  void moveBlock(decode::Cursor& Pos, size_t StartAddress,
+  void alignToByte(decode::WriteCursor& Pos) OVERRIDE;
+  size_t getStreamAddress(decode::WriteCursor& Pos) OVERRIDE;
+  void writeFixedBlockSize(decode::WriteCursor& Pos, size_t BlockSize) OVERRIDE;
+  void writeVarintBlockSize(decode::WriteCursor& Pos, size_t BlockSIze) OVERRIDE;
+  size_t getBlockSize(decode::WriteCursor& StartPos,
+                      decode::WriteCursor& EndPos) OVERRIDE;
+  void moveBlock(decode::WriteCursor& Pos, size_t StartAddress,
                  size_t Size) OVERRIDE;
 
   static bool implementsClass(decode::StreamType RtClassId) {

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -353,7 +353,7 @@ IntType Interpreter::read(const Node* Nd) {
       return LastReadValue = dyn_cast<IntegerNode>(Nd)->getValue();
     }
     case OpPeek: {
-      Cursor InitialPos(ReadPos);
+      ReadCursor InitialPos(ReadPos);
       LastReadValue = read(Nd->getKid(0));
       ReadPos.swap(InitialPos);
       return LastReadValue;
@@ -504,7 +504,7 @@ void Interpreter::decompressBlock(const Node* Code) {
   const uint32_t OldSize = Reader->readBlockSize(ReadPos);
   Trace.traceUint32_t("block size", OldSize);
   Reader->pushEobAddress(ReadPos, OldSize);
-  Cursor BlockStart(WritePos);
+  WriteCursor BlockStart(WritePos);
   Writer->writeFixedBlockSize(WritePos, 0);
   size_t SizeAfterSizeWrite = Writer->getStreamAddress(WritePos);
   evalOrCopy(Code);

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -23,7 +23,8 @@
 
 #include <iostream>
 
-// The following turn on logging sections, functions in the decompression algorithm.
+// The following turn on logging sections, functions in the decompression
+// algorithm.
 #define LOG_SECTIONS 0
 #define LOG_FUNCTIONS 0
 // The following logs lookahead on each call to eval.
@@ -76,16 +77,16 @@ IntType Interpreter::eval(const Node* Nd) {
   TRACE_METHOD("eval", Trace);
   Trace.traceSexp(Nd);
 #if LOG_EVAL_LOOKAHEAD
-      if (Trace.getTraceProgress()) {
-        decode::ReadCursor Lookahead(ReadPos);
-        fprintf(Trace.indent(), "Lookahead:");
-        for (int i = 0; i < 10; ++i) {
-          if (!Lookahead.atByteEob())
-            fprintf(Trace.getFile(), " %x", Lookahead.readByte());
-        }
-        fprintf(Trace.getFile(), " ");
-        fprintf(ReadPos.describe(Trace.getFile(), true), "\n");
-      }
+  if (Trace.getTraceProgress()) {
+    decode::ReadCursor Lookahead(ReadPos);
+    fprintf(Trace.indent(), "Lookahead:");
+    for (int i = 0; i < 10; ++i) {
+      if (!Lookahead.atByteEob())
+        fprintf(Trace.getFile(), " %x", Lookahead.readByte());
+    }
+    fprintf(Trace.getFile(), " ");
+    fprintf(ReadPos.describe(Trace.getFile(), true), "\n");
+  }
 #endif
   IntType ReturnValue = 0;
   switch (NodeType Type = Nd->getType()) {

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -27,7 +27,7 @@
 // call in the decompression algorithm.
 #define LOG_SECTIONS 0
 #define LOG_FUNCTIONS 0
-#define LOG_EVAL 0
+#define LOG_EVAL 1
 
 // The following two defines allows turning on tracing for the nth (zero based)
 // function.
@@ -183,13 +183,14 @@ IntType Interpreter::eval(const Node* Nd) {
     case OpEval:
 #if LOG_EVAL
       if (Trace.getTraceProgress()) {
-        decode::Cursor Lookahead(ReadPos);
+        decode::ReadCursor Lookahead(ReadPos);
         fprintf(Trace.indent(), "Lookahead:");
         for (int i = 0; i < 10; ++i) {
           if (!Lookahead.atByteEob())
             fprintf(Trace.getFile(), " %x", Lookahead.readByte());
         }
-        fprintf(Trace.getFile(), "\n");
+        fprintf(Trace.getFile(), " ");
+        fprintf(ReadPos.describe(Trace.getFile()), "\n");
       }
 #endif
       if (auto* Sym = dyn_cast<SymbolNode>(Nd->getKid(0))) {

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -21,7 +21,8 @@
 #define DECOMPRESSOR_SRC_INTERP_INTERPRETER_H
 
 #include "stream/Queue.h"
-#include "stream/Cursor.h"
+#include "stream/ReadCursor.h"
+#include "stream/WriteCursor.h"
 #include "interp/ReadStream.h"
 #include "interp/TraceSexpReaderWriter.h"
 #include "interp/WriteStream.h"
@@ -60,9 +61,9 @@ class Interpreter {
   void setMinimizeBlockSize(bool NewValue) { MinimizeBlockSize = NewValue; }
 
  private:
-  decode::Cursor ReadPos;
+  decode::ReadCursor ReadPos;
   std::shared_ptr<ReadStream> Reader;
-  decode::Cursor WritePos;
+  decode::WriteCursor WritePos;
   std::shared_ptr<WriteStream> Writer;
   filt::Node* DefaultFormat;
   std::shared_ptr<filt::SymbolTable> Symtab;

--- a/src/interp/ReadStream.h
+++ b/src/interp/ReadStream.h
@@ -39,27 +39,41 @@ class ReadStream : public std::enable_shared_from_this<ReadStream> {
   uint8_t readUint8(decode::ReadCursor& Pos) { return readUint8Bits(Pos, 8); }
   virtual uint8_t readUint8Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
 
-  uint32_t readUint32(decode::ReadCursor& Pos) { return readUint32Bits(Pos, 8); }
-  virtual uint32_t readUint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
+  uint32_t readUint32(decode::ReadCursor& Pos) {
+    return readUint32Bits(Pos, 8);
+  }
+  virtual uint32_t readUint32Bits(decode::ReadCursor& Pos,
+                                  uint32_t NumBits) = 0;
 
-  uint64_t readUint64(decode::ReadCursor& Pos) { return readUint64Bits(Pos, 8); }
-  virtual uint64_t readUint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
+  uint64_t readUint64(decode::ReadCursor& Pos) {
+    return readUint64Bits(Pos, 8);
+  }
+  virtual uint64_t readUint64Bits(decode::ReadCursor& Pos,
+                                  uint32_t NumBits) = 0;
 
-  int32_t readVarint32(decode::ReadCursor& Pos) { return readVarint32Bits(Pos, 8); }
-  virtual int32_t readVarint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
+  int32_t readVarint32(decode::ReadCursor& Pos) {
+    return readVarint32Bits(Pos, 8);
+  }
+  virtual int32_t readVarint32Bits(decode::ReadCursor& Pos,
+                                   uint32_t NumBits) = 0;
 
-  int64_t readVarint64(decode::ReadCursor& Pos) { return readVarint64Bits(Pos, 8); }
-  virtual int64_t readVarint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
+  int64_t readVarint64(decode::ReadCursor& Pos) {
+    return readVarint64Bits(Pos, 8);
+  }
+  virtual int64_t readVarint64Bits(decode::ReadCursor& Pos,
+                                   uint32_t NumBits) = 0;
 
   uint32_t readVaruint32(decode::ReadCursor& Pos) {
     return readVaruint32Bits(Pos, 8);
   }
-  virtual uint32_t readVaruint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
+  virtual uint32_t readVaruint32Bits(decode::ReadCursor& Pos,
+                                     uint32_t NumBits) = 0;
 
   uint64_t readVaruint64(decode::ReadCursor& Pos) {
     return readVaruint64Bits(Pos, 8);
   }
-  virtual uint64_t readVaruint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
+  virtual uint64_t readVaruint64Bits(decode::ReadCursor& Pos,
+                                     uint32_t NumBits) = 0;
 
   // Align to nearest (next) byte boundary.
   virtual void alignToByte(decode::ReadCursor& Pos) = 0;

--- a/src/interp/ReadStream.h
+++ b/src/interp/ReadStream.h
@@ -20,7 +20,7 @@
 #define DECOMPRESSOR_SRC_INTERP_READSTREAM_H
 
 #include "sexp/Ast.h"
-#include "stream/Cursor.h"
+#include "stream/ReadCursor.h"
 #include "utils/Casting.h"
 
 #include <memory>
@@ -36,42 +36,42 @@ class ReadStream : public std::enable_shared_from_this<ReadStream> {
   ReadStream& operator=(const ReadStream&) = delete;
 
  public:
-  uint8_t readUint8(decode::Cursor& Pos) { return readUint8Bits(Pos, 8); }
-  virtual uint8_t readUint8Bits(decode::Cursor& Pos, uint32_t NumBits) = 0;
+  uint8_t readUint8(decode::ReadCursor& Pos) { return readUint8Bits(Pos, 8); }
+  virtual uint8_t readUint8Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
 
-  uint32_t readUint32(decode::Cursor& Pos) { return readUint32Bits(Pos, 8); }
-  virtual uint32_t readUint32Bits(decode::Cursor& Pos, uint32_t NumBits) = 0;
+  uint32_t readUint32(decode::ReadCursor& Pos) { return readUint32Bits(Pos, 8); }
+  virtual uint32_t readUint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
 
-  uint64_t readUint64(decode::Cursor& Pos) { return readUint64Bits(Pos, 8); }
-  virtual uint64_t readUint64Bits(decode::Cursor& Pos, uint32_t NumBits) = 0;
+  uint64_t readUint64(decode::ReadCursor& Pos) { return readUint64Bits(Pos, 8); }
+  virtual uint64_t readUint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
 
-  int32_t readVarint32(decode::Cursor& Pos) { return readVarint32Bits(Pos, 8); }
-  virtual int32_t readVarint32Bits(decode::Cursor& Pos, uint32_t NumBits) = 0;
+  int32_t readVarint32(decode::ReadCursor& Pos) { return readVarint32Bits(Pos, 8); }
+  virtual int32_t readVarint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
 
-  int64_t readVarint64(decode::Cursor& Pos) { return readVarint64Bits(Pos, 8); }
-  virtual int64_t readVarint64Bits(decode::Cursor& Pos, uint32_t NumBits) = 0;
+  int64_t readVarint64(decode::ReadCursor& Pos) { return readVarint64Bits(Pos, 8); }
+  virtual int64_t readVarint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
 
-  uint32_t readVaruint32(decode::Cursor& Pos) {
+  uint32_t readVaruint32(decode::ReadCursor& Pos) {
     return readVaruint32Bits(Pos, 8);
   }
-  virtual uint32_t readVaruint32Bits(decode::Cursor& Pos, uint32_t NumBits) = 0;
+  virtual uint32_t readVaruint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
 
-  uint64_t readVaruint64(decode::Cursor& Pos) {
+  uint64_t readVaruint64(decode::ReadCursor& Pos) {
     return readVaruint64Bits(Pos, 8);
   }
-  virtual uint64_t readVaruint64Bits(decode::Cursor& Pos, uint32_t NumBits) = 0;
+  virtual uint64_t readVaruint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) = 0;
 
   // Align to nearest (next) byte boundary.
-  virtual void alignToByte(decode::Cursor& Pos) = 0;
+  virtual void alignToByte(decode::ReadCursor& Pos) = 0;
 
   // The following virtuals are used to implement blocks.
 
   // Reads in the stream specific block size.
-  virtual size_t readBlockSize(decode::Cursor& Pos) = 0;
+  virtual size_t readBlockSize(decode::ReadCursor& Pos) = 0;
 
   // Sets Eob based on BlockSize (returned from readBlockSize), based
   // on stream specific block size.
-  virtual void pushEobAddress(decode::Cursor& Pos, size_t BlockSize) = 0;
+  virtual void pushEobAddress(decode::ReadCursor& Pos, size_t BlockSize) = 0;
 
   decode::StreamType getType() const { return Type; }
 

--- a/src/interp/WriteStream.h
+++ b/src/interp/WriteStream.h
@@ -96,8 +96,10 @@ class WriteStream : public std::enable_shared_from_this<WriteStream> {
 
   // Saves the block size using a fixed format that is independent of
   // the block size.
-  virtual void writeFixedBlockSize(decode::WriteCursor& Pos, size_t BlockSize) = 0;
-  virtual void writeVarintBlockSize(decode::WriteCursor& Pos, size_t BlockSIze) = 0;
+  virtual void writeFixedBlockSize(decode::WriteCursor& Pos,
+                                   size_t BlockSize) = 0;
+  virtual void writeVarintBlockSize(decode::WriteCursor& Pos,
+                                    size_t BlockSIze) = 0;
 
   // Returns the size of the block, defined by the range of the
   // passed positions (specific to the stream).

--- a/src/interp/WriteStream.h
+++ b/src/interp/WriteStream.h
@@ -20,7 +20,7 @@
 #define DECOMPRESSOR_SRC_INTERP_WRITESTREAM_H
 
 #include "sexp/Ast.h"
-#include "stream/Cursor.h"
+#include "stream/WriteCursor.h"
 #include "utils/Casting.h"
 
 #include <memory>
@@ -36,76 +36,76 @@ class WriteStream : public std::enable_shared_from_this<WriteStream> {
   WriteStream& operator=(const WriteStream&) = delete;
 
  public:
-  void writeUint8(uint8_t Value, decode::Cursor& Pos) {
+  void writeUint8(uint8_t Value, decode::WriteCursor& Pos) {
     writeUint8Bits(Value, Pos, 8);
   }
   virtual void writeUint8Bits(uint8_t,
-                              decode::Cursor& Pos,
+                              decode::WriteCursor& Pos,
                               uint32_t NumBits) = 0;
 
-  void writeUint32(uint32_t Value, decode::Cursor& Pos) {
+  void writeUint32(uint32_t Value, decode::WriteCursor& Pos) {
     writeUint32Bits(Value, Pos, 8);
   }
   virtual void writeUint32Bits(uint32_t Value,
-                               decode::Cursor& Pos,
+                               decode::WriteCursor& Pos,
                                uint32_t NumBits) = 0;
 
-  void writeUint64(uint64_t Value, decode::Cursor& Pos) {
+  void writeUint64(uint64_t Value, decode::WriteCursor& Pos) {
     writeUint64Bits(Value, Pos, 8);
   }
   virtual void writeUint64Bits(uint64_t Value,
-                               decode::Cursor& Pos,
+                               decode::WriteCursor& Pos,
                                uint32_t NumBits) = 0;
 
-  void writeVarint32(int32_t Value, decode::Cursor& Pos) {
+  void writeVarint32(int32_t Value, decode::WriteCursor& Pos) {
     writeVarint32Bits(Value, Pos, 8);
   }
   virtual void writeVarint32Bits(int32_t Value,
-                                 decode::Cursor& Pos,
+                                 decode::WriteCursor& Pos,
                                  uint32_t NumBits) = 0;
 
-  void writeVarint64(int64_t Value, decode::Cursor& Pos) {
+  void writeVarint64(int64_t Value, decode::WriteCursor& Pos) {
     return writeVarint64Bits(Value, Pos, 8);
   }
   virtual void writeVarint64Bits(int64_t Value,
-                                 decode::Cursor& Pos,
+                                 decode::WriteCursor& Pos,
                                  uint32_t NumBits) = 0;
 
-  void writeVaruint32(uint32_t Value, decode::Cursor& Pos) {
+  void writeVaruint32(uint32_t Value, decode::WriteCursor& Pos) {
     writeVaruint32Bits(Value, Pos, 8);
   }
   virtual void writeVaruint32Bits(uint32_t Value,
-                                  decode::Cursor& Pos,
+                                  decode::WriteCursor& Pos,
                                   uint32_t NumBits) = 0;
 
-  void writeVaruint64(uint64_t Value, decode::Cursor& Pos) {
+  void writeVaruint64(uint64_t Value, decode::WriteCursor& Pos) {
     writeVaruint64Bits(Value, Pos, 8);
   }
 
   virtual void writeVaruint64Bits(uint64_t Value,
-                                  decode::Cursor& Pos,
+                                  decode::WriteCursor& Pos,
                                   uint32_t NumBits) = 0;
 
-  virtual void alignToByte(decode::Cursor& Pos) = 0;
+  virtual void alignToByte(decode::WriteCursor& Pos) = 0;
 
   // The following virtuals are used to implement blocks.
 
   // Returns stream specific address (i.e. bit address for bit streams, byte
   // address for byte streams, and int address for int streams).
-  virtual size_t getStreamAddress(decode::Cursor& Pos) = 0;
+  virtual size_t getStreamAddress(decode::WriteCursor& Pos) = 0;
 
   // Saves the block size using a fixed format that is independent of
   // the block size.
-  virtual void writeFixedBlockSize(decode::Cursor& Pos, size_t BlockSize) = 0;
-  virtual void writeVarintBlockSize(decode::Cursor& Pos, size_t BlockSIze) = 0;
+  virtual void writeFixedBlockSize(decode::WriteCursor& Pos, size_t BlockSize) = 0;
+  virtual void writeVarintBlockSize(decode::WriteCursor& Pos, size_t BlockSIze) = 0;
 
   // Returns the size of the block, defined by the range of the
   // passed positions (specific to the stream).
-  virtual size_t getBlockSize(decode::Cursor& StartPos,
-                              decode::Cursor& EndPos) = 0;
+  virtual size_t getBlockSize(decode::WriteCursor& StartPos,
+                              decode::WriteCursor& EndPos) = 0;
 
   // Moves Size elemens (stream specific) to StartAddress.
-  virtual void moveBlock(decode::Cursor& Pos,
+  virtual void moveBlock(decode::WriteCursor& Pos,
                          size_t StartAddress,
                          size_t Size) = 0;
 

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -1,27 +1,20 @@
-/* -*- C++ -*- */
-/*
- * Copyright 2016 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "stream/Cursor.h"
-
-namespace {
-#ifndef NDEBUG
-static constexpr uint32_t MaxBitsAllowed = sizeof(uint32_t) * CHAR_BIT;
-#endif
-}
 
 namespace wasm {
 
@@ -61,45 +54,6 @@ void Cursor::writeFillBuffer() {
   size_t BufferSize = Que->writeToPage(CurAddress, Page::Size, *this);
   if (BufferSize == 0)
     fatal("Write failed!\n");
-}
-
-uint32_t Cursor::readBits(uint32_t NumBits) {
-  assert(NumBits <= MaxBitsAllowed);
-  uint32_t Value = 0;
-  while (NumBits != 0) {
-    BitsInByteType AvailBits = CurByte.getReadBitsRemaining();
-    if (NumBits <= AvailBits) {
-      Value = (Value << NumBits) | CurByte.readBits(NumBits);
-      return Value;
-    }
-    if (!CurByte.isEmpty()) {
-      Value = (Value << AvailBits) | CurByte.getValue();
-      NumBits -= AvailBits;
-    }
-    CurByte.setByte(readByte());
-  }
-  return Value;
-}
-
-void Cursor::writeBits(uint32_t Value, uint32_t NumBits) {
-  assert(NumBits <= MaxBitsAllowed);
-  while (NumBits > 0) {
-    const BitsInByteType AvailBits = CurByte.getWriteBitsRemaining();
-    if (AvailBits >= NumBits) {
-      CurByte.writeBits(Value, NumBits);
-      if (AvailBits == NumBits) {
-        writeByte(CurByte.getValue());
-        CurByte.reset();
-      }
-      return;
-    }
-    uint32_t Shift = NumBits - AvailBits;
-    CurByte.writeBits(Value >> Shift, AvailBits);
-    Value &= (uint32_t(1) << Shift) - 1;
-    NumBits -= AvailBits;
-    writeByte(CurByte.getValue());
-    CurByte.reset();
-  }
 }
 
 FILE* Cursor::describe(FILE* File, bool IncludeDetail) {

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -122,38 +122,6 @@ class Cursor : public PageCursor {
 
   void jumpToByteAddress(size_t NewAddress);
 
-  // Reads next byte. Returns zero if at end of file.
-  uint8_t readByte() {
-    assert(isByteAligned());
-    if (isIndexAtEndOfPage() && !readFillBuffer())
-      return 0;
-    return PageCursor::readByte();
-  }
-
-  // Writes next byte. Fails if at end of file.
-  void writeByte(uint8_t Byte) {
-    assert(isByteAligned());
-    if (isIndexAtEndOfPage())
-      writeFillBuffer();
-    PageCursor::writeByte(Byte);
-  }
-
-  // ------------------------------------------------------------------------
-  // The following methods assume that the cursor is accessing a bit stream.
-  // ------------------------------------------------------------------------
-
-  // Reads up to 32 bits from the input.
-  uint32_t readBits(uint32_t NumBits);
-
-  // Writes up to 32 bits to the output.
-  void writeBits(uint32_t Value, uint32_t NumBits);
-
-  // ------------------------------------------------------------------------
-  // The following methods are for debugging.
-  // ------------------------------------------------------------------------
-
-  void writeCurPage(FILE* File) { Que->writePageAt(File, getCurAddress()); }
-
   // For debugging.
   FILE* describe(FILE* File, bool IncludeDetail = false);
 
@@ -165,13 +133,6 @@ class Cursor : public PageCursor {
   std::shared_ptr<BlockEob> EobPtr;
   WorkingByte CurByte;
 
-  // Returns true if able to fill the buffer with at least one byte.
-  bool readFillBuffer();
-
-  // Creates new pages in buffer so that writes can occur.
-  void writeFillBuffer();
-
- protected:
   Cursor(StreamType Type, std::shared_ptr<Queue> Que)
       : Type(Type), Que(Que), EobPtr(Que->getEofPtr()) {}
   explicit Cursor(const Cursor& C)
@@ -180,6 +141,11 @@ class Cursor : public PageCursor {
         Que(C.Que),
         EobPtr(C.EobPtr),
         CurByte(C.CurByte) {}
+
+  // Returns true if able to fill the buffer with at least one byte.
+  bool readFillBuffer();
+  // Creates new pages in buffer so that writes can occur.
+  void writeFillBuffer();
 };
 
 }  // end of namespace decode

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -1,19 +1,18 @@
-/* -*- C++ -*- */
-/*
- * Copyright 2016 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Defines a pointer into a byte stream.
 
@@ -83,14 +82,6 @@ class Cursor : public PageCursor {
   Cursor& operator=(const Cursor&) = delete;
 
  public:
-  Cursor(StreamType Type, std::shared_ptr<Queue> Que)
-      : Type(Type), Que(Que), EobPtr(Que->getEofPtr()) {}
-  explicit Cursor(const Cursor& C)
-      : PageCursor(C),
-        Type(C.Type),
-        Que(C.Que),
-        EobPtr(C.EobPtr),
-        CurByte(C.CurByte) {}
   ~Cursor() {}
 
   void swap(Cursor& C) {
@@ -109,13 +100,7 @@ class Cursor : public PageCursor {
 
   const WorkingByte& getWorkingByte() const { return CurByte; }
 
-  BitsInByteType getBitsRead() const { return CurByte.getBitsRead(); }
-
-  BitsInByteType getBitsWritten() const { return CurByte.getBitsWritten(); }
-
   std::shared_ptr<Queue> getQueue() { return Que; }
-
-  bool atReadBitEob() { return getCurReadBitAddress() == getEobAddress(); }
 
   bool atByteEob() {
     return getCurAddress() >= getEobAddress().getByteAddress() ||
@@ -125,19 +110,6 @@ class Cursor : public PageCursor {
   BitAddress& getEobAddress() const { return EobPtr->getEobAddress(); }
 
   void freezeEof() { Que->freezeEof(getCurAddress()); }
-
-  void setEobAddress(const BitAddress& NewValue) {
-    EobPtr->setEobAddress(NewValue);
-  }
-
-  void pushEobAddress(const BitAddress& NewValue) {
-    EobPtr = std::make_shared<BlockEob>(NewValue, EobPtr);
-  }
-
-  void popEobAddress() {
-    EobPtr = EobPtr->getEnclosingEobPtr();
-    assert(EobPtr);
-  }
 
   // ------------------------------------------------------------------------
   // The following methods assume that the cursor is accessing a byte stream.
@@ -170,16 +142,6 @@ class Cursor : public PageCursor {
   // The following methods assume that the cursor is accessing a bit stream.
   // ------------------------------------------------------------------------
 
-  BitAddress getCurReadBitAddress() const {
-    BitAddress Address(getCurAddress(), getBitsRead());
-    return Address;
-  }
-
-  BitAddress getCurWriteBitAddress() const {
-    BitAddress Address(getCurAddress(), getBitsWritten());
-    return Address;
-  }
-
   // Reads up to 32 bits from the input.
   uint32_t readBits(uint32_t NumBits);
 
@@ -208,6 +170,16 @@ class Cursor : public PageCursor {
 
   // Creates new pages in buffer so that writes can occur.
   void writeFillBuffer();
+
+ protected:
+  Cursor(StreamType Type, std::shared_ptr<Queue> Que)
+      : Type(Type), Que(Que), EobPtr(Que->getEofPtr()) {}
+  explicit Cursor(const Cursor& C)
+      : PageCursor(C),
+        Type(C.Type),
+        Que(C.Que),
+        EobPtr(C.EobPtr),
+        CurByte(C.CurByte) {}
 };
 
 }  // end of namespace decode

--- a/src/stream/ReadCursor.cpp
+++ b/src/stream/ReadCursor.cpp
@@ -1,0 +1,43 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stream/ReadCursor.h"
+
+namespace wasm {
+
+namespace decode {
+
+uint32_t ReadCursor::readBits(uint32_t NumBits) {
+  assert(NumBits <= sizeof(uint32_t) * CHAR_BIT);
+  uint32_t Value = 0;
+  while (NumBits != 0) {
+    BitsInByteType AvailBits = CurByte.getReadBitsRemaining();
+    if (NumBits <= AvailBits) {
+      Value = (Value << NumBits) | CurByte.readBits(NumBits);
+      return Value;
+    }
+    if (!CurByte.isEmpty()) {
+      Value = (Value << AvailBits) | CurByte.getValue();
+      NumBits -= AvailBits;
+    }
+    CurByte.setByte(readByte());
+  }
+  return Value;
+}
+
+}  // end of namespace decode
+
+}  // end of namespace wasm

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -1,0 +1,60 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a pointer to a byte stream for reading.
+
+#ifndef DECOMPRESSOR_SRC_STREAM_READCURSOR_H
+#define DECOMPRESSOR_SRC_STREAM_READCURSOR_H
+
+#include "stream/Cursor.h"
+
+namespace wasm {
+
+namespace decode {
+
+class ReadCursor : public Cursor {
+  ReadCursor() = delete;
+  ReadCursor& operator=(const ReadCursor&) = delete;
+ public:
+  ReadCursor(StreamType Type, std::shared_ptr<Queue> Que)
+      : Cursor(Type, Que) {}
+  explicit ReadCursor(const ReadCursor& C) : Cursor(C) {}
+  ~ReadCursor() {}
+
+  bool atReadBitEob() { return getCurReadBitAddress() == getEobAddress(); }
+
+  BitsInByteType getBitsRead() const { return CurByte.getBitsRead(); }
+
+  BitAddress getCurReadBitAddress() const {
+    BitAddress Address(getCurAddress(), getBitsRead());
+    return Address;
+  }
+
+  void pushEobAddress(const BitAddress& NewValue) {
+    EobPtr = std::make_shared<BlockEob>(NewValue, EobPtr);
+  }
+
+  void popEobAddress() {
+    EobPtr = EobPtr->getEnclosingEobPtr();
+    assert(EobPtr);
+  }
+};
+
+}  // end of namespace decode
+
+}  // end of namespace wasm
+
+#endif // DECOMPRESSOR_SRC_STREAM_READCURSOR_H

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -25,7 +25,7 @@ namespace wasm {
 
 namespace decode {
 
-class ReadCursor : public Cursor {
+class ReadCursor FINAL : public Cursor {
   ReadCursor() = delete;
   ReadCursor& operator=(const ReadCursor&) = delete;
  public:
@@ -51,6 +51,18 @@ class ReadCursor : public Cursor {
     EobPtr = EobPtr->getEnclosingEobPtr();
     assert(EobPtr);
   }
+
+  // Reads next byte. Returns zero if at end of file. NOTE: Assumes byte
+  // aligned!
+  uint8_t readByte() {
+    assert(isByteAligned());
+    if (isIndexAtEndOfPage() && !readFillBuffer())
+      return 0;
+    return PageCursor::readByte();
+  }
+
+  // Reads up to 32 bits from the input.
+  uint32_t readBits(uint32_t NumBits);
 };
 
 }  // end of namespace decode

--- a/src/stream/WriteCursor.cpp
+++ b/src/stream/WriteCursor.cpp
@@ -1,0 +1,47 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stream/WriteCursor.h"
+
+
+namespace wasm {
+
+namespace decode {
+
+void WriteCursor::writeBits(uint32_t Value, uint32_t NumBits) {
+  assert(NumBits <= sizeof(uint32_t) * CHAR_BIT);
+  while (NumBits > 0) {
+    const BitsInByteType AvailBits = CurByte.getWriteBitsRemaining();
+    if (AvailBits >= NumBits) {
+      CurByte.writeBits(Value, NumBits);
+      if (AvailBits == NumBits) {
+        writeByte(CurByte.getValue());
+        CurByte.reset();
+      }
+      return;
+    }
+    uint32_t Shift = NumBits - AvailBits;
+    CurByte.writeBits(Value >> Shift, AvailBits);
+    Value &= (uint32_t(1) << Shift) - 1;
+    NumBits -= AvailBits;
+    writeByte(CurByte.getValue());
+    CurByte.reset();
+  }
+}
+
+}  // end of namespace decode
+
+}  // end of namespace wasm

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -1,0 +1,49 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a pointer to a byte stream for reading.
+
+#ifndef DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H
+#define DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H
+
+#include "stream/Cursor.h"
+
+namespace wasm {
+
+namespace decode {
+
+class WriteCursor : public Cursor {
+  WriteCursor() = delete;
+  WriteCursor& operator=(const WriteCursor&) = delete;
+ public:
+  WriteCursor(StreamType Type, std::shared_ptr<Queue> Que)
+      : Cursor(Type, Que) {}
+  explicit WriteCursor(const WriteCursor& C) : Cursor(C) {}
+  ~WriteCursor() {}
+
+  BitsInByteType getBitsWritten() const { return CurByte.getBitsWritten(); }
+  BitAddress getCurWriteBitAddress() const {
+    BitAddress Address(getCurAddress(), getBitsWritten());
+    return Address;
+  }
+
+};
+
+}  // end of namespace decode
+
+}  // end of namespace wasm
+
+#endif // DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -25,7 +25,7 @@ namespace wasm {
 
 namespace decode {
 
-class WriteCursor : public Cursor {
+class WriteCursor FINAL : public Cursor {
   WriteCursor() = delete;
   WriteCursor& operator=(const WriteCursor&) = delete;
  public:
@@ -40,6 +40,16 @@ class WriteCursor : public Cursor {
     return Address;
   }
 
+  // Writes next byte. Fails if at end of file. NOTE: Assumed byte aligned!
+  void writeByte(uint8_t Byte) {
+    assert(isByteAligned());
+    if (isIndexAtEndOfPage())
+      writeFillBuffer();
+    PageCursor::writeByte(Byte);
+  }
+
+  // Writes up to 32 bits to the output.
+  void writeBits(uint32_t Value, uint32_t NumBits);
 };
 
 }  // end of namespace decode


### PR DESCRIPTION
Previously, there was only one class (Cursor) for tracking positions into streams.

This CL creates two derived classes of Cursor, ReadCursor and WriteCursor. ReadCursors are used to track positions in a stream while reading, while WriteCursor s are used to track positions in a stream while writing. Base class Cursor is no longer has a public constructor, forcing the user of the new derived classes.

This was done to separate out reading methods to the ReadCursor, and writing methods to the WriteCursor. This helps minimize the accidental use of the wrong IO accessor.
