### PR TITLE
Clean up binary s-expression reader for decompression.

### DIFF
--- a/src/binary/BinaryReader.def
+++ b/src/binary/BinaryReader.def
@@ -27,6 +27,7 @@
   X(Name,        "readName")                                                   \
   X(Section,     "readSection")                                                \
   X(SectionBody, "readSectionBody")                                            \
+  X(Started,     "Started")                                                    \
   X(SymbolTable, "readSymbolTable")                                            \
 
 //#define X(tag, name)

--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -70,19 +70,19 @@ void BinaryWriter::writeNode(const Node* Nd) {
       fatal("Unable to write filter s-expression");
       break;
     }
-#define X(tag, format, defval, mergable, NODE_DECLS)                           \
-    case Op##tag: {                                                            \
-      Writer->writeUint8(Opcode, WritePos);                                    \
-      auto *Int = cast<tag##Node>(Nd);                                         \
-      if (Int->isDefaultValue()) {                                             \
-        Writer->writeUint8(1, WritePos);                                       \
-      } else {                                                                 \
-        Writer->writeUint8(0, WritePos);                                       \
-        Writer->write##format(Int->getValue(), WritePos);                      \
-      }                                                                        \
-      break;                                                                   \
-    }
-    AST_INTEGERNODE_TABLE
+#define X(tag, format, defval, mergable, NODE_DECLS)    \
+  case Op##tag: {                                       \
+    Writer->writeUint8(Opcode, WritePos);               \
+    auto* Int = cast<tag##Node>(Nd);                    \
+    if (Int->isDefaultValue()) {                        \
+      Writer->writeUint8(1, WritePos);                  \
+    } else {                                            \
+      Writer->writeUint8(0, WritePos);                  \
+      Writer->write##format(Int->getValue(), WritePos); \
+    }                                                   \
+    break;                                              \
+  }
+      AST_INTEGERNODE_TABLE
 #undef X
     case OpAnd:
     case OpBlock:

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -267,7 +267,7 @@ void Interpreter::fail(const std::string& Message) {
     fprintf(Out, "Error: ");
     getTrace().getTextWriter()->writeAbbrev(Out, Frame.Nd);
   }
-  fprintf(Out, "Error: (method %s) %s\n: ", getName(Frame.CallMethod),
+  fprintf(Out, "Error: (method %s) %s\n", getName(Frame.CallMethod),
           Message.c_str());
   fail();
 }
