### PR TITLE
Clean up tracing of interpreter to match logical model.

### DIFF
--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -168,6 +168,8 @@ class Interpreter {
     LastReadValue = Value;
     ReturnStack.push_back(Value);
     FrameStack.pop();
+    TRACE(IntType, "returns", LastReadValue);
+    Frame.State = InterpState::Exit;
   }
 
   bool hasEnoughHeadroom() const;


### PR DESCRIPTION
Adds tracing to method Interpreter::runMethods() so that it matches logical call sequence, rather than implemented loop (push) model.
