### PR TITLE
Refactor s-expression reader to pass in read cursor.

### DIFF
--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -52,9 +52,17 @@ class BinaryReader {
 
   ~BinaryReader() {}
 
+  // Returns the input buffer to the caller, so that they can
+  // access it.
+  const std::shared_ptr<decode::Queue> &getInput() const { return Input; }
+
   FileNode* readFile();
 
+  FileNode* readFile(decode::ReadCursor &ReadPos);
+
   SectionNode* readSection();
+
+  SectionNode* readSection(decode::ReadCursor &ReadPos);
 
   void setTraceProgress(bool NewValue) { Trace.setTraceProgress(NewValue); }
 
@@ -62,7 +70,8 @@ class BinaryReader {
 
  private:
   std::shared_ptr<interp::ReadStream> Reader;
-  decode::ReadCursor ReadPos;
+  std::shared_ptr<decode::Queue> Input;
+  decode::ReadCursor *ReadPos;
   std::shared_ptr<SymbolTable> Symtab;
   SectionSymbolTable SectionSymtab;
   // The magic number of the input.

--- a/src/interp/TraceSexpReader.cpp
+++ b/src/interp/TraceSexpReader.cpp
@@ -21,20 +21,20 @@ namespace wasm {
 
 namespace interp {
 
-TraceClassSexpReader::TraceClassSexpReader(decode::Cursor& ReadPos)
+TraceClassSexpReader::TraceClassSexpReader(decode::Cursor* ReadPos)
     : TraceClassSexp(), ReadPos(ReadPos) {
 }
 
-TraceClassSexpReader::TraceClassSexpReader(decode::Cursor& ReadPos,
+TraceClassSexpReader::TraceClassSexpReader(decode::Cursor* ReadPos,
                                            const char* Label)
     : TraceClassSexp(Label), ReadPos(ReadPos) {
 }
 
-TraceClassSexpReader::TraceClassSexpReader(decode::Cursor& ReadPos, FILE* File)
+TraceClassSexpReader::TraceClassSexpReader(decode::Cursor* ReadPos, FILE* File)
     : TraceClassSexp(File), ReadPos(ReadPos) {
 }
 
-TraceClassSexpReader::TraceClassSexpReader(decode::Cursor& ReadPos,
+TraceClassSexpReader::TraceClassSexpReader(decode::Cursor* ReadPos,
                                            const char* Label,
                                            FILE* File)
     : TraceClassSexp(Label, File), ReadPos(ReadPos) {
@@ -44,7 +44,9 @@ TraceClassSexpReader::~TraceClassSexpReader() {
 }
 
 void TraceClassSexpReader::traceContext() const {
-  ReadPos.describe(File);
+  if (ReadPos == nullptr)
+    return;
+  ReadPos->describe(File);
   fputc(' ', File);
 }
 

--- a/src/interp/TraceSexpReader.h
+++ b/src/interp/TraceSexpReader.h
@@ -31,16 +31,21 @@ class TraceClassSexpReader : public filt::TraceClassSexp {
   TraceClassSexpReader& operator=(const TraceClassSexpReader&) = delete;
 
  public:
-  explicit TraceClassSexpReader(decode::Cursor& ReadPos);
-  TraceClassSexpReader(decode::Cursor& ReadPos, const char* Label);
-  TraceClassSexpReader(decode::Cursor& ReadPos, FILE* File);
-  TraceClassSexpReader(decode::Cursor& ReadPos, const char* Label, FILE* File);
+  explicit TraceClassSexpReader(decode::Cursor* ReadPos);
+  TraceClassSexpReader(decode::Cursor* ReadPos, const char* Label);
+  TraceClassSexpReader(decode::Cursor* ReadPos, FILE* File);
+  TraceClassSexpReader(decode::Cursor* ReadPos, const char* Label, FILE* File);
   ~TraceClassSexpReader();
 
   void traceContext() const OVERRIDE;
 
+  decode::Cursor* getReadPos() const { return ReadPos; }
+  void setReadPos(decode::Cursor* NewPos) {
+    ReadPos = NewPos;
+  }
+
  protected:
-  decode::Cursor& ReadPos;
+  decode::Cursor* ReadPos;
 };
 
 }  // end of namespace interp

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -102,6 +102,10 @@ class Cursor : public PageCursor {
 
   std::shared_ptr<Queue> getQueue() { return Que; }
 
+  bool atEof() const {
+    return CurAddress >= Que->getEofAddress();
+  }
+
   BitAddress& getEobAddress() const { return EobPtr->getEobAddress(); }
 
   void freezeEof() { Que->freezeEof(getCurAddress()); }

--- a/src/stream/Queue.h
+++ b/src/stream/Queue.h
@@ -45,6 +45,7 @@ namespace wasm {
 namespace decode {
 
 static constexpr size_t kUndefinedAddress = std::numeric_limits<size_t>::max();
+static constexpr size_t kMaxAddress = std::numeric_limits<size_t>::max() - 1;
 
 typedef uint8_t BitsInByteType;
 


### PR DESCRIPTION
This is in preparation of refactoring the binary filter s-expression reader to work in a "push" mode where input is streamed (into the read cursor) and passed to the binary reader in chunks.
