### PR TITLE
Change streams to handle errors.

### DIFF
--- a/src/stream/Page.cpp
+++ b/src/stream/Page.cpp
@@ -21,15 +21,15 @@ namespace wasm {
 
 namespace decode {
 
-Page::Page(size_t MinAddress)
-    : Index(Page::index(MinAddress)),
-      MinAddress(MinAddress),
-      MaxAddress(MinAddress) {
+Page::Page(size_t PageIndex)
+    : Index(PageIndex),
+      MinAddress(minAddressForPage(PageIndex)),
+      MaxAddress(minAddressForPage(PageIndex)) {
   std::memset(&Buffer, 0, Page::Size);
 }
 
 FILE* Page::describe(FILE* File) {
-  fprintf(File, "Page[%" PRIuMAX "] [%" PRIxMAX ":%" PRIxMAX ") = %p",
+  fprintf(File, "Page[%" PRIuMAX "] [%" PRIxMAX "..%" PRIxMAX ") = %p",
           uintmax_t(Index), uintmax_t(MinAddress), uintmax_t(MaxAddress),
           (void*)this);
   return File;

--- a/src/stream/Page.h
+++ b/src/stream/Page.h
@@ -83,7 +83,12 @@ class Page : public std::enable_shared_from_this<Page> {
     return Address & Page::Mask;
   }
 
-  Page(size_t MinAddress);
+  // Returns the minimum address for a page index.
+  static constexpr size_t minAddressForPage(size_t PageIndex) {
+    return PageIndex << SizeLog2;
+  }
+
+  Page(size_t PageIndex);
 
   size_t spaceRemaining() const {
     return MinAddress == MaxAddress
@@ -115,10 +120,9 @@ class Page : public std::enable_shared_from_this<Page> {
 };
 
 class PageCursor {
-  PageCursor() = delete;
   friend class Queue;
-
  public:
+  PageCursor() : CurAddress(0) {}
   PageCursor(Queue* Que);
   PageCursor(std::shared_ptr<Page> CurPage, size_t CurAddress)
       : CurPage(CurPage), CurAddress(CurAddress) {
@@ -128,13 +132,13 @@ class PageCursor {
       : CurPage(PC.CurPage), CurAddress(PC.CurAddress) {
     assert(CurPage);
   }
-  size_t getMinAddress() const {
-    return CurPage ? CurPage->getMinAddress() : 0;
-  }
   PageCursor& operator=(const PageCursor& C) {
     CurPage = C.CurPage;
     CurAddress = C.CurAddress;
     return *this;
+  }
+  size_t getMinAddress() const {
+    return CurPage ? CurPage->getMinAddress() : 0;
   }
   size_t getMaxAddress() const {
     return CurPage ? CurPage->getMaxAddress() : 0;
@@ -153,10 +157,8 @@ class PageCursor {
     assert(CurPage);
     return CurPage->Buffer + getRelativeAddress();
   }
-
   // For debugging only.
   FILE* describe(FILE* File, bool IncludePage = false);
-
  protected:
   std::shared_ptr<Page> CurPage;
   // Absolute address.

--- a/src/stream/ReadBackedQueue.cpp
+++ b/src/stream/ReadBackedQueue.cpp
@@ -31,7 +31,8 @@ bool ReadBackedQueue::readFill(size_t Address) {
     size_t SpaceAvailable = LastPage->spaceRemaining();
     // Create new page if current page full.
     if (SpaceAvailable == 0) {
-      appendPage();
+      if (!appendPage())
+        return false;
       SpaceAvailable = Page::Size;
     }
     size_t NumBytes = Reader->read(&(LastPage->Buffer[Page::address(Address)]),

--- a/src/stream/ReadCursor.cpp
+++ b/src/stream/ReadCursor.cpp
@@ -22,7 +22,7 @@ namespace decode {
 
 uint8_t ReadCursor::readByte() {
   assert(isByteAligned());
-  if (getCurAddress() < GuaranteedBeforeEob)
+  if (CurAddress < GuaranteedBeforeEob)
     return readOneByte();
   bool atEof = isIndexAtEndOfPage() && !readFillBuffer();
   updateGuaranteedBeforeEob();

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -42,9 +42,9 @@ class ReadCursor FINAL : public Cursor {
   ~ReadCursor() {}
 
   bool atByteEob() {
-    if (getCurAddress() < GuaranteedBeforeEob)
+    if (CurAddress < GuaranteedBeforeEob)
       return false;
-    bool Result = getCurAddress() >= getEobAddress().getByteAddress() ||
+    bool Result = CurAddress >= getEobAddress().getByteAddress() ||
                   !readFillBuffer();
     updateGuaranteedBeforeEob();
     return Result;
@@ -58,7 +58,7 @@ class ReadCursor FINAL : public Cursor {
   BitsInByteType getBitsRead() const { return CurByte.getBitsRead(); }
 
   BitAddress getCurReadBitAddress() const {
-    BitAddress Address(getCurAddress(), getBitsRead());
+    BitAddress Address(CurAddress, getBitsRead());
     return Address;
   }
 
@@ -91,7 +91,6 @@ class ReadCursor FINAL : public Cursor {
     ++CurAddress;
     CurPage = Que->getReadPage(CurAddress);
     assert(CurPage);
-    assert(CurPage == Que->getCachedPage(CurAddress));
     return Byte;
   }
 };

--- a/src/stream/WriteBackedQueue.cpp
+++ b/src/stream/WriteBackedQueue.cpp
@@ -32,7 +32,7 @@ void WriteBackedQueue::dumpFirstPage() {
   size_t Address = 0;
   size_t Size = FirstPage->getMaxAddress() - FirstPage->getMinAddress();
   if (!Writer->write(&FirstPage->Buffer[Address], Size))
-    fatal("Write to raw stream failed in Queue::dumpFirstPage");
+    fail();
   Queue::dumpFirstPage();
 }
 

--- a/src/stream/WriteCursor.cpp
+++ b/src/stream/WriteCursor.cpp
@@ -22,7 +22,7 @@ namespace decode {
 
 void WriteCursor::writeByte(uint8_t Byte) {
   assert(isByteAligned());
-  if (getCurAddress() < GuaranteedBeforeEob)
+  if (CurAddress < GuaranteedBeforeEob)
     return writeOneByte(Byte);
   if (isIndexAtEndOfPage())
     writeFillBuffer();

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -40,7 +40,7 @@ class WriteCursor FINAL : public Cursor {
 
   BitsInByteType getBitsWritten() const { return CurByte.getBitsWritten(); }
   BitAddress getCurWriteBitAddress() const {
-    BitAddress Address(getCurAddress(), getBitsWritten());
+    BitAddress Address(CurAddress, getBitsWritten());
     return Address;
   }
 
@@ -56,7 +56,6 @@ class WriteCursor FINAL : public Cursor {
     ++CurAddress;
     CurPage = Que->getWritePage(CurAddress);
     assert(CurPage);
-    assert(CurPage == Que->getCachedPage(CurAddress));
   }
 };
 


### PR DESCRIPTION
Changing streams (i.e. queues and the corresponding cursors) to have state, and error recover when something goes wrong. One can check if something went wrong with Queue::isGood().

The error recovery is handled using an "error" page. The code reserves the largest page index allowed by size_t for this. Whenever the stream goes bad, cursors are moved to this error page (allowing other routines to continue). Internally, the state is set to "bad", and the eof is truncated to address zero.
