### PR TITLE
Convert read filter s-expressions into pull model.

### DIFF
--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -1,19 +1,18 @@
-/* -*- C++ -*- */
-/*
- * Copyright 2016 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // implements a reader to extract filter sections.
 
@@ -33,6 +32,19 @@ namespace {
 // Note: Headroom is used to guarantee that we have enough space to
 // read any sexpression node.
 static constexpr size_t kResumeHeadroom = 100;
+
+const char* RunMethodName[] = {
+#define X(tag, name) name,
+    BINARY_READER_METHODS_TABLE
+#undef X
+};
+
+const char* RunStateName[] = {
+#define X(tag, name) name,
+    BINARY_READER_STATES_TABLE
+#undef X
+};
+
 } // end of anonymous namespace
 
 bool BinaryReader::Runner::hasEnoughHeadroom() const {
@@ -43,57 +55,189 @@ bool BinaryReader::Runner::hasEnoughHeadroom() const {
 
 void BinaryReader::Runner::resumeReading() {
   TRACE_METHOD("resumeReading", getTrace());
-  TRACE(size_t, "cursize", ReadPos->getCurByteAddress());
-  TRACE(size_t, "fillSize", FillPos->getCurByteAddress());
-
+  // TODO(karlschimpf) Why is this lock necessary (stops core dump).
+  UsingReadPos Lock(*Reader, *ReadPos);
   while (hasEnoughHeadroom()) {
+    TRACE(string, "method",
+          std::string(RunMethodName[int(CurMethod)])
+          + "." + RunStateName[int(CurState)]);
     switch (CurMethod) {
+      case RunMethod::Block: {
+        switch (CurState) {
+          case RunState::Enter:
+            TRACE_ENTER(RunMethodName[int(CurMethod)]);
+            BlockStack.back().Size =
+                Reader->Reader->readBlockSize(*ReadPos.get());
+            TRACE(size_t, "Block size", BlockStack.back().Size);
+            Reader->Reader->pushEobAddress(*ReadPos,
+                                           BlockStack.back().Size);
+            pushFrame(BlockStack.back().Method, RunState::Exit);
+            break;
+          case RunState::Exit:
+            popFrame();
+            ReadPos->popEobAddress();
+            TRACE_EXIT_OVERRIDE(RunMethodName[int(RunMethod::Block)]);
+            break;
+          default:
+            fatal("resume reading block not implemented");
+            break;
+        }
+        break;
+      }
       case RunMethod::File:
         switch (CurState) {
           case RunState::Enter: {
-            TRACE_ENTER("readFile");
-            UsingReadPos ReadLoc(*Reader, *ReadPos);
+            TRACE_ENTER(RunMethodName[int(CurMethod)]);
             CurFile = Reader->readHeader();
-            CurState = RunState::FileSectionLoop;
+            pushFrame(RunMethod::Section, RunState::Loop);
             break;
           }
-          case RunState::FileSectionLoop:
-            TRACE_MESSAGE("resuming readFile");
-            if (ReadPos->atByteEob()) {
+          case RunState::Loop: {
+            CurFile->append(CurSection);
+            CurSection = nullptr;
+            if (ReadPos->atEof()) {
               CurState = RunState::Exit;
               break;
             }
             pushFrame(RunMethod::Section);
             break;
+          }
           case RunState::Exit: {
+            Reader->SectionSymtab.install(CurFile);
+            TRACE_EXIT_OVERRIDE(RunMethodName[int(RunMethod::File)]);
+            if (CallStack.empty()) {
+              CurState = RunState::Succeeded;
+              return;
+            }
             popFrame();
-            TRACE_EXIT();
             break;
           }
           default:
-            fatal("resume on file not implemented");
+            fatal("resume reading file not implemented");
             break;
         }
         break;
+      case RunMethod::Name: {
+        switch (CurState) {
+          case RunState::Enter: {
+            TRACE_ENTER(RunMethodName[int(CurMethod)]);
+            CurState = RunState::Loop;
+            Name.clear();
+            uint32_t Size = Reader->Reader->readVaruint32(*ReadPos.get());
+            enterCountedLoop(Size);
+            break;
+          }
+          case RunState::Loop: {
+            if (getThenDecIterCount() == 0) {
+              CurState = RunState::Exit;
+              break;
+            }
+            Name.push_back(char(Reader->Reader->readUint8(*ReadPos.get())));
+            break;
+          }
+          case RunState::Exit:
+            popFrame();
+            TRACE_EXIT_OVERRIDE(RunMethodName[int(RunMethod::Name)]);
+            break;
+          default:
+            fatal("resume reading name not implemented");
+            break;
+        }
+        break;
+      }
       case RunMethod::Section:
         switch (CurState) {
           case RunState::Enter: {
-            TRACE_ENTER("readSection");
-            UsingReadPos ReadLoc(*Reader, *ReadPos);
-            CurState = RunState::SectionNodeLoop;
+            TRACE_ENTER(RunMethodName[int(CurMethod)]);
+            pushFrame(RunMethod::Name, RunState::Setup);
             break;
           }
-          case RunState::SectionNodeLoop:
-            TRACE_MESSAGE("resuming readSection");
-            fatal("resuming readSection not implemented yet");
+          case RunState::Setup: {
+            CurSection = create<SectionNode>();
+            CurSection->append(create<SymbolNode>(Name));
+            // Save StartStackSize for exit.
+            pushLoopCount(Reader->NodeStack.size());
+            CurState = RunState::Exit;
+            pushBlock(RunMethod::SectionBody);
             break;
+          }
           case RunState::Exit: {
+            size_t StartStackSize = popLoopCount();
+            size_t StackSize = Reader->NodeStack.size();
+            if (StackSize < StartStackSize)
+              fatal("Malformed section: " + Name);
+            for (size_t i = StartStackSize; i < StackSize; ++i)
+              CurSection->append(Reader->NodeStack[i]);
+            for (size_t i = StartStackSize; i < StackSize; ++i)
+              Reader->NodeStack.pop_back();
+            TRACE_EXIT_OVERRIDE(RunMethodName[int(RunMethod::Section)]);
+            if (CallStack.empty()) {
+              CurState = RunState::Succeeded;
+              return;
+            }
             popFrame();
-            TRACE_EXIT();
             break;
           }
           default:
-            fatal("resume of section not implemented");
+            fatal("resume reading section not implemented");
+            break;
+        }
+        break;
+      case RunMethod::SectionBody:
+        switch (CurState) {
+          case RunState::Enter: {
+            TRACE_ENTER(RunMethodName[int(CurMethod)]);
+            SymbolNode *Sym = CurSection->getSymbol();
+            assert(Sym);
+            if (Sym->getStringName() != "filter")
+              fatal("Handling non-filter sections not implemented!");
+            pushFrame(RunMethod::SymbolTable, RunState::Loop);
+            break;
+          }
+          case RunState::Loop:
+            if (ReadPos->atByteEob()) {
+              CurState = RunState::Exit;
+              break;
+            }
+            Reader->readNode();
+            break;
+          case RunState::Exit:
+            popFrame();
+            TRACE_EXIT_OVERRIDE(RunMethodName[int(RunMethod::SectionBody)]);
+            break;
+          default:
+            fatal("resume section body not implemented");
+            break;
+        }
+        break;
+      case RunMethod::SymbolTable:
+        switch (CurState) {
+          case RunState::Enter: {
+            TRACE_ENTER(RunMethodName[int(CurMethod)]);
+            Reader->SectionSymtab.clear();
+            enterCountedLoop(Reader->Reader->readVaruint32(*ReadPos.get()));
+            break;
+          }
+          case RunState::Loop: {
+            if (getThenDecIterCount() == 0) {
+              CurState = RunState::Exit;
+              break;
+            }
+            pushFrame(RunMethod::Name, RunState::LoopCont);
+            break;
+          }
+          case RunState::LoopCont:
+            TRACE(size_t, "index", Reader->SectionSymtab.getNumberSymbols());
+            TRACE(string, "Symbol", Name);
+            Reader->SectionSymtab.addSymbol(Name);
+            CurState = RunState::Loop;
+            break;
+          case RunState::Exit:
+            popFrame();
+            TRACE_EXIT_OVERRIDE(RunMethodName[int(RunMethod::SymbolTable)]);
+            break;
+          default:
+            fatal("resume reading symbol table not implemented");
             break;
         }
         break;
@@ -253,7 +397,9 @@ FileNode* BinaryReader::readHeader() {
     fatal("Unable to read, did not find WASM binary magic number");
   Version = Reader->readUint32(*ReadPos);
   TRACE(uint32_t, "Version", Version);
-  return Symtab->create<FileNode>();
+  auto *File = Symtab->create<FileNode>();
+  TRACE(int, "File kids", File->getNumKids());
+  return File;
 }
 
 FileNode* BinaryReader::readFile(StreamType Type) {
@@ -265,8 +411,9 @@ FileNode* BinaryReader::readFile(ReadCursor &NewReadPos) {
   TRACE_METHOD("readFile", Trace);
   UsingReadPos ReadLock(*this, NewReadPos);
   auto *File = readHeader();
-  while (!ReadPos->atByteEob())
+  while (!ReadPos->atByteEob()) {
     File->append(readSection(*ReadPos));
+  }
   TRACE_SEXP(nullptr, File);
   SectionSymtab.install(File);
   return File;
@@ -307,16 +454,6 @@ SectionNode* BinaryReader::readSection(ReadCursor &NewReadPos) {
   TRACE_SEXP(nullptr, Section);
   return Section;
 }
-
-#if 0
-bool BinaryReader::readStartSection(ReadCursor &NewReadPos,
-                                    size_t StopAddress,
-                                    SectionNode*& Section) {
-  TRACE_METHOD("readSection", Trace);
-  Section = nullptr;
-  UsingReadPos ReadLoc(*this, NewReadPos);
-}
-#endif
 
 void BinaryReader::readSymbolTable() {
   TRACE_METHOD("readSymbolTable", Trace);
@@ -554,7 +691,7 @@ std::shared_ptr<BinaryReader::Runner> BinaryReader::startReadingSection(
     std::shared_ptr<SymbolTable> Symtab) {
   auto BinReader = std::make_shared<BinaryReader>(ReadPos->getQueue(), Symtab);
   auto Rnnr = std::make_shared<Runner>(BinReader, ReadPos);
-  Rnnr->CurMethod = RunMethod::File;
+  Rnnr->CurMethod = RunMethod::Section;
   Rnnr->CurState = RunState::Enter;
   return Rnnr;
 }

--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -37,12 +37,14 @@ const char* RunMethodName[] = {
 #define X(tag, name) name,
     BINARY_READER_METHODS_TABLE
 #undef X
+    "RunMethod_NO_SUCH_METHOD"
 };
 
 const char* RunStateName[] = {
 #define X(tag, name) name,
     BINARY_READER_STATES_TABLE
 #undef X
+    "RunState_NO_SUCH_STATE"
 };
 
 } // end of anonymous namespace
@@ -241,7 +243,7 @@ void BinaryReader::Runner::resumeReading() {
             break;
         }
         break;
-      case RunMethod::Unknown:
+      case RunMethod::RunMethod_NO_SUCH_METHOD:
         fatal("resume on unknown method!");
         break;
     }

--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -699,6 +699,10 @@ std::shared_ptr<BinaryReader::Runner> BinaryReader::startReadingSection(
 std::shared_ptr<BinaryReader::Runner> BinaryReader::startReadingFile(
     std::shared_ptr<decode::ReadCursor> ReadPos,
     std::shared_ptr<SymbolTable> Symtab) {
+  // The following two voids are to make sure that the compiler doesn't complain
+  // about unused globals.
+  (void)RunMethodName;
+  (void)RunStateName;
   auto BinReader = std::make_shared<BinaryReader>(ReadPos->getQueue(), Symtab);
   auto Rnnr = std::make_shared<Runner>(BinReader, ReadPos);
   Rnnr->CurMethod = RunMethod::File;

--- a/src/binary/BinaryReader.def
+++ b/src/binary/BinaryReader.def
@@ -27,7 +27,6 @@
   X(Section,     "readSection")                                                \
   X(SectionBody, "readSectionBody")                                            \
   X(SymbolTable, "readSymbolTable")                                            \
-  X(Unknown,     "readUnknown")                                                \
 
 //#define(tag, name)
 #define BINARY_READER_STATES_TABLE                                             \

--- a/src/binary/BinaryReader.def
+++ b/src/binary/BinaryReader.def
@@ -1,0 +1,44 @@
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines methods and state for binary reader.
+
+#ifndef DECOMPRESSOR_SRC_BINARY_BINARYREADER_DEF
+#define DECOMPRESSOR_SRC_BINARY_BINARYREADER_DEF
+
+//#define(tag, name)
+#define BINARY_READER_METHODS_TABLE                                            \
+  /* enum name, text name */                                                   \
+  X(Block,       "readBlock")                                                  \
+  X(File,        "readFile")                                                   \
+  X(Name,        "readName")                                                   \
+  X(Section,     "readSection")                                                \
+  X(SectionBody, "readSectionBody")                                            \
+  X(SymbolTable, "readSymbolTable")                                            \
+  X(Unknown,     "readUnknown")                                                \
+
+//#define(tag, name)
+#define BINARY_READER_STATES_TABLE                                             \
+  /* enum name, text name */                                                   \
+  X(Enter,     "enter")                                                        \
+  X(Exit,      "exit")                                                         \
+  X(Loop,      "loop")                                                         \
+  X(LoopCont,   "loop-cont")                                                   \
+  X(Setup,     "setup")                                                        \
+  X(Failed,    "failed")                                                       \
+  X(Succeeded, "Succeeded")                                                    \
+
+#endif // DECOMPRESSOR_SRC_BINARY_BINARYREADER_DEF
+

