### PR TITLE
Fix interpreter to understand parameter passing.

### DIFF
--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -77,6 +77,7 @@ class Interpreter {
   decode::IntType LastReadValue;
   bool MinimizeBlockSize;
   TraceClassSexpReaderWriter Trace;
+  filt::ConstNodeVectorType CallStack;
 
   void decompressSection();
   void readSectionName();
@@ -97,6 +98,7 @@ class Interpreter {
   // Reads opcode selector into Value. Returns the Bitsize to the (fixed) number
   // of bits used to read the opcode selector. Otherwise returns zero.
   uint32_t readOpcodeSelector(const filt::Node* Nd, decode::IntType& Value);
+  const filt::Node* getParam(const filt::Node* Param);
 };
 
 }  // end of namespace interp.

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -101,75 +101,95 @@
   /* Internal (not opcodes in compressed file) */                              \
   X(UnknownSection,    0xFF, "unknown.section", nullptr,           1, 0)       \
 
-//#define X(tag)
+//#define X(tag, NODE_DECLS)
 #define AST_NULLARYNODE_TABLE                                                  \
-  X(BlockEndNoArgs)                                                            \
-  X(Error)                                                                     \
-  X(LastRead)                                                                \
-  X(Uint8NoArgs)                                                               \
-  X(Uint32NoArgs)                                                              \
-  X(Uint64NoArgs)                                                              \
-  X(Varint32NoArgs)                                                            \
-  X(Varint64NoArgs)                                                            \
-  X(Varuint32NoArgs)                                                           \
-  X(Varuint64NoArgs)                                                           \
-  X(Void)                                                                      \
+  X(BlockEndNoArgs,)                                                           \
+  X(Error,)                                                                    \
+  X(LastRead,)                                                                 \
+  X(Uint8NoArgs,)                                                              \
+  X(Uint32NoArgs,)                                                             \
+  X(Uint64NoArgs,)                                                             \
+  X(Varint32NoArgs,)                                                           \
+  X(Varint64NoArgs,)                                                           \
+  X(Varuint32NoArgs,)                                                          \
+  X(Varuint64NoArgs,)                                                          \
+  X(Void,)                                                                     \
 
-//#define X(tag)
+//#define X(tag, NODE_DECLS)
 #define AST_INTEGERNODE_TABLE                                                  \
-  X(I32Const)                                                                  \
-  X(I64Const)                                                                  \
-  X(Param)                                                                     \
-  X(U8Const)                                                                   \
-  X(U32Const)                                                                  \
-  X(U64Const)                                                                  \
-  X(Uint32OneArg)                                                              \
-  X(Uint64OneArg)                                                              \
-  X(Uint8OneArg)                                                               \
-  X(Varint32OneArg)                                                            \
-  X(Varint64OneArg)                                                            \
-  X(Varuint32OneArg)                                                           \
-  X(Varuint64OneArg)                                                           \
-  X(Version)                                                                   \
+  X(I32Const,)                                                                 \
+  X(I64Const,)                                                                 \
+  X(Param, PARAM_DECLS )                                                       \
+  X(U8Const,)                                                                  \
+  X(U32Const,)                                                                 \
+  X(U64Const,)                                                                 \
+  X(Uint32OneArg,)                                                             \
+  X(Uint64OneArg,)                                                             \
+  X(Uint8OneArg,)                                                              \
+  X(Varint32OneArg,)                                                           \
+  X(Varint64OneArg,)                                                           \
+  X(Varuint32OneArg,)                                                          \
+  X(Varuint64OneArg,)                                                          \
+  X(Version,)                                                                  \
 
-//#define X(tag)
+#define PARAM_DECLS                                                            \
+  public:                                                                      \
+    bool validateNode(NodeVectorType &Parents) OVERRIDE;                       \
+    SymbolNode *getDefiningSymbol() const {                                    \
+      return DefiningSymbol.get();                                             \
+    }                                                                          \
+  private:                                                                     \
+    utils::initialized_ptr<SymbolNode> DefiningSymbol;                         \
+
+//#define X(tag, NODE_DECLS)
 #define AST_UNARYNODE_TABLE                                                    \
-  X(Block)                                                                     \
-  X(LoopUnbounded)                                                             \
-  X(Not)                                                                       \
-  X(Peek)                                                                      \
-  X(Read)                                                                      \
-  X(Undefine)                                                                  \
-  X(UnknownSection)                                                            \
+  X(Block,)                                                                    \
+  X(LoopUnbounded,)                                                            \
+  X(Not,)                                                                      \
+  X(Peek,)                                                                     \
+  X(Read,)                                                                     \
+  X(Undefine,)                                                                 \
+  X(UnknownSection,)                                                           \
 
-//#define X(tag)
+//#define X(tag, NODE_DECLS)
 #define AST_BINARYNODE_TABLE                                                   \
-  X(And)                                                                       \
-  X(Case)                                                                      \
-  X(IfThen)                                                                    \
-  X(Loop)                                                                      \
-  X(Or)                                                                        \
-  X(Rename)                                                                    \
-  X(Write)                                                                     \
+  X(And,)                                                                      \
+  X(Case,)                                                                     \
+  X(IfThen,)                                                                   \
+  X(Loop,)                                                                     \
+  X(Or,)                                                                       \
+  X(Rename,)                                                                   \
+  X(Write,)                                                                    \
 
