### PR TITLE
Fix parameter lookup (for evals) to use lexical scope

### DIFF
--- a/src/interp/Interpreter.def
+++ b/src/interp/Interpreter.def
@@ -25,6 +25,7 @@
   X(EvalBlock,   "evalBlock")                                                  \
   X(Eval,        "eval")                                                       \
   X(Finished,    "finished")                                                   \
+  X(GetParam,    "getParam")                                                   \
   X(Read,        "read")                                                       \
   X(Write,       "write")                                                      \
 

--- a/src/interp/Interpreter.def
+++ b/src/interp/Interpreter.def
@@ -24,8 +24,8 @@
   /* enum name , text name */                                                  \
   X(EvalBlock,   "evalBlock")                                                  \
   X(Eval,        "eval")                                                       \
+  X(EvalParam,   "evalParam")                                                   \
   X(Finished,    "finished")                                                   \
-  X(GetParam,    "getParam")                                                   \
   X(Read,        "read")                                                       \
   X(Write,       "write")                                                      \
 

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -116,6 +116,7 @@ class Interpreter {
     }
     EvalFrame(const EvalFrame& F)
         : Caller(F.Caller), CallingEvalIndex(F.CallingEvalIndex) {}
+    bool isDefined() const { return Caller != nullptr; }
     void reset() {
       Caller = nullptr;
       CallingEvalIndex = 0;
@@ -139,6 +140,7 @@ class Interpreter {
   std::string CurSectionName;
   // The last read value.
   decode::IntType LastReadValue;
+  Method DispatchedMethod;
   bool MinimizeBlockSize;
   TraceClassSexpReaderWriter Trace;
 
@@ -175,8 +177,6 @@ class Interpreter {
   };
   OpcodeLocalsFrame OpcodeLocals;
   utils::ValueStack<OpcodeLocalsFrame> OpcodeLocalsStack;
-  // The parameter found from Method::GetParam.
-  const filt::Node* FoundParameter;
 
   void fail();
 

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -326,9 +326,11 @@ bool ParamNode::validateNode(NodeVectorType& Parents) {
   TRACE_SEXP(nullptr, this);
   for (size_t i = Parents.size(); i > 0; --i) {
     auto* Nd = Parents[i - 1];
-    auto* Define = cast<DefineNode>(Nd);
-    if (Define == nullptr)
+    auto* Define = dyn_cast<DefineNode>(Nd);
+    if (Define == nullptr) {
+      TRACE_SEXP("parent Nd", Nd);
       continue;
+    }
     TRACE_SEXP("Enclosing define", Nd);
     // Don't complain about this if specifying number of parameters for define.
     if (i == Parents.size() && this == Define->getKid(1))

--- a/src/utils/ValueStack.h
+++ b/src/utils/ValueStack.h
@@ -166,6 +166,12 @@ class ValueStack {
   // Note: Size doesn't include top.
   size_t size() const { return Stack.size(); }
   size_t sizeWithTop() const { return Stack.size() + 1; }
+  const T& at(size_t Index) const {
+    if (Index < Stack.size())
+      return Stack.at(Index);
+    assert(Index == Stack.size());
+    return Value;
+  }
   void push() { Stack.push_back(Value); }
   // Push Value onto stack
   void push(const T& Value) { Stack.push_back(Value); }

--- a/test/test-sources/defaults-param-test.df
+++ b/test/test-sources/defaults-param-test.df
@@ -110,9 +110,12 @@
     )
   )
 
-# HACK
+# HACK - Do 2 levels of calls to verify that parameter closure lookup
+# is handled correctly.
 #  (define 'code.opcode' (param 0) (uint8))
-  (define 'code.opcode' (param 1) (param 0))
+  (define 'code.opcode' (param 1)
+    (eval 'code.opcode1' (param 0)))
+  (define 'code.opcode1' (param 1) (param 0))
 
   (define 'data' (param 0)
     (loop (varuint32 6)        # number of data segments.


### PR DESCRIPTION
Update the "Eval" call stack to apply a function closure (based on calling context) before evaluating the found value for the parameter. This allows parameter expressions to have lexical scope (i.e. only apply to the define they appear in).
