### PR TITLE
Speed up atEob and readByte in read cursors.

### DIFF
--- a/src/interp/ByteWriteStream.cpp
+++ b/src/interp/ByteWriteStream.cpp
@@ -158,8 +158,7 @@ size_t ByteWriteStream::getBlockSize(decode::WriteCursor& StartPos,
 
 void ByteWriteStream::moveBlock(decode::WriteCursor& Pos, size_t StartAddress,
                                 size_t Size) {
-  ReadCursor CopyPos(StreamType::Byte, Pos.getQueue());
-  CopyPos.jumpToByteAddress(StartAddress);
+  ReadCursor CopyPos(Pos, StartAddress);
   for (size_t i = 0; i < Size; ++i)
     Pos.writeByte(CopyPos.readByte());
 }

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -25,6 +25,7 @@ FILE* WorkingByte::describe(FILE* File) {
   return File;
 }
 
+#if 0
 void Cursor::jumpToByteAddress(size_t NewAddress) {
   if (isValidPageAddress(NewAddress)) {
     // We can reuse the same page, since NewAddress is within the page.
@@ -34,6 +35,7 @@ void Cursor::jumpToByteAddress(size_t NewAddress) {
   // Move to the wanted page.
   Que->readFromPage(NewAddress, 0, *this);
 }
+#endif
 
 bool Cursor::readFillBuffer() {
   size_t CurAddress = getCurAddress();

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -102,11 +102,6 @@ class Cursor : public PageCursor {
 
   std::shared_ptr<Queue> getQueue() { return Que; }
 
-  bool atByteEob() {
-    return getCurAddress() >= getEobAddress().getByteAddress() ||
-           !readFillBuffer();
-  }
-
   BitAddress& getEobAddress() const { return EobPtr->getEobAddress(); }
 
   void freezeEof() { Que->freezeEof(getCurAddress()); }
@@ -120,7 +115,9 @@ class Cursor : public PageCursor {
     return getCurAddress();
   }
 
+#if 0
   void jumpToByteAddress(size_t NewAddress);
+#endif
 
   // For debugging.
   FILE* describe(FILE* File, bool IncludeDetail = false);
@@ -139,6 +136,13 @@ class Cursor : public PageCursor {
         EobPtr(Que->getEofPtr()) {}
   explicit Cursor(const Cursor& C)
       : PageCursor(C),
+        Type(C.Type),
+        Que(C.Que),
+        EobPtr(C.EobPtr),
+        CurByte(C.CurByte) {}
+
+  Cursor(const Cursor& C, size_t StartAddress)
+      : PageCursor(C.Que->getPage(StartAddress), StartAddress),
         Type(C.Type),
         Que(C.Que),
         EobPtr(C.EobPtr),

--- a/src/stream/Page.h
+++ b/src/stream/Page.h
@@ -124,7 +124,7 @@ class PageCursor {
 #if 0
   PageCursor() : CurAddress(0) {}
 #endif
-  PageCursor(Queue *Que);
+  PageCursor(Queue* Que);
   PageCursor(std::shared_ptr<Page> CurPage, size_t CurAddress)
       : CurPage(CurPage), CurAddress(CurAddress) {
     assert(CurPage);

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -81,7 +81,11 @@ class ReadCursor FINAL : public Cursor {
   // aligned!
   uint8_t readByte() {
     assert(isByteAligned());
-    if (isIndexAtEndOfPage() && !readFillBuffer())
+    if (getCurAddress() < GuaranteedBeforeEob)
+      return PageCursor::readByte();
+    bool atEof = isIndexAtEndOfPage() && !readFillBuffer();
+      updateGuaranteedBeforeEob();
+      if (atEof)
       return 0;
     return PageCursor::readByte();
   }

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -32,6 +32,7 @@ class WriteCursor FINAL : public Cursor {
   WriteCursor(StreamType Type, std::shared_ptr<Queue> Que)
       : Cursor(Type, Que) {}
   explicit WriteCursor(const WriteCursor& C) : Cursor(C) {}
+  WriteCursor(const Cursor& C, size_t StartAddress) : Cursor(C, StartAddress) {}
   ~WriteCursor() {}
 
   BitsInByteType getBitsWritten() const { return CurByte.getBitsWritten(); }


### PR DESCRIPTION
Does this by caching known non-eob range in read cursor, and then using to optimize tests in the corresponding atEob and readByte methods.
