### PR TITLE
Force cursors to always use a non-null page pointer.

### DIFF
--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -132,9 +132,11 @@ class Cursor : public PageCursor {
   // End of block address.
   std::shared_ptr<BlockEob> EobPtr;
   WorkingByte CurByte;
-
   Cursor(StreamType Type, std::shared_ptr<Queue> Que)
-      : Type(Type), Que(Que), EobPtr(Que->getEofPtr()) {}
+      : PageCursor(Que->getPage(0), 0),
+        Type(Type),
+        Que(Que),
+        EobPtr(Que->getEofPtr()) {}
   explicit Cursor(const Cursor& C)
       : PageCursor(C),
         Type(C.Type),

--- a/src/stream/Page.cpp
+++ b/src/stream/Page.cpp
@@ -28,6 +28,11 @@ FILE* Page::describe(FILE* File) {
   return File;
 }
 
+PageCursor::PageCursor(Queue *Que)
+    : CurPage(Que->getPage(0)), CurAddress(0) {
+  assert(CurPage);
+}
+
 FILE* PageCursor::describe(FILE* File, bool IncludePage) {
   BitAddress Addr(CurAddress);
   Addr.describe(File);

--- a/src/stream/Page.h
+++ b/src/stream/Page.h
@@ -56,6 +56,8 @@ namespace wasm {
 
 namespace decode {
 
+class Queue;
+
 class Page : public std::enable_shared_from_this<Page> {
   Page(const Page&) = delete;
   Page& operator=(const Page&) = delete;
@@ -119,11 +121,18 @@ class Page : public std::enable_shared_from_this<Page> {
 
 class PageCursor {
  public:
+#if 0
   PageCursor() : CurAddress(0) {}
+#endif
+  PageCursor(Queue *Que);
   PageCursor(std::shared_ptr<Page> CurPage, size_t CurAddress)
-      : CurPage(CurPage), CurAddress(CurAddress) {}
+      : CurPage(CurPage), CurAddress(CurAddress) {
+    assert(CurPage);
+  }
   PageCursor(const PageCursor& PC)
-      : CurPage(PC.CurPage), CurAddress(PC.CurAddress) {}
+      : CurPage(PC.CurPage), CurAddress(PC.CurAddress) {
+    assert(CurPage);
+  }
   size_t getMinAddress() const {
     return CurPage ? CurPage->getMinAddress() : 0;
   }

--- a/src/stream/Queue.cpp
+++ b/src/stream/Queue.cpp
@@ -94,8 +94,6 @@ size_t Queue::writeToPage(size_t Address,
   }
   Cursor.CurPage = getPage(Address);
   Cursor.setCurAddress(Address);
-  if (!Cursor.CurPage)
-    return 0;
   dumpPreviousPages();
   // Compute largest contiguous range of bytes available.
   if (Address + WantedSize > Cursor.getMaxAddress())
@@ -107,7 +105,7 @@ void Queue::freezeEof(size_t Address) {
   assert(Address != kUndefinedAddress && "WASM stream too big to process");
   assert(!EofFrozen);
   // This call zero-fill pages if writing hasn't reached Address yet.
-  PageCursor Cursor;
+  PageCursor Cursor(this);
   writeToPage(Address, 0, Cursor);
   EofPtr->setEobAddress(Address);
   Cursor.setMaxAddress(Address);
@@ -138,7 +136,7 @@ void Queue::writePageAt(FILE* File, size_t Address) {
 
 size_t Queue::read(size_t& Address, uint8_t* ToBuf, size_t WantedSize) {
   size_t Count = 0;
-  PageCursor Cursor;
+  PageCursor Cursor(this);
   while (WantedSize) {
     size_t FoundSize = readFromPage(Address, WantedSize, Cursor);
     if (FoundSize == 0)
@@ -153,7 +151,7 @@ size_t Queue::read(size_t& Address, uint8_t* ToBuf, size_t WantedSize) {
 }
 
 bool Queue::write(size_t& Address, uint8_t* FromBuf, size_t WantedSize) {
-  PageCursor Cursor;
+  PageCursor Cursor(this);
   while (WantedSize) {
     size_t FoundSize = writeToPage(Address, WantedSize, Cursor);
     if (FoundSize == 0)

--- a/src/stream/Queue.h
+++ b/src/stream/Queue.h
@@ -118,6 +118,7 @@ class Queue : public std::enable_shared_from_this<Queue> {
   Queue(const Queue&) = delete;
   Queue& operator=(const Queue&) = delete;
   friend class Cursor;
+  friend class PageCursor;
 
  public:
   Queue();

--- a/src/test/TestByteQueues.cpp
+++ b/src/test/TestByteQueues.cpp
@@ -113,8 +113,8 @@ int main(int Argc, char* Argv[]) {
   WriteBackedQueue Output(getOutput());
   // uint8_t Buffer[MaxBufSize];
   size_t Address = 0;
-  PageCursor ReadCursor;
-  PageCursor WriteCursor;
+  PageCursor ReadCursor(&Input);
+  PageCursor WriteCursor(&Output);
   while (Address < Input.currentSize()) {
     size_t ReadBytesAvailable =
         Input.readFromPage(Address, BufSize, ReadCursor);

--- a/test/test-sources/Makefile.common
+++ b/test/test-sources/Makefile.common
@@ -42,7 +42,19 @@ else ifndef RELEASE
   RELEASE = 0
 endif
 
-BUILDDIR = ../../build
+# PAGE_SIZE (if defined) specifies that log2 size (i.e. number of bits) to use
+# for page size.
+ifdef PAGE_SIZE
+  PAGE_BUILD_SUFFIX=/p$(PAGE_SIZE)
+  USE_PAGE_SIZE = $(PAGE_SIZE)
+  MAKE_PAGE_SIZE = "PAGESIZE=$(PAGE_SIZE)"
+else
+  USE_PAGE_SIZE = default
+  PAGE_BUILD_SUFFIX=
+  MAKE_PAGE_SIZE=
+endif
+
+BUILDDIR = ../../build$(PAGE_BUILD_SUFFIX)
 
 SEXP_SRCDIR = ../../src/sexp
 SEXP_DEFAULTS = $(SEXP_SRCDIR)/defaults.df


### PR DESCRIPTION
This is in preparation if speeding up the Cursor implementation. The current code has to do far too much checking on each byte. Part of the problem is that the cursor may not be pointing to a page, and the other part is that it doesn't know if read fill needs to be applied. This CL fixes the former.

It also fixes the make files so that page size testing uses different directories.
