### PR TITLE
Clean up stack handling in decompressor interpreter.

### DIFF
--- a/src/interp/Interpreter.def
+++ b/src/interp/Interpreter.def
@@ -34,6 +34,7 @@
   X(Exit,      "exit")                                                         \
   X(Loop,      "loop")                                                         \
   X(Failed,    "failed")                                                       \
+  X(Step2,     "Step2")                                                        \
   X(Succeeded, "Succeeded")                                                    \
 
 #endif // DECOMPRESSOR_SRC_INTERP_INTERPRETER_DEF


### PR DESCRIPTION
Applies some clean ups to stacks in the state-based model. These changes should make it much easier to complete the change from a (read) pull model to a (read) push model.
