### PR TITLE
Adding wasm toolchain build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
-language: c++
+language: c++ node_js
+
+node_js: "node"
 
 sudo: false
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++6-4.7-dev
 
 before_script: ./travis/install_dependencies.sh
 

--- a/travis/build_and_test.sh
+++ b/travis/build_and_test.sh
@@ -7,7 +7,18 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/.."
 DEPS_DIR="${ROOT_DIR}/travis_deps"
 export PATH=${DEPS_DIR}/bison/bin:${PATH}
+export NODE=`which node`
 
 cd ${ROOT_DIR}
 
+# TODO(kschimpf): Fix me.
+# Build for Wasm.
+#make clean-all
+#make -j8 PLATFORM=Travis WASM=1 RELEASE=1
+
+# Build for Wasm Vanilla.
+make clean-all
+make -j8 PLATFORM=Travis WASM=1 WASM_VANILLA=1 RELEASE=1
+
+# Build for host.
 make presubmit -j8 PLATFORM=Travis

--- a/travis/install_dependencies.sh
+++ b/travis/install_dependencies.sh
@@ -7,13 +7,29 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/.."
 DEPS_DIR="${ROOT_DIR}/travis_deps"
 
-# Install newer bison.
+# Cleanup.
 rm -rf ${DEPS_DIR}
 mkdir -p ${DEPS_DIR}
 cd ${DEPS_DIR}
-wget --no-check-certificate http://ftp.gnu.org/gnu/bison/bison-3.0.2.tar.gz
-tar -xf bison-3.0.2.tar.gz
-cd bison-3.0.2
-./configure --prefix=${DEPS_DIR}/bison
-mkdir ${DEPS_DIR}/bison
-make -j 4 install
+
+# Install pinned wasm toolchain.
+WASM_ARCHIVE=https://storage.googleapis.com/wasm-llvm/builds/git
+WASM_FILENAME=wasm-binaries-10995.tbz2
+WASM_URL=${WASM_ARCHIVE}/${WASM_FILENAME}
+curl ${WASM_URL} -O
+tar xf ${WASM_FILENAME}
+sed -e s:/b/build/slave/linux/build/src/src/work/:$PWD/: \
+  < wasm-install/emscripten_config > wasm_emscripten_config
+sed -e s:/b/build/slave/linux/build/src/src/work/:$PWD/: \
+  < wasm-install/emscripten_config_vanilla > wasm_emscripten_config_vanilla
+
+if [ "${TRAVIS}" = true ]; then
+  # Install newer bison.
+  wget --no-check-certificate http://ftp.gnu.org/gnu/bison/bison-3.0.2.tar.gz
+  tar -xf bison-3.0.2.tar.gz
+  cd bison-3.0.2
+  ./configure --prefix=${DEPS_DIR}/bison
+  mkdir ${DEPS_DIR}/bison
+  make -j 4 install
+  cd ..
+fi


### PR DESCRIPTION
This falls over on allocators.
It seems that emscripten has an issue with operator new (anything that includes <new> even indirectly end up horking it.
See if you can figure out what's going on.