-//#define X(tag)
+//#define X(tag, NODE_DECLS)
 #define AST_SELECTNODE_TABLE                                                   \
-  X(Switch)                                                                    \
-  X(Map)                                                                       \
+  X(Switch,)                                                                   \
+  X(Map,)                                                                      \
 
-//#define X(tag)
+//#define X(tag, NODE_DECLS)
 #define AST_NARYNODE_TABLE                                                     \
-  X(File)                                                                      \
-  X(Filter)                                                                    \
-  X(Eval)                                                                      \
-  X(Section)                                                                   \
-  X(Sequence)                                                                  \
+  X(File,)                                                                     \
+  X(Filter,)                                                                   \
+  X(Eval,EVAL_DECLS)                                                           \
+  X(Section,)                                                                  \
+  X(Sequence,)                                                                 \
 
-//#define X(tag)
+#define EVAL_DECLS                                                             \
+ public:                                                                       \
+  SymbolNode *getCallName() const {                                            \
+    return dyn_cast<SymbolNode>(getKid(0));                                    \
+  }                                                                            \
+
+//#define X(tag, NODE_DECLS)
 #define AST_TERNARYNODE_TABLE                                                  \
-  X(Convert)                                                                   \
-  X(Define)                                                                    \
-  X(IfThenElse)                                                                \
+  X(Convert,)                                                                  \
+  X(Define, DEFINE_DECLS)                                                      \
+  X(IfThenElse,)                                                               \
+
+#define DEFINE_DECLS                                                           \
+ public:                                                                       \
+  bool isValidParam(decode::IntType Index);                                    \
+  std::string getName() const;                                                 \
 
 //#define X(tag)
 #define AST_NODE_HAS_HIDDEN_SEQ                                                \