@@ -1246,8 +1246,7 @@ void Interpreter::runMethods() {
                 break;
               case State::Exit:
                 OpcodeLocals.CaseMask = Frame.ReturnValue;
-                OpcodeLocals.SelShift =
-                    cast<Uint8Node>(Frame.Nd)->getValue();
+                OpcodeLocals.SelShift = cast<Uint8Node>(Frame.Nd)->getValue();
                 popAndReturn();
                 TraceExitFrame();
                 break;
@@ -1264,8 +1263,7 @@ void Interpreter::runMethods() {
                 break;
               case State::Exit:
                 OpcodeLocals.CaseMask = Frame.ReturnValue;
-                OpcodeLocals.SelShift =
-                    cast<Uint32Node>(Frame.Nd)->getValue();
+                OpcodeLocals.SelShift = cast<Uint32Node>(Frame.Nd)->getValue();
                 popAndReturn();
                 TraceExitFrame();
                 break;
@@ -1283,8 +1281,7 @@ void Interpreter::runMethods() {
                 break;
               case State::Exit:
                 OpcodeLocals.CaseMask = Frame.ReturnValue;
-                OpcodeLocals.SelShift =
-                    cast<Uint64Node>(Frame.Nd)->getValue();
+                OpcodeLocals.SelShift = cast<Uint64Node>(Frame.Nd)->getValue();
                 popAndReturn();
                 TraceExitFrame();
                 break;
@@ -1353,33 +1350,29 @@ void Interpreter::runMethods() {
             break;
           case OpUint32:  // Method::Write
             TraceEnterFrame();
-            Writer->writeUint32Bits(
-                WriteValue, WritePos,
-                cast<Uint32Node>(Frame.Nd)->getValue());
+            Writer->writeUint32Bits(WriteValue, WritePos,
+                                    cast<Uint32Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
             TraceExitFrame();
             break;
           case OpUint64:  // Method::Write
             TraceEnterFrame();
-            Writer->writeUint64Bits(
-                WriteValue, WritePos,
-                cast<Uint64Node>(Frame.Nd)->getValue());
+            Writer->writeUint64Bits(WriteValue, WritePos,
+                                    cast<Uint64Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
             TraceExitFrame();
             break;
           case OpVarint32:  // Method::Write
             TraceEnterFrame();
-            Writer->writeVarint32Bits(
-                WriteValue, WritePos,
-                cast<Varint32Node>(Frame.Nd)->getValue());
+            Writer->writeVarint32Bits(WriteValue, WritePos,
+                                      cast<Varint32Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
             TraceExitFrame();
             break;
           case OpVarint64:  // Method::Write
             TraceEnterFrame();
-            Writer->writeVarint64Bits(
-                WriteValue, WritePos,
-                cast<Varint64Node>(Frame.Nd)->getValue());
+            Writer->writeVarint64Bits(WriteValue, WritePos,
+                                      cast<Varint64Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
             TraceExitFrame();
             break;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -359,15 +359,15 @@ bool IntegerNode::implementsClass(NodeType Type) {
   switch (Type) {
     default:
       return false;
-#define X(tag, format, defval, mergable, NODE_DECLS)                           \
-  case Op##tag:                                                                \
+#define X(tag, format, defval, mergable, NODE_DECLS) \
+  case Op##tag:                                      \
     return true;
       AST_INTEGERNODE_TABLE
 #undef X
   }
 }
 
-#define X(tag, format, defval, mergable, NODE_DECLS)     \
+#define X(tag, format, defval, mergable, NODE_DECLS) \
   void tag##Node::forceCompilation() {}
 AST_INTEGERNODE_TABLE
 #undef X

--- a/src/utils/ValueStack.h
+++ b/src/utils/ValueStack.h
@@ -140,23 +140,23 @@ class ValueStack {
   Iterator begin() const { return Iterator(this, 0); }
   Iterator end() const { return Iterator(this, sizeWithTop()); }
   IteratorRange iterRange(size_t BeginIndex, size_t EndIndex) const {
-    assert(BeginIndex < sizeWithTop());
+    assert(BeginIndex <= sizeWithTop());
     assert(EndIndex <= sizeWithTop());
     return IteratorRange(this, BeginIndex, EndIndex);
   }
   IteratorRange iterRange(size_t BeginIndex) const {
-    assert(BeginIndex < sizeWithTop());
+    assert(BeginIndex <= sizeWithTop());
     return IteratorRange(this, BeginIndex);
   }
   BackwardIterator rbegin() const { return BackwardIterator(this, size()); }
   BackwardIterator rend() const { return BackWardIterator(this, size_t(-1)); }
   BackwardIteratorRange riterRange(size_t BeginIndex, size_t EndIndex) const {
-    assert(BeginIndex < sizeWithTop());
+    assert(BeginIndex <= sizeWithTop());
     assert(EndIndex <= sizeWithTop());
     return BackwardIteratorRange(this, BeginIndex, EndIndex);
   }
   BackwardIteratorRange riterRange(size_t BeginIndex) const {
-    assert(BeginIndex < sizeWithTop());
+    assert(BeginIndex <= sizeWithTop());
     return BackwardIteratorRange(this, BeginIndex);
   }
   ValueStack(T& Value) : Value(Value) {}


### PR DESCRIPTION
Gets rid of the "Runner" class of the binary parser, and cleans up the API for resuming the parse (incrementally).

It does not fix the problem that too many read routines may need a LARGE number of bytes, and should be converted to the state model to allow pausing, and resuming when more bytes are available.
