### PR TITLE
Clean up code of decompression interpreter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ endif
 
 CXX := clang++
 
+ifeq ($(CXX),clang++)
+  CXX_SUBDIR =
+else
+  CXX_SUBDIR = /$(CXX)
+endif
+
 PLATFORM := Default
 
 # Define platform specific stuff.
@@ -71,7 +77,7 @@ endif
 
 SRCDIR = src
 
-BUILDBASEDIR = build$(PAGE_BUILD_SUFFIX)
+BUILDBASEDIR = build$(CXX_SUBDIR)$(PAGE_BUILD_SUFFIX)
 ifeq ($(RELEASE), 0)
   BUILDDIR = $(BUILDBASEDIR)/debug
 else
@@ -221,6 +227,7 @@ $(info Using PLATFORM = $(PLATFORM))
 $(info Using CXX = $(CXX))
 $(info Using RELEASE = $(RELEASE))
 $(info Using PAGE_SIZE = $(USE_PAGE_SIZE))
+$(info Using CXX_SUBDIR = $(CXX_SUBDIR))
 $(info -----------------------------------------------)
 
 CCACHE := `command -v ccache`
@@ -548,7 +555,7 @@ test-decompress: $(BUILD_EXECDIR)/decompress
 	$< -d $(TEST_SRCS_DIR)/defaults.wasm -m \
 		-i $(TEST_SRCS_DIR)/if-then-br.wasm -o - \
 		| diff - $(TEST_SRCS_DIR)/if-then-br.wasm
-	cd test/test-sources; make test RELEASE=$(RELEASE)
+	cd test/test-sources; make test RELEASE=$(RELEASE) CXX=$(CXX)
 	@echo "*** decompress tests passed ***"
 
 .PHONY: test-decompress

--- a/test/test-sources/Makefile.common
+++ b/test/test-sources/Makefile.common
@@ -42,6 +42,14 @@ else ifndef RELEASE
   RELEASE = 0
 endif
 
+CXX := clang++
+
+ifeq ($(CXX),clang++)
+  CXX_SUBDIR =
+else
+  CXX_SUBDIR = /$(CXX)
+endif
+
 # PAGE_SIZE (if defined) specifies that log2 size (i.e. number of bits) to use
 # for page size.
 ifdef PAGE_SIZE
@@ -54,7 +62,7 @@ else
   MAKE_PAGE_SIZE=
 endif
 
-BUILDDIR = ../../build$(PAGE_BUILD_SUFFIX)
+BUILDDIR = ../../build$(CXX_SUBDIR)$(PAGE_BUILD_SUFFIX)
 
 SEXP_SRCDIR = ../../src/sexp
 SEXP_DEFAULTS = $(SEXP_SRCDIR)/defaults.df


### PR DESCRIPTION
Now that most of the code of the decompression interpreter has been converted to a state model, this CL looks at the API and cleans up the API to better match where the code is now (rather than where it was during the transition).

Also does minor tweak on the Makefiles, so that the compiler used is implied in the build directory used. This cuts down on accidental make mismatches due to compiler choice tests.
