### PR TITLE
Speed up writeByte in a write cursor.

### DIFF
--- a/src/interp/ByteReadStream.cpp
+++ b/src/interp/ByteReadStream.cpp
@@ -79,11 +79,13 @@ uint32_t ByteReadStream::readUint32Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return readFixed<uint32_t>(Pos);
 }
 
-int32_t ByteReadStream::readVarint32Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
+int32_t ByteReadStream::readVarint32Bits(ReadCursor& Pos,
+                                         uint32_t /*NumBits*/) {
   return readSignedLEB128<uint32_t>(Pos);
 }
 
-int64_t ByteReadStream::readVarint64Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
+int64_t ByteReadStream::readVarint64Bits(ReadCursor& Pos,
+                                         uint32_t /*NumBits*/) {
   return readSignedLEB128<uint64_t>(Pos);
 }
 
@@ -91,15 +93,18 @@ uint64_t ByteReadStream::readUint64Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
   return readFixed<uint64_t>(Pos);
 }
 
-uint32_t ByteReadStream::readVaruint32Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
+uint32_t ByteReadStream::readVaruint32Bits(ReadCursor& Pos,
+                                           uint32_t /*NumBits*/) {
   return readLEB128<uint32_t>(Pos);
 }
 
-uint64_t ByteReadStream::readVaruint64Bits(ReadCursor& Pos, uint32_t /*NumBits*/) {
+uint64_t ByteReadStream::readVaruint64Bits(ReadCursor& Pos,
+                                           uint32_t /*NumBits*/) {
   return readLEB128<uint64_t>(Pos);
 }
 
-void ByteReadStream::alignToByte(ReadCursor& /*Pos*/) {}
+void ByteReadStream::alignToByte(ReadCursor& /*Pos*/) {
+}
 
 size_t ByteReadStream::readBlockSize(decode::ReadCursor& Pos) {
   return readVaruint32(Pos);

--- a/src/interp/ByteReadStream.h
+++ b/src/interp/ByteReadStream.h
@@ -36,8 +36,10 @@ class ByteReadStream FINAL : public ReadStream {
   uint64_t readUint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
   int32_t readVarint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
   int64_t readVarint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
-  uint32_t readVaruint32Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
-  uint64_t readVaruint64Bits(decode::ReadCursor& Pos, uint32_t NumBits) OVERRIDE;
+  uint32_t readVaruint32Bits(decode::ReadCursor& Pos,
+                             uint32_t NumBits) OVERRIDE;
+  uint64_t readVaruint64Bits(decode::ReadCursor& Pos,
+                             uint32_t NumBits) OVERRIDE;
   void alignToByte(decode::ReadCursor& Pos) OVERRIDE;
   size_t readBlockSize(decode::ReadCursor& Pos) OVERRIDE;
   void pushEobAddress(decode::ReadCursor& Pos, size_t BlockSize) OVERRIDE;
@@ -50,4 +52,4 @@ class ByteReadStream FINAL : public ReadStream {
 
 }  // end of namespace wasm
 
-#endif // DECOMPRESSOR_SRC_INTERP_BYTEREADSTREAM_H
+#endif  // DECOMPRESSOR_SRC_INTERP_BYTEREADSTREAM_H

--- a/src/interp/ByteWriteStream.cpp
+++ b/src/interp/ByteWriteStream.cpp
@@ -134,14 +134,14 @@ void ByteWriteStream::writeVaruint64Bits(uint64_t Value,
   writeLEB128<uint64_t>(Value, Pos);
 }
 
-void ByteWriteStream::alignToByte(decode::WriteCursor& Pos) {}
+void ByteWriteStream::alignToByte(decode::WriteCursor& Pos) {
+}
 
 size_t ByteWriteStream::getStreamAddress(WriteCursor& Pos) {
   return Pos.getCurByteAddress();
 }
 
-void ByteWriteStream::writeFixedBlockSize(WriteCursor& Pos,
-                                          size_t BlockSize) {
+void ByteWriteStream::writeFixedBlockSize(WriteCursor& Pos, size_t BlockSize) {
   writeFixedLEB128<uint32_t>(BlockSize, Pos);
 }
 
@@ -153,16 +153,16 @@ void ByteWriteStream::writeVarintBlockSize(decode::WriteCursor& Pos,
 size_t ByteWriteStream::getBlockSize(decode::WriteCursor& StartPos,
                                      decode::WriteCursor& EndPos) {
   return EndPos.getCurByteAddress() -
-      (StartPos.getCurByteAddress() + ChunksInWord);
+         (StartPos.getCurByteAddress() + ChunksInWord);
 }
 
-void ByteWriteStream::moveBlock(decode::WriteCursor& Pos, size_t StartAddress,
+void ByteWriteStream::moveBlock(decode::WriteCursor& Pos,
+                                size_t StartAddress,
                                 size_t Size) {
   ReadCursor CopyPos(Pos, StartAddress);
   for (size_t i = 0; i < Size; ++i)
     Pos.writeByte(CopyPos.readByte());
 }
-
 
 }  // end of namespace decode
 

--- a/src/interp/ByteWriteStream.h
+++ b/src/interp/ByteWriteStream.h
@@ -61,10 +61,12 @@ class ByteWriteStream FINAL : public WriteStream {
   void alignToByte(decode::WriteCursor& Pos) OVERRIDE;
   size_t getStreamAddress(decode::WriteCursor& Pos) OVERRIDE;
   void writeFixedBlockSize(decode::WriteCursor& Pos, size_t BlockSize) OVERRIDE;
-  void writeVarintBlockSize(decode::WriteCursor& Pos, size_t BlockSIze) OVERRIDE;
+  void writeVarintBlockSize(decode::WriteCursor& Pos,
+                            size_t BlockSIze) OVERRIDE;
   size_t getBlockSize(decode::WriteCursor& StartPos,
                       decode::WriteCursor& EndPos) OVERRIDE;
-  void moveBlock(decode::WriteCursor& Pos, size_t StartAddress,
+  void moveBlock(decode::WriteCursor& Pos,
+                 size_t StartAddress,
                  size_t Size) OVERRIDE;
 
   static bool implementsClass(decode::StreamType RtClassId) {

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -25,18 +25,6 @@ FILE* WorkingByte::describe(FILE* File) {
   return File;
 }
 
-#if 0
-void Cursor::jumpToByteAddress(size_t NewAddress) {
-  if (isValidPageAddress(NewAddress)) {
-    // We can reuse the same page, since NewAddress is within the page.
-    setCurAddress(NewAddress);
-    return;
-  }
-  // Move to the wanted page.
-  Que->readFromPage(NewAddress, 0, *this);
-}
-#endif
-
 bool Cursor::readFillBuffer() {
   size_t CurAddress = getCurAddress();
   if (CurAddress >= Que->getEofAddress())

--- a/src/stream/Page.cpp
+++ b/src/stream/Page.cpp
@@ -28,7 +28,7 @@ FILE* Page::describe(FILE* File) {
   return File;
 }
 
-PageCursor::PageCursor(Queue *Que)
+PageCursor::PageCursor(Queue* Que)
     : CurPage(Que->FirstPage), CurAddress(Que->FirstPage->getMinAddress()) {
   assert(CurPage);
 }

--- a/src/stream/Page.h
+++ b/src/stream/Page.h
@@ -121,9 +121,6 @@ class Page : public std::enable_shared_from_this<Page> {
 
 class PageCursor {
  public:
-#if 0
-  PageCursor() : CurAddress(0) {}
-#endif
   PageCursor(Queue* Que);
   PageCursor(std::shared_ptr<Page> CurPage, size_t CurAddress)
       : CurPage(CurPage), CurAddress(CurAddress) {

--- a/src/stream/Queue.cpp
+++ b/src/stream/Queue.cpp
@@ -35,9 +35,7 @@ FILE* BlockEob::describe(FILE* File) const {
 }
 
 Queue::Queue()
-    : MinPeekSize(32),
-      EofFrozen(false),
-      EofPtr(std::make_shared<BlockEob>()) {
+    : MinPeekSize(32), EofFrozen(false), EofPtr(std::make_shared<BlockEob>()) {
   LastPage = FirstPage = std::make_shared<Page>(0);
   PageMap.push_back(LastPage);
 }

--- a/src/stream/ReadBackedQueue.cpp
+++ b/src/stream/ReadBackedQueue.cpp
@@ -39,8 +39,8 @@ bool ReadBackedQueue::readFill(size_t Address) {
       LastPage = NewPage;
       SpaceAvailable = Page::Size;
     }
-    size_t NumBytes = Reader->read(
-        &(LastPage->Buffer[Page::address(Address)]), SpaceAvailable);
+    size_t NumBytes = Reader->read(&(LastPage->Buffer[Page::address(Address)]),
+                                   SpaceAvailable);
     LastPage->incrementMaxAddress(NumBytes);
     if (NumBytes == 0) {
       freezeEof(Address);

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -28,28 +28,21 @@ namespace decode {
 class ReadCursor FINAL : public Cursor {
   ReadCursor() = delete;
   ReadCursor& operator=(const ReadCursor&) = delete;
+
  public:
-  ReadCursor(StreamType Type, std::shared_ptr<Queue> Que)
-      : Cursor(Type, Que) {
-    updateGuaranteedBeforeEob();
-  }
+  ReadCursor(StreamType Type, std::shared_ptr<Queue> Que) : Cursor(Type, Que) {}
 
-  explicit ReadCursor(const Cursor& C) : Cursor(C) {
-    updateGuaranteedBeforeEob();
-  }
+  explicit ReadCursor(const Cursor& C) : Cursor(C) {}
 
-  ReadCursor(const Cursor& C, size_t StartAddress) : Cursor(C, StartAddress) {
-    updateGuaranteedBeforeEob();
-  }
+  ReadCursor(const Cursor& C, size_t StartAddress) : Cursor(C, StartAddress) {}
 
   ~ReadCursor() {}
 
   bool atByteEob() {
     if (getCurAddress() < GuaranteedBeforeEob)
       return false;
-    bool Result =
-        getCurAddress() >= getEobAddress().getByteAddress() ||
-        !readFillBuffer();
+    bool Result = getCurAddress() >= getEobAddress().getByteAddress() ||
+                  !readFillBuffer();
     updateGuaranteedBeforeEob();
     return Result;
   }
@@ -84,24 +77,18 @@ class ReadCursor FINAL : public Cursor {
     if (getCurAddress() < GuaranteedBeforeEob)
       return PageCursor::readByte();
     bool atEof = isIndexAtEndOfPage() && !readFillBuffer();
-      updateGuaranteedBeforeEob();
-      if (atEof)
+    updateGuaranteedBeforeEob();
+    if (atEof)
       return 0;
     return PageCursor::readByte();
   }
 
   // Reads up to 32 bits from the input.
   uint32_t readBits(uint32_t NumBits);
-protected:
-  size_t GuaranteedBeforeEob;
-  void updateGuaranteedBeforeEob() {
-    GuaranteedBeforeEob = std::min(CurPage->getMaxAddress(),
-                                   EobPtr->getEobAddress().getByteAddress());
-  }
 };
 
 }  // end of namespace decode
 
 }  // end of namespace wasm
 
-#endif // DECOMPRESSOR_SRC_STREAM_READCURSOR_H
+#endif  // DECOMPRESSOR_SRC_STREAM_READCURSOR_H

--- a/src/stream/WriteCursor.cpp
+++ b/src/stream/WriteCursor.cpp
@@ -16,7 +16,6 @@
 
 #include "stream/WriteCursor.h"
 
-
 namespace wasm {
 
 namespace decode {

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -28,6 +28,7 @@ namespace decode {
 class WriteCursor FINAL : public Cursor {
   WriteCursor() = delete;
   WriteCursor& operator=(const WriteCursor&) = delete;
+
  public:
   WriteCursor(StreamType Type, std::shared_ptr<Queue> Que)
       : Cursor(Type, Que) {}
@@ -44,8 +45,11 @@ class WriteCursor FINAL : public Cursor {
   // Writes next byte. Fails if at end of file. NOTE: Assumed byte aligned!
   void writeByte(uint8_t Byte) {
     assert(isByteAligned());
+    if (getCurAddress() < GuaranteedBeforeEob)
+      return PageCursor::writeByte(Byte);
     if (isIndexAtEndOfPage())
       writeFillBuffer();
+    updateGuaranteedBeforeEob();
     PageCursor::writeByte(Byte);
   }
 
@@ -57,4 +61,4 @@ class WriteCursor FINAL : public Cursor {
 
 }  // end of namespace wasm
 
-#endif // DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H
+#endif  // DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H


### PR DESCRIPTION
Does same trick as was done with readByte in the last commit.

Also reformats several files to match that of clang-format.
