### PR TITLE
Make version expressions explicitly state usage.

### DIFF
--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -208,7 +208,7 @@ void BinaryReader::resume() {
             CasmVersion = Reader->readUint32(ReadPos);
             if (CasmVersion != CasmBinaryVersion)
               fatal("Casm version not " + std::to_string(CasmBinaryVersion));
-            auto *Version = Symtab->getVersionFileDefinition(
+            auto *Version = Symtab->getCasmVersionDefinition(
                 CasmVersion, ValueFormat::Hexidecimal);
             TRACE_SEXP("Casm version", Version);
             assert(CurFile);
@@ -494,7 +494,7 @@ void BinaryReader::resume() {
             WasmVersion = Reader->readUint32(ReadPos);
             if (WasmVersion != WasmBinaryVersion)
               fatal("Wasm version not " + std::to_string(WasmBinaryVersion));
-            auto *Version = Symtab->getVersionSectionDefinition(
+            auto *Version = Symtab->getWasmVersionDefinition(
                 WasmVersion, ValueFormat::Hexidecimal);
             TRACE_SEXP("Wasm version", Version);
             assert(CurSection);

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -371,8 +371,8 @@ void Interpreter::resume() {
           case OpSection:
           case OpUndefine:
           case OpUnknownSection:
-          case OpVersionFile:
-          case OpVersionSection:  // Method::Eval
+          case OpCasmVersion:
+          case OpWasmVersion:  // Method::Eval
             fail("Not allowed!");
             break;
           case OpError:  // Method::Eval
@@ -990,8 +990,8 @@ void Interpreter::resume() {
           case OpSymbol:
           case OpUndefine:
           case OpUnknownSection:
-          case OpVersionFile:
-          case OpVersionSection:
+          case OpCasmVersion:
+          case OpWasmVersion:
           case OpAnd:
           case OpError:
           case OpEval:
@@ -1398,8 +1398,8 @@ void Interpreter::resume() {
           case OpSymbol:
           case OpUndefine:
           case OpUnknownSection:
-          case OpVersionFile:
-          case OpVersionSection:
+          case OpCasmVersion:
+          case OpWasmVersion:
           case OpAnd:
           case OpError:
           case OpEval:

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -217,6 +217,7 @@ id ({letter}|{digit}|[_.])*
 "bitwise"         return Parser::make_BITWISE(Driver.getLoc());
 "byte"            return Parser::make_BYTE(Driver.getLoc());
 "case"            return Parser::make_CASE(Driver.getLoc());
+"casm"            return Parser::make_CASM(Driver.getLoc());
 "define"          return Parser::make_DEFINE(Driver.getLoc());
 "empty"           return Parser::make_EMPTY(Driver.getLoc());
 "end"             return Parser::make_KEYWORD_END(Driver.getLoc());
@@ -260,6 +261,7 @@ id ({letter}|{digit}|[_.])*
 "varuint64"       return Parser::make_VARUINT64(Driver.getLoc());
 "version"         return Parser::make_VERSION(Driver.getLoc());
 "void"            return Parser::make_VOID(Driver.getLoc());
+"wasm"            return Parser::make_WASM(Driver.getLoc());
 "write"           return Parser::make_WRITE(Driver.getLoc());
 "xor"             return Parser::make_XOR(Driver.getLoc());
 "0x"{hexdigit}+   return make_HexInteger(Driver, yytext);

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -83,6 +83,7 @@ struct IntValue {
 %token BLOCK         "block"
 %token BYTE          "byte"
 %token CASE          "case"
+%token CASM          "casm"
 %token CLOSEPAREN    ")"
 %token DEFINE        "define"
 %token DOT           "."
@@ -129,6 +130,7 @@ struct IntValue {
 %token VARUINT64     "varuint64"
 %token VERSION       "version"
 %token VOID          "void"
+%token WASM          "wasm"
 %token WRITE         "write"
 %token XOR           "xor"
 
@@ -174,8 +176,8 @@ struct IntValue {
 %type <wasm::filt::Node *> seq_stmt_list
 %type <wasm::filt::Node *> statement
 %type <wasm::filt::Node *> symbol
-%type <wasm::filt::Node *> version_file
-%type <wasm::filt::Node *> version_section
+%type <wasm::filt::Node *> casm_version
+%type <wasm::filt::Node *> wasm_version
 
 %start file
 
@@ -270,7 +272,7 @@ declaration_stmt_list
         ;
 
 declaration_list
-        : symbol version_section {  // Section name / wasm version.
+        : symbol wasm_version {  // Section name / wasm version.
             $$ = Driver.create<SectionNode>();
             $$->append($1);
             $$->append($2);
@@ -506,24 +508,24 @@ params_decl
           }
         ;
 
-version_file
-        : "(" "version" INTEGER ")" {
-            $$ = Driver.getVersionFileDefinition($3.Value, $3.Format);
-            if ($3.Format != decode::ValueFormat::Hexidecimal)
+casm_version
+        : "(" "casm" "." "version" INTEGER ")" {
+            $$ = Driver.getCasmVersionDefinition($5.Value, $5.Format);
+            if ($5.Format != decode::ValueFormat::Hexidecimal)
               Driver.error("Casm version # not hexidecimal");
-            if ($3.Value != CasmBinaryVersion)
+            if ($5.Value != CasmBinaryVersion)
               Driver.error("Only casm version "
                            + std::to_string(CasmBinaryVersion)
                            + " is supported");
           }
         ;
 
-version_section
-        : "(" "version" INTEGER ")" {
-            $$ = Driver.getVersionSectionDefinition($3.Value, $3.Format);
-            if ($3.Format != decode::ValueFormat::Hexidecimal)
+wasm_version
+        : "(" "wasm" "." "version" INTEGER ")" {
+            $$ = Driver.getWasmVersionDefinition($5.Value, $5.Format);
+            if ($5.Format != decode::ValueFormat::Hexidecimal)
               Driver.error("Wasm version # not hexidecimal");
-            if ($3.Value != WasmBinaryVersion)
+            if ($5.Value != WasmBinaryVersion)
               Driver.error("Only wasm version "
                            + std::to_string(WasmBinaryVersion)
                            + " is supported");
@@ -554,12 +556,11 @@ section : "(" "section" declaration_list ")" { $$ = $3; }
         ;
 
 section_list
-        : version_file section { // first section of file.
+        : casm_version { // version of the decompressor.
             $$ = Driver.create<FileNode>();
             $$->append($1);
-            $$->append($2);
           }
-        | section_list section { // Remaining sections in file.
+        | section_list section { // Sections in file.
             $$ = $1;
             $$->append($2);
           }

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -94,8 +94,8 @@
   X(File,              0x62, "file",             nullptr,           0, 0)      \
   X(Section,           0x63, "section",          nullptr,           1, 0)      \
   X(Undefine,          0x64, "undefine",         nullptr,           1, 0)      \
-  X(VersionFile,       0x65, "version",          "versionFile",     1, 0)      \
-  X(VersionSection,    0x66, "version",          "versionSection",  1, 0)      \
+  X(CasmVersion,       0x65, "casm.version",     nullptr,           1, 0)      \
+  X(WasmVersion,       0x66, "wasm.version",     nullptr,           1, 0)      \
   X(Rename,            0x67, "rename",           nullptr,           2, 0)      \
   X(Locals,            0x68, "locals",           nullptr,           1, 0)      \
   X(Params,            0x69, "params",           nullptr,           1, 0)      \
@@ -120,14 +120,14 @@
 //   mergable: True if instances can be merged.
 //   NODE_DECLS: Other declarations for the node.
 #define AST_VERSION_INTEGERNODE_TABLE                                          \
-  X(VersionFile, Uint32, 0, true, VERSIONFILE_DECLS)                           \
-  X(VersionSection, Uint32, 0, true, VERSIONSECTION_DECLS)                     \
+  X(CasmVersion, Uint32, 0, true, CASM_VERSION_DECLS)                          \
+  X(WasmVersion, Uint32, 0, true, WASM_VERSION_DECLS)                          \
 
-#define VERSIONFILE_DECLS                                                      \
+#define CASM_VERSION_DECLS                                                     \
   uint32_t getExpectedVersion() const { return CasmBinaryVersion; }            \
   const char* getExpectedVersionName() const { return "Casm"; }                \
 
-#define VERSIONSECTION_DECLS                                                   \
+#define WASM_VERSION_DECLS                                                     \
   uint32_t getExpectedVersion() const { return WasmBinaryVersion; }            \
   const char* getExpectedVersionName() const { return "Wasm"; }                \
 

--- a/src/sexp/defaults.df
+++ b/src/sexp/defaults.df
@@ -16,9 +16,9 @@
 # This file defines the default algorithms for decompressing a WASM
 # module.
 
-(version 0x0)
+(casm.version 0x0)
 (section 'filter'
-  (version 0xb)
+  (wasm.version 0xb)
 
   (define 'code' (params)
     (loop (varuint32)            # Number of function bodies.

--- a/test/test-sources/MismatchedParens.df
+++ b/test/test-sources/MismatchedParens.df
@@ -1,2 +1,2 @@
-(version 0x0)
-(section 'foo' version))
+(casm.version 0x0)
+(section 'foo' (wasm.version 0xb)))

--- a/test/test-sources/MismatchedParens.df-out
+++ b/test/test-sources/MismatchedParens.df-out
@@ -1,2 +1,2 @@
-2.16-22: syntax error, unexpected version, expecting (
+2.35: syntax error, unexpected ), expecting $END
 Errors detected: test/test-sources/MismatchedParens.df

--- a/test/test-sources/defaults-param-test.df
+++ b/test/test-sources/defaults-param-test.df
@@ -16,9 +16,9 @@
 # defaults.df except for method 'code.opcode". Rather than reading a (uint8), it
 # uses the code passed as a parameter.
 
-(version 0x0)
+(casm.version 0x0)
 (section 'filter'
-  (version 0xb)
+  (wasm.version 0xb)
 
   (define 'code' (params)
     (loop (varuint32)            # Number of function bodies.

--- a/test/test-sources/defaults.df
+++ b/test/test-sources/defaults.df
@@ -1,6 +1,6 @@
-(version 0x0)
+(casm.version 0x0)
 (section 'filter'
-  (version 0xb)
+  (wasm.version 0xb)
   (define 'code' (params)
     (loop (varuint32) (eval 'code.function'))
   )


### PR DESCRIPTION
Use "casm.version" to denote compressed version and "wasm.version" to denote WASM version that was compressed.