--- a/src/utils/Trace.cpp
+++ b/src/utils/Trace.cpp
@@ -23,6 +23,13 @@ namespace wasm {
 
 namespace utils {
 
+void TraceClass::init() {
+  Label = "Trace";
+  File = stderr;
+  IndentLevel = 0;
+  TraceProgress = false;
+}
+
 TraceClass::TraceClass() {
   init();
 }

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -181,9 +181,10 @@ class TraceClass : std::enable_shared_from_this<TraceClass> {
     if (getTraceProgress())
       traceHexInternal(Name, Value);
   }
-  void tracePointer(const char* Name, void* Ptr) {
+  template <typename T>
+  void tracePointer(const char* Name, T* Ptr) {
     if (getTraceProgress())
-      tracePointerInternal(Name, Ptr);
+      tracePointerInternal(Name, (void*)Ptr);
   }
   bool getTraceProgress() const { return wasm::isDebug() && TraceProgress; }
   void setTraceProgress(bool NewValue) { TraceProgress = NewValue; }
@@ -197,13 +198,6 @@ class TraceClass : std::enable_shared_from_this<TraceClass> {
   bool TraceProgress;
   std::vector<const char*> CallStack;
 
-  void init() {
-    Label = nullptr;
-    File = stderr;
-    IndentLevel = 0;
-    TraceProgress = false;
-  }
-
   void enter(const char* Name);
   void exit();
   void traceMessageInternal(const std::string& Message);
@@ -214,6 +208,9 @@ class TraceClass : std::enable_shared_from_this<TraceClass> {
   void traceUintInternal(const char* Name, uintmax_t Value);
   void traceHexInternal(const char* Name, uintmax_t Value);
   void tracePointerInternal(const char* Name, void* Value);
+
+ private:
+  inline void init();
 };
 
 }  // end of namespace utils

--- a/src/utils/backwards_iterator.h
+++ b/src/utils/backwards_iterator.h
@@ -1,0 +1,41 @@
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a backwards iterator for for loop ranges.
+
+#ifndef DECOMPRESSOR_SRC_UTILS_BACKWARDS_ITERATOR_H
+#define DECOMPRESSOR_SRC_UTILS_BACKWARDS_ITERATOR_H
+
+namespace wasm {
+
+namespace utils {
+
+template <typename T>
+class backwards {
+ public:
+  explicit backwards(T& t) : t(t) {}
+  typename T::const_reverse_iterator begin() const { return t.rbegin(); }
+  typename T::const_reverse_iterator end() const { return t.rend(); }
+
+ private:
+  const T& t;
+};
+
+}  // end of namespace utils
+
+}  // end of namespace wasm
+
+#endif  // DECOMPRESSOR_SRC_UTILS_BACKWARDS_ITERATOR_H

--- a/src/utils/initialized_ptr.h
+++ b/src/utils/initialized_ptr.h
@@ -1,0 +1,168 @@
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines pointers that are always initialized.
+
+#ifndef DECOMPRESSOR_SRC_UTILS_INITIALIZED_PTR_H
+#define DECOMPRESSOR_SRC_UTILS_INITIALIZED_PTR_H
+
+namespace wasm {
+
+namespace utils {
+
+template <typename T>
+class initialized_ptr {
+ public:
+  typedef T* pointer;
+  typedef T element_type;
+  initialized_ptr() : Ptr(nullptr) {}
+  initialized_ptr(std::nullptr_t) : Ptr(nullptr) {}
+  explicit initialized_ptr(const initialized_ptr<T>& P) : Ptr(P.Ptr) {}
+  explicit initialized_ptr(pointer P) : Ptr(P) {}
+  initialized_ptr<T>& operator=(initialized_ptr<T>& P) {
+    Ptr = P.Ptr;
+    return *this;
+  }
+  initialized_ptr<T>& operator=(pointer P) {
+    Ptr = P;
+    return *this;
+  }
+  initialized_ptr<T>& operator=(std::nullptr_t) {
+    Ptr = nullptr;
+    return *this;
+  }
+  void reset(pointer P = nullptr) { Ptr = P; }
+  void swap(initialized_ptr<T>& P) {
+    pointer Tmp = Ptr;
+    Ptr = P.Ptr;
+    P.Poitner = Tmp;
+  }
+  void swap(pointer& P) {
+    pointer Tmp = Ptr;
+    Ptr = P;
+    P = Tmp;
+  }
+  pointer get() const { return Ptr; }
+  explicit operator bool() const { return Ptr != nullptr; }
+  pointer operator->() const { return Ptr; }
+  const element_type& operator*() const { return *Ptr; }
+  element_type& operator*() { return *Ptr; }
+
+ private:
+  T* Ptr;
+};
+
+template <typename T>
+inline bool operator<(const initialized_ptr<T>& P1,
+                      const initialized_ptr<T>& P2) {
+  return P1.get() < P2.get();
+}
+
+template <typename T>
+inline bool operator<(std::nullptr_t, const initialized_ptr<T>& P2) {
+  return nullptr < P2.get();
+}
+
+template <typename T>
+inline bool operator<(const initialized_ptr<T>& P1, std::nullptr_t) {
+  return P1.get() < nullptr;
+}
+
+template <typename T>
+inline bool operator<=(const initialized_ptr<T>& P1,
+                       const initialized_ptr<T>& P2) {
+  return P1.get() <= P2.get();
+}
+
+template <typename T>
+inline bool operator<=(std::nullptr_t, const initialized_ptr<T>& P2) {
+  return nullptr <= P2.get();
+}
+
+template <typename T>
+inline bool operator<=(const initialized_ptr<T>& P1, std::nullptr_t) {
+  return P1.get() <= nullptr;
+}
+
+template <typename T>
+inline bool operator==(const initialized_ptr<T>& P1,
+                       const initialized_ptr<T>& P2) {
+  return P1.get() == P2.get();
+}
+
+template <typename T>
+inline bool operator==(std::nullptr_t, const initialized_ptr<T>& P2) {
+  return nullptr == P2.get();
+}
+
+template <typename T>
+inline bool operator==(const initialized_ptr<T>& P1, std::nullptr_t) {
+  return P1.get() == nullptr;
+}
+
+template <typename T>
+inline bool operator>=(const initialized_ptr<T>& P1,
+                       const initialized_ptr<T>& P2) {
+  return P1.get() >= P2.get();
+}
+
+template <typename T>
+inline bool operator>=(std::nullptr_t, const initialized_ptr<T>& P2) {
+  return nullptr >= P2.get();
+}
+
+template <typename T>
+inline bool operator>=(const initialized_ptr<T>& P1, std::nullptr_t) {
+  return P1.get() >= nullptr;
+}
+
+template <typename T>
+inline bool operator>(const initialized_ptr<T>& P1,
+                      const initialized_ptr<T>& P2) {
+  return P1.get() > P2.get();
+}
+
+template <typename T>
+inline bool operator>(std::nullptr_t, const initialized_ptr<T>& P2) {
+  return nullptr > P2.get();
+}
+
+template <typename T>
+inline bool operator>(const initialized_ptr<T>& P1, std::nullptr_t) {
+  return P1.get() > nullptr;
+}
+
+template <typename T>
+inline bool operator!=(const initialized_ptr<T>& P1,
+                       const initialized_ptr<T>& P2) {
+  return P1.get() != P2.get();
+}
+
+template <typename T>
+inline bool operator!=(std::nullptr_t, const initialized_ptr<T>& P2) {
+  return nullptr != P2.get();
+}
+
+template <typename T>
+inline bool operator!=(const initialized_ptr<T>& P1, std::nullptr_t) {
+  return P1.get() != nullptr;
+}
+
+}  // end of namespace utils
+
+}  // end of namespace wasm
+
+#endif  // DECOMPRESSOR_SRC_UTILS_INITIALIZED_PTR_H


### PR DESCRIPTION
Added code to be able to understand passing code as parameters to method calls.

Also uses lexical scope for parameter references. Doing so is a bit tricky, because parameters may be code that also contains parameter values. The key was to initially associate parameter nodes with the defining symbol of the definition they appear in. Then, when the are  executed, look up the call stack until it is a call on the defining symbol. Then extract the appropriate parameter argument from the caller.