--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -73,10 +73,16 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
 #define X(tag, name) tag,
     BINARY_READER_METHODS_TABLE
 #undef X
+    // The following is necessary for some compilers, because otherwise a comma
+    // warning may occur.
+    RunMethod_NO_SUCH_METHOD
   };
   enum class RunState {
 #define X(tag, name) tag,
     BINARY_READER_STATES_TABLE
+    // The following is necessary for some compilers, because otherwise a comma
+    // warning may occur.
+    RunState_NO_SUCH_STATE
 #undef X
   };
   class Runner {
@@ -85,7 +91,7 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
     Runner(std::shared_ptr<BinaryReader> Reader,
            std::shared_ptr<decode::ReadCursor> ReadPos)
         : Reader(Reader), ReadPos(ReadPos),
-          CurMethod(RunMethod::Unknown),
+          CurMethod(RunMethod::RunMethod_NO_SUCH_METHOD),
           CurState(RunState::Failed),
           CurFile(nullptr),
           CurSection(nullptr) {

--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -27,6 +27,7 @@
 #include "sexp/TextWriter.h"
 #include "stream/Queue.h"
 #include "stream/ReadCursor.h"
+#include "stream/WriteCursor.h"
 #include "utils/Defs.h"
 
 #include <functional>
@@ -38,14 +39,102 @@ namespace wasm {
 
 namespace filt {
 
-class BinaryReader {
+class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
   BinaryReader() = delete;
   BinaryReader(const BinaryReader&) = delete;
   BinaryReader& operator=(const BinaryReader&) = delete;
 
  public:
+  // Internal state for resuming.
+  enum class RunMethod { File,  Section, Unknown };
+  enum class RunState { Enter, Exit, SectionNodeLoop, FileSectionLoop, Fail, Success };
+  class Runner {
+    friend class BinaryReader;
+   public:
+    Runner(std::shared_ptr<BinaryReader> Reader,
+           std::shared_ptr<decode::ReadCursor> ReadPos)
+        : Reader(Reader), ReadPos(ReadPos),
+          CurMethod(RunMethod::Unknown),
+          CurState(RunState::Fail),
+          CurFile(nullptr),
+          CurSection(nullptr) {
+      FillPos = std::make_shared<decode::WriteCursor>(
+          *ReadPos.get(), ReadPos->getCurByteAddress());
+    }
+    std::shared_ptr<decode::ReadCursor> getReadPos() const {
+      return ReadPos;
+    }
+    std::shared_ptr<decode::WriteCursor> getFillPos() const {
+      return FillPos;
+    }
+    bool needsMoreInput() const {
+      return !isSuccessful() && !errorsFound();
+    }
+    bool isSuccessful() const {
+      return CurState == RunState::Success;
+    }
+    bool errorsFound() const {
+      return CurState == RunState::Fail;
+    }
+    bool isReadingSection() const {
+      return CurMethod == RunMethod::Section;
+    }
+    SectionNode* getSection() {
+      return (isSuccessful() && isReadingSection())  ? CurSection : nullptr;
+    }
+    bool isReadingFile() const {
+      return CurMethod == RunMethod::File;
+    }
+    FileNode* getFile() {
+      return (isSuccessful() && isReadingFile()) ? CurFile : nullptr;
+    }
+    bool isEofFrozen() const { return ReadPos->isEofFrozen(); }
+    size_t filledSize() const { return FillPos->getCurByteAddress(); }
+    void resumeReading();
+
+    void setTraceProgress(bool NewValue) {
+      Reader->setTraceProgress(NewValue);
+    }
+    TraceClassSexpReader& getTrace() { return Reader->getTrace(); }
+   private:
+    struct CallFrame {
+      CallFrame(RunMethod Method, RunState State)
+          : Method(Method), State(State) {}
+      RunMethod Method;
+      RunState State;
+    };
+    std::shared_ptr<BinaryReader> Reader;
+    std::shared_ptr<decode::ReadCursor> ReadPos;
+    std::shared_ptr<decode::WriteCursor> FillPos;
+    std::vector<CallFrame> CallStack;
+    RunMethod CurMethod;
+    RunState CurState;
+    FileNode *CurFile;
+    SectionNode *CurSection;
+    bool hasEnoughHeadroom() const;
+    void pushFrame(RunMethod NewMethod) {
+      CallStack.push_back(CallFrame(CurMethod, CurState));
+      CurMethod = NewMethod;
+      CurState = RunState::Enter;
+    }
+    void popFrame() {
+      CallFrame &Frame = CallStack.back();
+      CurMethod = Frame.Method;
+      CurState = Frame.State;
+      CallStack.pop_back();
+    }
+  };
+
   // Returns true if it begins with a WASM file magic number.
   static bool isBinary(const char* Filename);
+
+  static std::shared_ptr<Runner>
+  startReadingSection(std::shared_ptr<decode::ReadCursor> ReadPos,
+                      std::shared_ptr<SymbolTable> Symtab);
+
+  static std::shared_ptr<Runner>
+  startReadingFile(std::shared_ptr<decode::ReadCursor> ReadPos,
+                   std::shared_ptr<SymbolTable> Symtab);
 
   BinaryReader(std::shared_ptr<decode::Queue> Input,
                std::shared_ptr<SymbolTable> Symtab);
@@ -56,11 +145,11 @@ class BinaryReader {
   // access it.
   const std::shared_ptr<decode::Queue> &getInput() const { return Input; }
 
-  FileNode* readFile();
+  FileNode* readFile(decode::StreamType = decode::StreamType::Byte);
 
   FileNode* readFile(decode::ReadCursor &ReadPos);
 
-  SectionNode* readSection();
+  SectionNode* readSection(decode::StreamType = decode::StreamType::Byte);
 
   SectionNode* readSection(decode::ReadCursor &ReadPos);
 
@@ -81,11 +170,30 @@ class BinaryReader {
   std::vector<Node*> NodeStack;
   TraceClassSexpReader Trace;
 
+  class UsingReadPos {
+   public:
+    UsingReadPos(BinaryReader &Reader, decode::ReadCursor &ReadPos)
+        : Reader(Reader), OldReadPos(&ReadPos) {
+      Reader.ReadPos = &ReadPos;
+      if (isDebug())
+        Reader.Trace.setReadPos(&ReadPos);
+    }
+    ~UsingReadPos() {
+      Reader.ReadPos = OldReadPos;
+      if (isDebug())
+        Reader.Trace.setReadPos(OldReadPos);
+    }
+   private:
+    BinaryReader& Reader;
+    decode::ReadCursor *OldReadPos;
+  };
+
   // Reads in a name and returns the read name. Reference is only good till
   // next call to readInternalName() or ReadExternalName().
   InternalName& readInternalName();
   ExternalName& readExternalName();
 
+  FileNode* readHeader();
   void readBlock(std::function<void()> ApplyFn);
   void readSymbolTable();
   void readNode();

--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -1,30 +1,29 @@
-/* -*- C++ -*- */
-/*
- * Copyright 2016 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Defines how to read filter sections in a WASM file.
 
 #ifndef DECOMPRESSOR_SRC_BINARY_BINARYREADER_H
 #define DECOMPRESSOR_SRC_BINARY_BINARYREADER_H
 
+#include "binary/BinaryReader.def"
 #include "binary/SectionSymbolTable.h"
 #include "interp/ReadStream.h"
 #include "interp/TraceSexpReader.h"
 #include "sexp/Ast.h"
-#include "sexp/TextWriter.h"
 #include "stream/Queue.h"
 #include "stream/ReadCursor.h"
 #include "stream/WriteCursor.h"
@@ -45,9 +44,41 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
   BinaryReader& operator=(const BinaryReader&) = delete;
 
  public:
+
+  // Locks ReadPos to reader, for scope of this.
+  class UsingReadPos {
+   public:
+    UsingReadPos(BinaryReader &Reader, decode::ReadCursor &ReadPos)
+        : Reader(Reader), OldReadPos(&ReadPos) {
+      Reader.ReadPos = &ReadPos;
+      if (isDebug())
+        Reader.Trace.setReadPos(&ReadPos);
+    }
+    UsingReadPos(std::shared_ptr<BinaryReader> Reader,
+                 std::shared_ptr<decode::ReadCursor> ReadPos)
+        : Reader(*Reader.get()), OldReadPos(ReadPos.get()) {}
+    ~UsingReadPos() {
+      Reader.ReadPos = OldReadPos;
+      if (isDebug())
+        Reader.Trace.setReadPos(OldReadPos);
+    }
+   private:
+    BinaryReader& Reader;
+    decode::ReadCursor *OldReadPos;
+  };
+
   // Internal state for resuming.
-  enum class RunMethod { File,  Section, Unknown };
-  enum class RunState { Enter, Exit, SectionNodeLoop, FileSectionLoop, Fail, Success };
+  // TODO(karlschimpf) Create ".def" file to define names for these.
+  enum class RunMethod {
+#define X(tag, name) tag,
+    BINARY_READER_METHODS_TABLE
+#undef X
+  };
+  enum class RunState {
+#define X(tag, name) tag,
+    BINARY_READER_STATES_TABLE
+#undef X
+  };
   class Runner {
     friend class BinaryReader;
    public:
@@ -55,7 +86,7 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
            std::shared_ptr<decode::ReadCursor> ReadPos)
         : Reader(Reader), ReadPos(ReadPos),
           CurMethod(RunMethod::Unknown),
-          CurState(RunState::Fail),
+          CurState(RunState::Failed),
           CurFile(nullptr),
           CurSection(nullptr) {
       FillPos = std::make_shared<decode::WriteCursor>(
@@ -71,10 +102,10 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
       return !isSuccessful() && !errorsFound();
     }
     bool isSuccessful() const {
-      return CurState == RunState::Success;
+      return CurState == RunState::Succeeded;
     }
     bool errorsFound() const {
-      return CurState == RunState::Fail;
+      return CurState == RunState::Failed;
     }
     bool isReadingSection() const {
       return CurMethod == RunMethod::Section;
@@ -88,10 +119,13 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
     FileNode* getFile() {
       return (isSuccessful() && isReadingFile()) ? CurFile : nullptr;
     }
-    bool isEofFrozen() const { return ReadPos->isEofFrozen(); }
+    bool isEofFrozen() const { return FillPos->isEofFrozen(); }
     size_t filledSize() const { return FillPos->getCurByteAddress(); }
     void resumeReading();
-
+    template <typename T, typename... Args>
+    T* create(Args&&... args) {
+      return Reader->Symtab->create<T>(std::forward<Args>(args)...);
+    }
     void setTraceProgress(bool NewValue) {
       Reader->setTraceProgress(NewValue);
     }
@@ -107,21 +141,60 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
     std::shared_ptr<decode::ReadCursor> ReadPos;
     std::shared_ptr<decode::WriteCursor> FillPos;
     std::vector<CallFrame> CallStack;
-    RunMethod CurMethod;
-    RunState CurState;
-    FileNode *CurFile;
-    SectionNode *CurSection;
-    bool hasEnoughHeadroom() const;
-    void pushFrame(RunMethod NewMethod) {
-      CallStack.push_back(CallFrame(CurMethod, CurState));
+    void pushFrame(RunMethod NewMethod, RunState ResumeState) {
+      CallStack.push_back(CallFrame(CurMethod, ResumeState));
       CurMethod = NewMethod;
       CurState = RunState::Enter;
+    }
+    void pushFrame(RunMethod NewMethod) {
+      pushFrame(NewMethod, CurState);
     }
     void popFrame() {
       CallFrame &Frame = CallStack.back();
       CurMethod = Frame.Method;
       CurState = Frame.State;
       CallStack.pop_back();
+    }
+    std::vector<size_t> LoopCounter;
+    ExternalName Name;
+    RunMethod CurMethod;
+    RunState CurState;
+    FileNode *CurFile;
+    SectionNode *CurSection;
+    struct BlockFrame {
+      BlockFrame(RunMethod Method, size_t Size)
+          : Method(Method), Size(Size) {}
+      RunMethod Method;
+      size_t Size;
+    };
+    std::vector<BlockFrame> BlockStack;
+    void pushBlock(RunMethod Method) {
+      BlockStack.push_back(BlockFrame(Method, 0));
+      pushFrame(RunMethod::Block);
+    }
+    size_t popBlock() {
+      size_t Size = BlockStack.back().Size;
+      BlockStack.pop_back();
+      return Size;
+    }
+    bool hasEnoughHeadroom() const;
+    void pushLoopCount(size_t Count) {
+      LoopCounter.push_back(Count);
+    }
+    size_t popLoopCount() {
+      size_t Count = LoopCounter.back();
+      LoopCounter.pop_back();
+      return Count;
+    }
+    void enterCountedLoop(size_t Count) {
+      pushLoopCount(Count);
+      CurState = RunState::Loop;
+    }
+    size_t getThenDecIterCount() {
+      size_t Count = LoopCounter.back()--;
+      if (Count == 0)
+        LoopCounter.pop_back();
+      return Count;
     }
   };
 
@@ -169,24 +242,6 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
   uint32_t Version;
   std::vector<Node*> NodeStack;
   TraceClassSexpReader Trace;
-
-  class UsingReadPos {
-   public:
-    UsingReadPos(BinaryReader &Reader, decode::ReadCursor &ReadPos)
-        : Reader(Reader), OldReadPos(&ReadPos) {
-      Reader.ReadPos = &ReadPos;
-      if (isDebug())
-        Reader.Trace.setReadPos(&ReadPos);
-    }
-    ~UsingReadPos() {
-      Reader.ReadPos = OldReadPos;
-      if (isDebug())
-        Reader.Trace.setReadPos(OldReadPos);
-    }
-   private:
-    BinaryReader& Reader;
-    decode::ReadCursor *OldReadPos;
-  };
 
   // Reads in a name and returns the read name. Reference is only good till
   // next call to readInternalName() or ReadExternalName().

--- a/src/binary/SectionSymbolTable.h
+++ b/src/binary/SectionSymbolTable.h
@@ -45,6 +45,9 @@ class SectionSymbolTable {
   const IndexLookupType& getVector() { return IndexLookup; }
   void addSymbol(std::string& Name);
   uint32_t getSymbolIndex(SymbolNode* Symbol);
+  IndexType getNumberSymbols() const {
+    return IndexLookup.size();
+  }
   void clear() {
     Symtab->clear();
     SymbolLookup.clear();

--- a/src/exec/decompwasm-sexp.cpp
+++ b/src/exec/decompwasm-sexp.cpp
@@ -20,8 +20,10 @@
 #include "stream/FileReader.h"
 #include "stream/FileWriter.h"
 #include "stream/ReadBackedQueue.h"
+#include "stream/ReadCursor.h"
 #include "stream/StreamReader.h"
 #include "stream/StreamWriter.h"
+#include "stream/WriteCursor.h"
 #include "utils/Defs.h"
 
 #include <cstring>
@@ -57,6 +59,8 @@ void usage(const char* AppName) {
   fprintf(stderr, "  -h\t\t\tPrint this usage message.\n");
   fprintf(stderr, "  -i File\t\tWasm file to read ('-' implies stdin).\n");
   fprintf(stderr,
+          "  -r N\t\t\tUse a stream runner to read input N chars at a time.\n");
+  fprintf(stderr,
           "  -o File\t\tFile with found s-expressions ('-' implies stdout).\n");
   fprintf(stderr, "  -s\t\t\tUse C++ streams instead of C file descriptors.\n");
   if (isDebug()) {
@@ -66,6 +70,7 @@ void usage(const char* AppName) {
 
 int main(int Argc, char* Argv[]) {
   int Verbose = 0;
+  int RunnerCount = 0;
   for (int i = 1; i < Argc; ++i) {
     if (Argv[i] == std::string("--expect-fail")) {
       ExpectExitFail = true;
@@ -87,6 +92,18 @@ int main(int Argc, char* Argv[]) {
         return exit_status(EXIT_FAILURE);
       }
       OutputFilename = Argv[i];
+    } else if (Argv[i] == std::string("-r")) {
+      if (++i >= Argc) {
+        fprintf(stderr, "No N specified after -r option\n");
+        usage(Argv[0]);
+        return exit_status(EXIT_FAILURE);
+      }
+      RunnerCount = atoi(Argv[i]);
+      if (RunnerCount == 0) {
+        fprintf(stderr, "-r N must be greater than zero\n");
+        usage(Argv[0]);
+        return exit_status(EXIT_FAILURE);
+      }
     } else if (Argv[i] == std::string("-s")) {
       UseFileStreams = true;
     } else if (isDebug() && (Argv[i] == std::string("-v") ||
@@ -98,15 +115,45 @@ int main(int Argc, char* Argv[]) {
       return exit_status(EXIT_FAILURE);
     }
   }
-  BinaryReader Reader(std::make_shared<ReadBackedQueue>(getInput()),
-                      std::make_shared<SymbolTable>());
-  Reader.setTraceProgress(Verbose >= 1);
-  FileNode* File = Reader.readFile();
+  FileNode* File = nullptr;
+  auto Input = std::make_shared<ReadBackedQueue>(getInput());
+  auto Symtab = std::make_shared<SymbolTable>();
+  if (RunnerCount) {
+    ReadCursor RawReadPos(StreamType::Byte, Input);
+    auto FillQueue = std::make_shared<Queue>();
+    auto FillReadPos = std::make_shared<ReadCursor>(StreamType::Byte,
+                                                    FillQueue);
+    WriteCursor FillWritePos(StreamType::Byte, FillQueue);
+    std::shared_ptr<BinaryReader::Runner> Runner
+        = BinaryReader::startReadingFile(FillReadPos, Symtab);
+    Runner->setTraceProgress(Verbose >= 1);
+    WriteCursor *FillPos = Runner->getFillPos().get();
+    while (Runner->needsMoreInput()) {
+      // Fill queue with more input and resume.
+      size_t BytesRemaining = RunnerCount;
+      while (BytesRemaining) {
+        if (RawReadPos.atEof()) {
+          FillWritePos.freezeEof();
+          break;
+        }
+        FillPos->writeByte(RawReadPos.readByte());
+        --BytesRemaining;
+      }
+      Runner->resumeReading();
+    }
+    if (Runner->errorsFound())
+      fatal("Errors found while reading filter section!");
+    File = Runner->getFile();
+  } else {
+    BinaryReader Reader(Input, Symtab);
+    Reader.setTraceProgress(Verbose >= 1);
+    File = Reader.readFile();
+  }
   if (File == nullptr) {
     fprintf(stderr, "Unable to parse WASM module!\n");
     return exit_status(EXIT_FAILURE);
   }
   TextWriter Writer;
   Writer.write(stdout, File);
-  return exit_status(EXIT_FAILURE);
+  return exit_status(EXIT_SUCCESS);
 }

--- a/src/exec/decompwasm-sexp.cpp
+++ b/src/exec/decompwasm-sexp.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "binary/BinaryReader.h"
+#include "sexp/TextWriter.h"
 #include "sexp-parser/Driver.h"
 #include "stream/FileReader.h"
 #include "stream/FileWriter.h"
@@ -123,17 +124,17 @@ int main(int Argc, char* Argv[]) {
     auto FillQueue = std::make_shared<Queue>();
     auto FillReadPos = std::make_shared<ReadCursor>(StreamType::Byte,
                                                     FillQueue);
-    WriteCursor FillWritePos(StreamType::Byte, FillQueue);
     std::shared_ptr<BinaryReader::Runner> Runner
         = BinaryReader::startReadingFile(FillReadPos, Symtab);
     Runner->setTraceProgress(Verbose >= 1);
     WriteCursor *FillPos = Runner->getFillPos().get();
     while (Runner->needsMoreInput()) {
+      // TODO(karlschimpf) Get a cleaner API for this!
       // Fill queue with more input and resume.
       size_t BytesRemaining = RunnerCount;
       while (BytesRemaining) {
         if (RawReadPos.atEof()) {
-          FillWritePos.freezeEof();
+          FillPos->freezeEof();
           break;
         }
         FillPos->writeByte(RawReadPos.readByte());

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -1,18 +1,17 @@
-/*
- * Copyright 2016 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Defines Opcodes for Ast nodes.
 
@@ -170,13 +169,19 @@
 #define AST_NARYNODE_TABLE                                                     \
   X(File,)                                                                     \
   X(Filter,)                                                                   \
-  X(Eval,EVAL_DECLS)                                                           \
-  X(Section,)                                                                  \
+  X(Eval, EVAL_DECLS)                                                          \
+  X(Section, SECTION_DECLS)                                                    \
   X(Sequence,)                                                                 \
 
 #define EVAL_DECLS                                                             \
  public:                                                                       \
-  SymbolNode *getCallName() const {                                            \
+  SymbolNode* getCallName() const {                                            \
+    return dyn_cast<SymbolNode>(getKid(0));                                    \
+  }                                                                            \
+
+#define SECTION_DECLS                                                          \
+ public:                                                                       \
+  SymbolNode* getSymbol() const {                                              \
     return dyn_cast<SymbolNode>(getKid(0));                                    \
   }                                                                            \
 

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -26,6 +26,8 @@
 
 namespace wasm {
 
+using namespace utils;
+
 namespace filt {
 
 namespace {

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -30,11 +30,7 @@ bool Cursor::readFillBuffer() {
   if (CurAddress >= Que->getEofAddress())
     return false;
   size_t BufferSize = Que->readFromPage(CurAddress, Page::Size, *this);
-  if (BufferSize == 0) {
-    Que->freezeEof(CurAddress);
-    return false;
-  }
-  return true;
+  return BufferSize > 0;
 }
 
 void Cursor::writeFillBuffer() {

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -104,11 +104,20 @@ class Cursor : public PageCursor {
 
   bool isEofFrozen() const { return Que->isEofFrozen(); }
 
-  bool atEof() const {
-    return CurAddress >= Que->getEofAddress();
+  bool atEof() const{
+    return isIndexAtEndOfPage() &&
+        !const_cast<Cursor*>(this)->readFillBuffer();
+  }
+
+  size_t getEofAddress() const {
+    return Que->getEofAddress();
   }
 
   BitAddress& getEobAddress() const { return EobPtr->getEobAddress(); }
+
+  size_t getByteEobAddress() const {
+    return EobPtr->getEobAddress().getByteAddress();
+  }
 
   void freezeEof() { Que->freezeEof(getCurAddress()); }
 

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -102,6 +102,8 @@ class Cursor : public PageCursor {
 
   std::shared_ptr<Queue> getQueue() { return Que; }
 
+  bool isEofFrozen() const { return Que->isEofFrozen(); }
+
   bool atEof() const {
     return CurAddress >= Que->getEofAddress();
   }

--- a/src/stream/Queue.cpp
+++ b/src/stream/Queue.cpp
@@ -112,6 +112,7 @@ void Queue::freezeEof(size_t Address) {
   LastPage = Cursor.CurPage;
   if (Cursor.CurPage->Next)
     Cursor.CurPage->Next.reset();
+  EofFrozen = true;
 }
 
 void Queue::writePageAt(FILE* File, size_t Address) {

--- a/src/stream/RawStream.h
+++ b/src/stream/RawStream.h
@@ -55,6 +55,7 @@ class RawStream : public std::enable_shared_from_this<RawStream> {
   virtual bool freeze() = 0;
 
   // Returns true if at the end of stream.
+  // WARNING: This is not set until after a read occurs.
   virtual bool atEof() = 0;
 };
 

--- a/src/utils/Trace.cpp
+++ b/src/utils/Trace.cpp
@@ -63,9 +63,10 @@ void TraceClass::enter(const char* Name) {
   fprintf(File, "enter %s\n", Name);
 }
 
-void TraceClass::exit() {
+void TraceClass::exit(const char *Name) {
   assert(~CallStack.empty());
-  const char* Name = CallStack.back();
+  if (Name == nullptr)
+    Name = CallStack.back();
   CallStack.pop_back();
   --IndentLevel;
   indent();
@@ -106,9 +107,9 @@ void TraceClass::traceCharInternal(const char* Name, char Ch) {
   fprintf(File, "%s = '%c'\n", Name, Ch);
 }
 
-void TraceClass::traceStringInternal(const char* Name, std::string& Value) {
+void TraceClass::traceStringInternal(const char* Name, const char* Value) {
   indent();
-  fprintf(File, "%s = '%s'\n", Name, Value.c_str());
+  fprintf(File, "%s = '%s'\n", Name, Value);
 }
 
 void TraceClass::traceIntInternal(const char* Name, intmax_t Value) {

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -26,6 +26,10 @@
 #define TRACE(type, name, value)
 #define TRACE_MESSAGE_USING(trace, Message)
 #define TRACE_MESSAGE(Message)
+#define TRACE_ENTER_USING(name, trace)
+#define TRACE_ENTER(name)
+#define TRACE_EXIT_USING(trace)
+#define TRACE_EXIT()
 #else
 #define TRACE_METHOD(Name, Trace) \
   TraceClass::Method tracEmethoD((Name), (Trace))
@@ -42,8 +46,21 @@
     if (tracE.getTraceProgress())                                              \
       tracE.trace_message(Message);                                            \
   } while (false)
-
 #define TRACE_MESSAGE(Message) TRACE_MESSAGE_USING(getTrace(), Message)
+#define TRACE_ENTER_USING(name, trace)                                         \
+  do {                                                                         \
+    auto &tracE = (trace);                                                     \
+    if (tracE.getTraceProgress())                                              \
+      (trace).enter((name));                                                   \
+  } while(false)
+#define TRACE_ENTER(name) TRACE_ENTER_USING((name), getTrace())
+#define TRACE_EXIT_USING(trace)                                                \
+  do {                                                                         \
+    auto &tracE = (trace);                                                     \
+    if (tracE.getTraceProgress())                                              \
+      (trace).exit();                                                          \
+  } while (false)
+#define TRACE_EXIT() TRACE_EXIT_USING(getTrace())
 #endif
 
 #include "utils/Defs.h"
@@ -86,6 +103,8 @@ class TraceClass : std::enable_shared_from_this<TraceClass> {
   explicit TraceClass(FILE* File);
   TraceClass(const char* Label, FILE* File);
   virtual ~TraceClass();
+  void enter(const char* Name);
+  void exit();
   virtual void traceContext() const;
   // Prints trace prefix only.
   FILE* indent();
@@ -303,9 +322,6 @@ class TraceClass : std::enable_shared_from_this<TraceClass> {
   int IndentLevel;
   bool TraceProgress;
   std::vector<const char*> CallStack;
-
-  void enter(const char* Name);
-  void exit();
   void traceMessageInternal(const std::string& Message);
   void traceBoolInternal(const char* Name, bool Value);
   void traceCharInternal(const char* Name, char Ch);


### PR DESCRIPTION
Restructures the binary reader of filter s-expressions to work in either a push, or a pull model.

Also fixes several (minor) bugs with the page queue and cursors.
