### PR TITLE
Use first available page for default cursor initializers.

### DIFF
--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -133,7 +133,7 @@ class Cursor : public PageCursor {
   std::shared_ptr<BlockEob> EobPtr;
   WorkingByte CurByte;
   Cursor(StreamType Type, std::shared_ptr<Queue> Que)
-      : PageCursor(Que->getPage(0), 0),
+      : PageCursor(Que->FirstPage, Que->FirstPage->getMinAddress()),
         Type(Type),
         Que(Que),
         EobPtr(Que->getEofPtr()) {}

--- a/src/stream/Page.cpp
+++ b/src/stream/Page.cpp
@@ -29,7 +29,7 @@ FILE* Page::describe(FILE* File) {
 }
 
 PageCursor::PageCursor(Queue *Que)
-    : CurPage(Que->getPage(0)), CurAddress(0) {
+    : CurPage(Que->FirstPage), CurAddress(Que->FirstPage->getMinAddress()) {
   assert(CurPage);
 }
 


### PR DESCRIPTION
Fix bug in previous CL that always assumed to initialize cursors using page 0 of the queue. Note: as read cursors move forward, initial pages of the queue may get deallocated to reclaim page space. This Cl fixes the default initialization to use the first (non-deleted) page of the queue.
