### PR TITLE
Implements most of the C api for decompression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ STRM_SRCS = \
 	FileWriter.cpp \
 	Cursor.cpp \
 	Page.cpp \
+	Pipe.cpp \
 	Queue.cpp \
 	ReadCursor.cpp \
 	ReadBackedQueue.cpp \

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ STRM_SRCS = \
 	StringWriter.cpp \
 	WriteBackedQueue.cpp \
 	WriteCursor.cpp \
+	WriteCursorBase.cpp \
+	WriteCursor2ReadQueue.cpp \
 	WriteUtils.cpp
 
 STRM_OBJS = $(patsubst %.cpp, $(STRM_OBJDIR)/%.o, $(STRM_SRCS))

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -151,8 +151,7 @@ int main(int Argc, char* Argv[]) {
     std::string Arg(Argv[i]);
     if (Arg == "--c-api") {
       UseCApi = true;
-    }
-    else if (Arg == "-d") {
+    } else if (Arg == "-d") {
       if (++i >= Argc) {
         fprintf(stderr, "No file specified after -d option\n");
         usage(Argv[0]);

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -18,6 +18,7 @@
 
 #include "interp/Decompress.h"
 #include "interp/Interpreter.h"
+#include "stream/Pipe.h"
 
 namespace wasm {
 
@@ -26,8 +27,6 @@ using namespace filt;
 
 namespace interp {
 
-extern "C" {
-
 namespace {
 
 struct Decompressor {
@@ -35,82 +34,88 @@ struct Decompressor {
   Decompressor& operator=(const Decompressor& D) = delete;
 
  public:
-  uint8_t* InputBuffer;
-  int32_t InputBufferSize;
-  int32_t InputBufferAllocSize;
-  uint8_t* OutputBuffer;
-  int32_t OutputBufferSize;
-  int32_t OutputBufferAllocSize;
-  bool Broken;
+  std::unique_ptr<uint8_t> Buffer;
+  int32_t BufferSize;
   std::shared_ptr<SymbolTable> Symtab;
   std::shared_ptr<Queue> Input;
-  std::shared_ptr<ReadCursor> ReadPos;
-  std::shared_ptr<Queue> Output;
-  std::shared_ptr<WriteCursor> WritePos;
+  std::shared_ptr<WriteCursor> InputPos;
+  Pipe OutputPipe;
+  std::shared_ptr<ReadCursor> OutputPos;
   std::shared_ptr<Interpreter> Interp;
   Decompressor();
-  ~Decompressor();
-  uint8_t* getNextInputBuffer(int32_t Size);
-  int32_t resumeDecompression();
+  uint8_t* getBuffer(int32_t Size);
+  int32_t resumeDecompression(int32_t Size);
   int32_t finishDecompression();
-  uint8_t* getNextOutputBuffer(int32_t Size);
+  bool fetchOutput(int32_t Size);
   int32_t currentStatus();
+  int32_t currentOutputSize();
+
+  TraceClassSexpReaderWriter& getTrace() { return Interp->getTrace(); }
+  void describeInputPos() {
+    fprintf(stderr, "InputPage %" PRIuMAX "[%" PRIxMAX ":%" PRIxMAX "]\n",
+            uintmax_t(InputPos->getCurByteAddress()),
+            uintmax_t(InputPos->getMinAddress()),
+            uintmax_t(InputPos->getMaxAddress()));
+  }
 };
-}
 
 Decompressor::Decompressor()
-    : InputBuffer(nullptr),
-      InputBufferSize(0),
-      InputBufferAllocSize(0),
-      OutputBuffer(nullptr),
-      OutputBufferSize(0),
-      OutputBufferAllocSize(0),
-      Broken(false),
+    : BufferSize(0),
       Symtab(std::make_shared<SymbolTable>()),
-      Input(std::make_shared<Queue>()),
-      Output(std::make_shared<Queue>()) {
-  ReadPos = std::make_shared<ReadCursor>(Input);
-  WritePos = std::make_shared<WriteCursor>(Output);
+      Input(std::make_shared<Queue>()) {
+  InputPos = std::make_shared<WriteCursor>(Input);
+  OutputPos = std::make_shared<ReadCursor>(OutputPipe.getOutput());
+  describeInputPos();
 }
 
-Decompressor::~Decompressor() {
-  delete[] InputBuffer;
-  delete[] OutputBuffer;
-}
-
-uint8_t* Decompressor::getNextInputBuffer(int32_t Size) {
-  if (Size <= InputBufferAllocSize) {
-    InputBufferSize = Size;
-    return InputBuffer;
-  }
-  if (Size > InputBufferAllocSize)
-    delete[] InputBuffer;
-  InputBufferAllocSize = std::max(Size, 1 >> 14);
-  InputBuffer = new uint8_t[InputBufferAllocSize];
-  InputBufferSize = Size;
-  return InputBuffer;
+uint8_t* Decompressor::getBuffer(int32_t Size) {
+  TRACE_METHOD("get_decompressor_buffer");
+  if (Size <= BufferSize)
+    return Buffer.get();
+  Buffer.reset(new uint8_t[Size]);
+  BufferSize = Size;
+  return Buffer.get();
 }
 
 int32_t Decompressor::currentStatus() {
-  fatal("currentStatus not implemented");
-  return DECOMPRESSOR_ERROR;
+  return (!Interp->isFinished() || Interp->isSuccessful())
+      ? DECOMPRESSOR_SUCCESS : DECOMPRESSOR_ERROR;
 }
 
-int32_t Decompressor::resumeDecompression() {
-  if (Interp->isFinished())
-    return currentStatus();
+int32_t Decompressor::currentOutputSize() {
+  int32_t Status = currentStatus();
+  if (Status == DECOMPRESSOR_SUCCESS)
+    Status = OutputPipe.getOutput()->fillSize() - OutputPos->getCurByteAddress();
+  TRACE(int32_t, "Status", Status);
+  return Status;
+}
+
+int32_t Decompressor::resumeDecompression(int32_t Size) {
+  TRACE_METHOD("resume_decompression");
+  if (Size > BufferSize) {
+    Interp->fail("resume_decompression(" + std::to_string(Size) +
+                 "): illegal size");
+    return DECOMPRESSOR_ERROR;
+  }
+  // TODO(karlschimpf) Speed up this copy.
+  describeInputPos();
+  for (int32_t i = 0; i < Size; ++i)
+    InputPos->writeByte(Buffer.get()[i]);
+  describeInputPos();
   Interp->resume();
-  return currentStatus();
+  return currentOutputSize();
 }
 
 int32_t Decompressor::finishDecompression() {
-  fatal("finishDecompression not implemented!");
-  return 0;
+  TRACE_METHOD("finish_decompression");
+  Interp->fail("finishDecompression not implemented");
+  return currentStatus();
 }
 
-uint8_t* Decompressor::getNextOutputBuffer(int32_t Size) {
-  fatal("getNextOutputBuffer notimplemented!");
-  return nullptr;
+bool Decompressor::fetchOutput(int32_t Size) {
+  TRACE_METHOD("fetch_decompressor_output");
+  Interp->fail("fetchOutput not implemented!");
+  return currentStatus() == DECOMPRESSOR_SUCCESS;
 }
 
 }  // end of anonymous namespace
@@ -119,46 +124,44 @@ extern "C" {
 
 void* create_decompressor() {
   auto* Decomp = new Decompressor();
-  if (!SymbolTable::installPredefinedDefaults(Decomp->Symtab, false)) {
-    Decomp->Broken = true;
-    return Decomp;
-  }
+  bool InstalledDefaults =
+      SymbolTable::installPredefinedDefaults(Decomp->Symtab, false);
   Decomp->Interp = std::make_shared<Interpreter>(Decomp->Input,
-                                                 Decomp->Output,
+                                                 Decomp->OutputPipe.getInput(),
                                                  Decomp->Symtab);
   Decomp->Interp->setTraceProgress(true);
+  Decomp->Interp->start();
+  if (!InstalledDefaults)
+    Decomp->Interp->fail("Unable to install decompression rules!");
   return Decomp;
 }
 
-void* get_next_decompressor_input_buffer(void* Dptr, int32_t Size) {
+uint8_t* get_decompressor_buffer(void* Dptr, int32_t Size) {
   Decompressor* D = (Decompressor*)Dptr;
-  return D->getNextInputBuffer(Size);
+  return D->getBuffer(Size);
 }
 
-int32_t resume_decompression(void* Dptr) {
+int32_t resume_decompression(void* Dptr, int32_t Size) {
   Decompressor* D = (Decompressor*)Dptr;
-  if (D->Broken)
-    return DECOMPRESSOR_ERROR;
-  return D->resumeDecompression();
+  return D->resumeDecompression(Size);
 }
 
 int32_t finish_decompression(void* Dptr) {
   Decompressor* D = (Decompressor*)Dptr;
-  if (D->Broken)
-    return DECOMPRESSOR_ERROR;
   return D->finishDecompression();
 }
 
-void* get_next_decompressor_output_buffer(void* Dptr, int32_t Size) {
+bool fetch_decompressor_output(void* Dptr, int32_t Size) {
   Decompressor* D = (Decompressor*)Dptr;
-  return D->getNextOutputBuffer(Size);
+  return D->fetchOutput(Size);
 }
 
 void destroy_decompressor(void* Dptr) {
   Decompressor* D = (Decompressor*)Dptr;
   delete D;
 }
-}
+
+} // end extern "C".
 
 }  // end of namespace interp
 

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -119,9 +119,8 @@ void* create_decompressor() {
   auto* Decomp = new Decompressor();
   bool InstalledDefaults =
       SymbolTable::installPredefinedDefaults(Decomp->Symtab, false);
-  Decomp->Interp = std::make_shared<Interpreter>(Decomp->Input,
-                                                 Decomp->OutputPipe.getInput(),
-                                                 Decomp->Symtab);
+  Decomp->Interp = std::make_shared<Interpreter>(
+      Decomp->Input, Decomp->OutputPipe.getInput(), Decomp->Symtab);
   Decomp->Interp->setTraceProgress(true);
   Decomp->Interp->start();
   if (!InstalledDefaults)
@@ -149,7 +148,7 @@ void destroy_decompressor(void* Dptr) {
   delete D;
 }
 
-} // end extern "C".
+}  // end extern "C".
 
 }  // end of namespace interp
 

--- a/src/interp/Decompress.h
+++ b/src/interp/Decompress.h
@@ -30,22 +30,18 @@ extern "C" {
 /* Returns an allocated and initialized decompressor. */
 extern void* create_decompressor();
 
-/* Creates a buffer to pass data in/out. D is the decompressor and Size
- * is the size of buffer to use.
+/* Creates a buffer to pass data in/out. D is the decompressor and Size is the
+ * size of buffer to use.
  */
 extern uint8_t* get_decompressor_buffer(void* D, int32_t Size);
 
-/* Resume decopmression, assuming the buffer contains Size bytes.
- * If non-negative, returns the number of output bytes available.
- * If negative, either DECOMPRESSOR_SUCCESS or DECOMPRESSOR_ERROR.
+/* Resume decopmression, assuming the buffer contains Size bytes to read.  If
+ * non-negative, returns the number of output bytes available.  If negative,
+ * either DECOMPRESSOR_SUCCESS or DECOMPRESSOR_ERROR. NOTE: If Size == 0, the
+ * code assumes that no more input will be provided (i.e. in all subsequent
+ * calls, Size == 0).
  */
 extern int32_t resume_decompression(void* D, int32_t Size);
-
-/* Finish decompression, flushing out any remaining output.
- * If non-negative, returns the number of output bytes available.
- * If negative, either DECOMPRESSOR_SUCCESS or DECOMPRESSOR_ERROR.
- */
-extern int32_t finish_decompression(void* D);
 
 /* Fetch the next Size bytes and put into the decompression buffer.
  * Returns true if successful.

--- a/src/interp/Decompress.h
+++ b/src/interp/Decompress.h
@@ -30,18 +30,27 @@ extern "C" {
 /* Returns an allocated and initialized decompressor. */
 extern void* create_decompressor();
 
-/* Requestes a buffer of Size bytes. Assumes the lifetime of the
- * buffer is to the next call to get_next_decompressor_buffer() or
- * destroy_decompressor() (which ever comes first).
+/* Creates a buffer to pass data in/out. D is the decompressor and Size
+ * is the size of buffer to use.
  */
-extern void* get_next_decompressor_input_buffer(void* D, int32_t Size);
+extern uint8_t* get_decompressor_buffer(void* D, int32_t Size);
 
-extern int32_t resume_decompression(void* D);
+/* Resume decopmression, assuming the buffer contains Size bytes.
+ * If non-negative, returns the number of output bytes available.
+ * If negative, either DECOMPRESSOR_SUCCESS or DECOMPRESSOR_ERROR.
+ */
+extern int32_t resume_decompression(void* D, int32_t Size);
 
-/* Called when no more input to process */
+/* Finish decompression, flushing out any remaining output.
+ * If non-negative, returns the number of output bytes available.
+ * If negative, either DECOMPRESSOR_SUCCESS or DECOMPRESSOR_ERROR.
+ */
 extern int32_t finish_decompression(void* D);
 
-extern void* get_next_decompressor_output_buffer(void* D, int32_t Size);
+/* Fetch the next Size bytes and put into the decompression buffer.
+ * Returns true if successful.
+ */
+extern bool fetch_decompressor_output(void* D, int32_t Size);
 
 /* Clean up D and then deallocates. */
 extern void destroy_decompressor(void* D);

--- a/src/interp/Decompress.h
+++ b/src/interp/Decompress.h
@@ -50,7 +50,6 @@ extern bool fetch_decompressor_output(void* D, int32_t Size);
 
 /* Clean up D and then deallocates. */
 extern void destroy_decompressor(void* D);
-
 }
 
 #endif  // DECOMPRESSOR_SRC_INTERP_DECOMPRESS_H

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -29,7 +29,7 @@
 // since they are the glue between a push and pull models. Rather, they
 // conceptually mimic the natural call structure. If you want to trace
 // resume() and readBackFilled() as well, change this flag to 1.
-#define LOG_RUNMETHODS 1
+#define LOG_RUNMETHODS 0
 // The following tracks runMetthods() and readBackFilled(), which run
 // interpreter methods with tracing showing equivalent non-push inter
 // The following turn on logging sections, functions in the decompression

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -29,7 +29,7 @@
 // since they are the glue between a push and pull models. Rather, they
 // conceptually mimic the natural call structure. If you want to trace
 // resume() and readBackFilled() as well, change this flag to 1.
-#define LOG_RUNMETHODS 0
+#define LOG_RUNMETHODS 1
 // The following tracks runMetthods() and readBackFilled(), which run
 // interpreter methods with tracing showing equivalent non-push inter
 // The following turn on logging sections, functions in the decompression
@@ -1544,8 +1544,7 @@ void Interpreter::resume() {
 }
 
 void Interpreter::decompress() {
-  assert(FrameStack.empty());
-  callTopLevel(Method::GetFile, nullptr);
+  start();
   readBackFilled();
 }
 

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -58,7 +58,10 @@ class Interpreter {
   void decompress();
 
   // Starts up decompression.
-  void start();
+  void start() {
+    assert(FrameStack.empty());
+    callTopLevel(Method::GetFile, nullptr);
+  }
 
   // Resumes decompression where it left off. Assumes that more
   // input has been added since the previous start()/resume() call.
@@ -72,6 +75,11 @@ class Interpreter {
   bool isFinished() const { return Frame.CallMethod == Method::Finished; }
   bool isSuccessful() const { return Frame.CallState == State::Succeeded; }
   bool errorsFound() const { return Frame.CallState == State::Failed; }
+
+  // Force interpretation to fail.
+  void fail(const std::string& Message);
+
+  TraceClassSexpReaderWriter& getTrace() { return Trace; }
 
  private:
   enum class Method {
@@ -138,6 +146,8 @@ class Interpreter {
     size_t CallingEvalIndex;
   };
 
+  void fail();
+
   decode::ReadCursor ReadPos;
   std::shared_ptr<ReadStream> Reader;
   decode::WriteCursor WritePos;
@@ -196,8 +206,6 @@ class Interpreter {
   OpcodeLocalsFrame OpcodeLocals;
   utils::ValueStack<OpcodeLocalsFrame> OpcodeLocalsStack;
 
-  void fail();
-  void fail(const std::string& Message);
   void failBadState();
   void failNotImplemented();
 
@@ -245,7 +253,6 @@ class Interpreter {
     popAndReturn(Value);
   }
 
-  TraceClassSexpReaderWriter& getTrace() { return Trace; }
   void TraceEnterFrame() {
     assert(Frame.CallState == Interpreter::State::Enter);
     TRACE_ENTER(getName(Frame.CallMethod));

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -40,12 +40,12 @@ bool Cursor::readFillBuffer() {
   return BufferSize > 0;
 }
 
-void Cursor::writeFillBuffer() {
+void Cursor::writeFillBuffer(size_t WantedSize) {
   if (CurAddress >= Que->getEofAddress()) {
     fail();
     return;
   }
-  size_t BufferSize = Que->writeToPage(CurAddress, Page::Size, *this);
+  size_t BufferSize = Que->writeToPage(CurAddress, WantedSize, *this);
   if (BufferSize == 0)
     fail();
 }

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -117,9 +117,7 @@ class Cursor : public PageCursor {
 
   bool isEofFrozen() const { return Que->isEofFrozen(); }
 
-  bool atEof() const {
-    return CurAddress == Que->getEofAddress();
-  }
+  bool atEof() const { return CurAddress == Que->getEofAddress(); }
 
   size_t getEofAddress() const { return Que->getEofAddress(); }
 

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -118,7 +118,7 @@ class Cursor : public PageCursor {
   bool isEofFrozen() const { return Que->isEofFrozen(); }
 
   bool atEof() const {
-    return isIndexAtEndOfPage() && !const_cast<Cursor*>(this)->readFillBuffer();
+    return CurAddress == Que->getEofAddress();
   }
 
   size_t getEofAddress() const { return Que->getEofAddress(); }
@@ -198,8 +198,9 @@ class Cursor : public PageCursor {
   // Returns true if able to fill the buffer with at least one byte.
   bool readFillBuffer();
 
-  // Creates new pages in buffer so that writes can occur.
-  void writeFillBuffer();
+  // Creates new pages in buffer so that writes can occur. WantedSize is
+  // a hint of the expecte growth.
+  void writeFillBuffer(size_t WantedSize = Page::Size);
 
   void fail();
 };

--- a/src/stream/Page.h
+++ b/src/stream/Page.h
@@ -102,6 +102,8 @@ class Page : public std::enable_shared_from_this<Page> {
 
   size_t getMaxAddress() const { return MaxAddress; }
 
+  size_t getPageSize() const { return MaxAddress - MinAddress; }
+
   void setMaxAddress(size_t NewValue) { MaxAddress = NewValue; }
 
   void incrementMaxAddress(size_t Increment = 1) { MaxAddress += Increment; }

--- a/src/stream/Pipe.cpp
+++ b/src/stream/Pipe.cpp
@@ -1,0 +1,40 @@
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "stream/Pipe.h"
+
+namespace wasm {
+
+namespace decode {
+
+Pipe::PipeBackedQueue::~PipeBackedQueue() {
+  // NOTE: we must override the base destructor so that calls to dumpFirstPage
+  // is the one local to this class!
+  while (FirstPage)
+    dumpFirstPage();
+}
+
+void Pipe::PipeBackedQueue::dumpFirstPage() {
+  // TODO(karlschimpf) Optimize this!
+  for (size_t i = 0, Size = FirstPage->getPageSize(); i < Size; ++i)
+    MyPipe.WritePos.writeByte(FirstPage->Buffer[i]);
+  Queue::dumpFirstPage();
+}
+
+}  // end of decode namespace
+
+}  // end of wasm namespace

--- a/src/stream/Pipe.h
+++ b/src/stream/Pipe.h
@@ -1,0 +1,69 @@
+/* -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a pipe that associates a write queue with a read queue.
+
+// The pipe is set up to not copy output on the write queue to the
+// read queue, until all write cursors can no longer reference the
+// contents.
+
+#ifndef DECOMPRESSOR_SRC_STREAM_PIPE_H
+#define DECOMPRESSOR_SRC_STREAM_PIPE_H
+
+#include "stream/Queue.h"
+#include "stream/WriteCursor2ReadQueue.h"
+
+namespace wasm {
+
+namespace decode {
+
+class Pipe FINAL {
+  Pipe(const Pipe&) = delete;
+  Pipe& operator=(const Pipe&) = delete;
+
+ public:
+  Pipe()
+      : Input(std::make_shared<Queue>()),
+        Output(std::make_shared<PipeBackedQueue>(*this)),
+        WritePos(Output) {}
+  ~Pipe() {}
+  std::shared_ptr<Queue> getInput() const { return Input; }
+  std::shared_ptr<Queue> getOutput() const { return Output; }
+  class PipeBackedQueue FINAL : public Queue {
+    PipeBackedQueue(const PipeBackedQueue&) = delete;
+    PipeBackedQueue& operator=(const PipeBackedQueue&) = delete;
+    PipeBackedQueue() = delete;
+
+   public:
+    PipeBackedQueue(Pipe& MyPipe) : Queue(), MyPipe(MyPipe) {}
+    ~PipeBackedQueue();
+
+   private:
+    Pipe& MyPipe;
+    void dumpFirstPage() OVERRIDE;
+  };
+
+ private:
+  std::shared_ptr<Queue> Input;
+  std::shared_ptr<PipeBackedQueue> Output;
+  WriteCursor2ReadQueue WritePos;
+};
+
+}  // end of namespace decode
+
+}  // end of namespace wasm
+
+#endif  // DECOMPRESSOR_SRC_STREAM_PIPE_H

--- a/src/stream/Queue.cpp
+++ b/src/stream/Queue.cpp
@@ -121,23 +121,20 @@ bool Queue::readFill(size_t Address) {
   return Address < LastPage->getMaxAddress();
 }
 
-bool Queue::writeFill(size_t Address) {
+bool Queue::writeFill(size_t Address, size_t WantedSize) {
+  Address += WantedSize;
   // Expand till page exists.
-  while (Address >= LastPage->getMaxAddress()) {
+  while (Address > LastPage->getMaxAddress()) {
     if (EofFrozen)
       return false;
-#if 1
-    LastPage->setMaxAddress(LastPage->getMinAddress() + Page::Size);
-#else
-    size_t NewMax = Address + 1;
-    if (NewMax > Page::Size)
-      NewMax = Page::Size;
-    LastPage->setMaxAddress(LastPage->getMinAddress() + NewMax);
-#endif
-    if (Address < LastPage->getMaxAddress())
-      return true;
-    if (!appendPage())
-      return false;
+    size_t MaxLimit = LastPage->getMinAddress() + Page::Size;
+    if (Address >= MaxLimit) {
+      LastPage->setMaxAddress(MaxLimit);
+      if (!appendPage())
+        return false;
+    } else {
+      LastPage->setMaxAddress(Address);
+    }
   }
   return true;
 }
@@ -160,7 +157,7 @@ std::shared_ptr<Page> Queue::readFillToPage(size_t Index, size_t& Address) {
 
 std::shared_ptr<Page> Queue::writeFillToPage(size_t Index, size_t& Address) {
   while (Index > LastPage->Index) {
-    bool WriteFillNextPage = writeFill(LastPage->getMinAddress() + Page::Size);
+    bool WriteFillNextPage = writeFill(LastPage->getMinAddress(), Page::Size);
     if (!WriteFillNextPage && Index > LastPage->Index) {
       // This should only happen if we reach eof. Verify,
       // If so, allow page wrap so that we can have a cursor pointing
@@ -194,7 +191,7 @@ size_t Queue::writeToPage(size_t& Address,
                           size_t WantedSize,
                           PageCursor& Cursor) {
   // Expand till page exists.
-  if (!writeFill(Address))
+  if (!writeFill(Address, WantedSize))
     return 0;
   Cursor.CurPage = getCachedPage(Address);
   Cursor.setCurAddress(Address);

--- a/src/stream/Queue.cpp
+++ b/src/stream/Queue.cpp
@@ -18,6 +18,8 @@
 #include "stream/Queue.h"
 #include "stream/WriteUtils.h"
 
+#include <algorithm>
+
 namespace wasm {
 
 namespace decode {
@@ -124,7 +126,14 @@ bool Queue::writeFill(size_t Address) {
   while (Address >= LastPage->getMaxAddress()) {
     if (EofFrozen)
       return false;
+#if 1
     LastPage->setMaxAddress(LastPage->getMinAddress() + Page::Size);
+#else
+    size_t NewMax = Address + 1;
+    if (NewMax > Page::Size)
+      NewMax = Page::Size;
+    LastPage->setMaxAddress(LastPage->getMinAddress() + NewMax);
+#endif
     if (Address < LastPage->getMaxAddress())
       return true;
     if (!appendPage())

--- a/src/stream/Queue.h
+++ b/src/stream/Queue.h
@@ -301,7 +301,7 @@ class Queue : public std::enable_shared_from_this<Queue> {
   // buffer as appropriate.
   virtual bool readFill(size_t Address);
 
-  virtual bool writeFill(size_t Address);
+  virtual bool writeFill(size_t Address, size_t WantedSize);
 };
 
 }  // end of namespace decode

--- a/src/stream/WriteCursor.cpp
+++ b/src/stream/WriteCursor.cpp
@@ -27,27 +27,6 @@ void WriteCursor::writeFillWriteByte(uint8_t Byte) {
   writeOneByte(Byte);
 }
 
-void WriteCursor::writeBits(uint32_t Value, uint32_t NumBits) {
-  assert(NumBits <= sizeof(uint32_t) * CHAR_BIT);
-  while (NumBits > 0) {
-    const BitsInByteType AvailBits = CurByte.getWriteBitsRemaining();
-    if (AvailBits >= NumBits) {
-      CurByte.writeBits(Value, NumBits);
-      if (AvailBits == NumBits) {
-        writeByte(CurByte.getValue());
-        CurByte.reset();
-      }
-      return;
-    }
-    uint32_t Shift = NumBits - AvailBits;
-    CurByte.writeBits(Value >> Shift, AvailBits);
-    Value &= (uint32_t(1) << Shift) - 1;
-    NumBits -= AvailBits;
-    writeByte(CurByte.getValue());
-    CurByte.reset();
-  }
-}
-
 }  // end of namespace decode
 
 }  // end of namespace wasm

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -14,64 +14,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Defines a pointer to a byte stream for reading.
+// Defines a pointer to a byte stream for writing.
 
 #ifndef DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H
 #define DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H
 
-#include "stream/Cursor.h"
+#include "stream/WriteCursorBase.h"
 
 namespace wasm {
 
 namespace decode {
 
-class WriteCursor FINAL : public Cursor {
+class WriteCursor FINAL : public WriteCursorBase {
  public:
   // Note: The nullary write cursor should not be used until it has been
   // assigned a value.
-  WriteCursor() : Cursor() {}
+  WriteCursor() : WriteCursorBase() {}
 
-  WriteCursor(std::shared_ptr<Queue> Que) : Cursor(StreamType::Byte, Que) {}
+  WriteCursor(std::shared_ptr<Queue> Que) :
+      WriteCursorBase(StreamType::Byte, Que) {}
 
   WriteCursor(StreamType Type, std::shared_ptr<Queue> Que)
-      : Cursor(Type, Que) {}
+      : WriteCursorBase(Type, Que) {}
 
-  explicit WriteCursor(const WriteCursor& C) : Cursor(C) {}
+  explicit WriteCursor(const WriteCursor& C) : WriteCursorBase(C) {}
+
   WriteCursor(const Cursor& C, size_t StartAddress)
-      : Cursor(C, StartAddress, false) {}
+      : WriteCursorBase(C, StartAddress) {}
 
   ~WriteCursor() {}
 
-  WriteCursor& operator=(const WriteCursor& C) {
-    assign(C);
-    return *this;
-  }
-
-  BitsInByteType getBitsWritten() const { return CurByte.getBitsWritten(); }
-  BitAddress getCurWriteBitAddress() const {
-    BitAddress Address(CurAddress, getBitsWritten());
-    return Address;
-  }
-
-  // Writes next byte. Fails if at end of file. NOTE: Assumed byte aligned!
-  void writeByte(uint8_t Byte) {
-    assert(isByteAligned());
-    if (CurAddress < GuaranteedBeforeEob)
-      return writeOneByte(Byte);
-    writeFillWriteByte(Byte);
-  }
-
-  // Writes up to 32 bits to the output.
-  void writeBits(uint32_t Value, uint32_t NumBits);
-
  protected:
-  void writeOneByte(uint8_t Byte) {
-    assert(CurPage);
-    *getBufferPtr() = Byte;
-    ++CurAddress;
-  }
 
-  void writeFillWriteByte(uint8_t Byte);
+  void writeFillWriteByte(uint8_t Byte) OVERRIDE;
 };
 
 }  // end of namespace decode

--- a/src/stream/WriteCursor2ReadQueue.cpp
+++ b/src/stream/WriteCursor2ReadQueue.cpp
@@ -1,0 +1,32 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stream/WriteCursor2ReadQueue.h"
+
+namespace wasm {
+
+namespace decode {
+
+void WriteCursor2ReadQueue::writeFillWriteByte(uint8_t Byte) {
+  if (isIndexAtEndOfPage())
+    writeFillBuffer(1);
+  updateGuaranteedBeforeEob();
+  writeOneByte(Byte);
+}
+
+}  // end of namespace decode
+
+}  // end of namespace wasm

--- a/src/stream/WriteCursor2ReadQueue.h
+++ b/src/stream/WriteCursor2ReadQueue.h
@@ -14,10 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Defines a pointer to a byte stream for writing.
+// Defines a pointer to a byte stream for writing, where the byte stream
+// is the input to a later step. Hence, it doesn't advance the byte stream
+// beyond defined results, so that the corresponding read cursors can
+// assume all contents is defined.
 
-#ifndef DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H
-#define DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H
+#ifndef DECOMPRESSOR_SRC_STREAM_WRITECURSOR2READQUEUE_H
+#define DECOMPRESSOR_SRC_STREAM_WRITECURSOR2READQUEUE_H
 
 #include "stream/WriteCursorBase.h"
 
@@ -25,24 +28,25 @@ namespace wasm {
 
 namespace decode {
 
-class WriteCursor FINAL : public WriteCursorBase {
+class WriteCursor2ReadQueue FINAL : public WriteCursorBase {
  public:
   // Note: The nullary write cursor should not be used until it has been
   // assigned a value.
-  WriteCursor() : WriteCursorBase() {}
+  WriteCursor2ReadQueue() : WriteCursorBase() {}
 
-  WriteCursor(std::shared_ptr<Queue> Que)
+  WriteCursor2ReadQueue(std::shared_ptr<Queue> Que)
       : WriteCursorBase(StreamType::Byte, Que) {}
 
-  WriteCursor(StreamType Type, std::shared_ptr<Queue> Que)
+  WriteCursor2ReadQueue(StreamType Type, std::shared_ptr<Queue> Que)
       : WriteCursorBase(Type, Que) {}
 
-  explicit WriteCursor(const WriteCursor& C) : WriteCursorBase(C) {}
+  explicit WriteCursor2ReadQueue(const WriteCursor2ReadQueue& C)
+      : WriteCursorBase(C) {}
 
-  WriteCursor(const Cursor& C, size_t StartAddress)
+  WriteCursor2ReadQueue(const Cursor& C, size_t StartAddress)
       : WriteCursorBase(C, StartAddress) {}
 
-  ~WriteCursor() {}
+  ~WriteCursor2ReadQueue() {}
 
  protected:
   void writeFillWriteByte(uint8_t Byte) OVERRIDE;
@@ -52,4 +56,4 @@ class WriteCursor FINAL : public WriteCursorBase {
 
 }  // end of namespace wasm
 
-#endif  // DECOMPRESSOR_SRC_STREAM_WRITECURSOR_H
+#endif  // DECOMPRESSOR_SRC_STREAM_WRITECURSOR2READQUEUE_H

--- a/src/stream/WriteCursorBase.cpp
+++ b/src/stream/WriteCursorBase.cpp
@@ -1,0 +1,46 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stream/WriteCursorBase.h"
+
+namespace wasm {
+
+namespace decode {
+
+void WriteCursorBase::writeBits(uint32_t Value, uint32_t NumBits) {
+  assert(NumBits <= sizeof(uint32_t) * CHAR_BIT);
+  while (NumBits > 0) {
+    const BitsInByteType AvailBits = CurByte.getWriteBitsRemaining();
+    if (AvailBits >= NumBits) {
+      CurByte.writeBits(Value, NumBits);
+      if (AvailBits == NumBits) {
+        writeByte(CurByte.getValue());
+        CurByte.reset();
+      }
+      return;
+    }
+    uint32_t Shift = NumBits - AvailBits;
+    CurByte.writeBits(Value >> Shift, AvailBits);
+    Value &= (uint32_t(1) << Shift) - 1;
+    NumBits -= AvailBits;
+    writeByte(CurByte.getValue());
+    CurByte.reset();
+  }
+}
+
+}  // end of namespace decode
+
+}  // end of namespace wasm

--- a/src/stream/WriteCursorBase.h
+++ b/src/stream/WriteCursorBase.h
@@ -1,0 +1,81 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines the base class of a pointer to a byte stream for writing.
+
+#ifndef DECOMPRESSOR_SRC_STREAM_WRITECURSORBASE_H
+#define DECOMPRESSOR_SRC_STREAM_WRITECURSORBASE_H
+
+#include "stream/Cursor.h"
+
+namespace wasm {
+
+namespace decode {
+
+class WriteCursorBase : public Cursor {
+ public:
+  // Note: The nullary write cursor should not be used until it has been
+  // assigned a value.
+  WriteCursorBase() : Cursor() {}
+
+  WriteCursorBase(std::shared_ptr<Queue> Que) : Cursor(StreamType::Byte, Que) {}
+
+  WriteCursorBase(StreamType Type, std::shared_ptr<Queue> Que)
+      : Cursor(Type, Que) {}
+
+  explicit WriteCursorBase(const WriteCursorBase& C) : Cursor(C) {}
+  WriteCursorBase(const Cursor& C, size_t StartAddress)
+      : Cursor(C, StartAddress, false) {}
+
+  ~WriteCursorBase() {}
+
+  WriteCursorBase& operator=(const WriteCursorBase& C) {
+    assign(C);
+    return *this;
+  }
+
+  BitsInByteType getBitsWritten() const { return CurByte.getBitsWritten(); }
+  BitAddress getCurWriteBitAddress() const {
+    BitAddress Address(CurAddress, getBitsWritten());
+    return Address;
+  }
+
+  // Writes next byte. Fails if at end of file. NOTE: Assumed byte aligned!
+  void writeByte(uint8_t Byte) {
+    assert(isByteAligned());
+    if (CurAddress < GuaranteedBeforeEob)
+      return writeOneByte(Byte);
+    writeFillWriteByte(Byte);
+  }
+
+  // Writes up to 32 bits to the output.
+  void writeBits(uint32_t Value, uint32_t NumBits);
+
+ protected:
+  void writeOneByte(uint8_t Byte) {
+    assert(CurPage);
+    *getBufferPtr() = Byte;
+    ++CurAddress;
+  }
+
+  virtual void writeFillWriteByte(uint8_t Byte) = 0;
+};
+
+}  // end of namespace decode
+
+}  // end of namespace wasm
+
+#endif  // DECOMPRESSOR_SRC_STREAM_WRITECURSORBASE_H

--- a/src/test/TestByteQueues.cpp
+++ b/src/test/TestByteQueues.cpp
@@ -128,12 +128,12 @@ int main(int Argc, char* Argv[]) {
       size_t WriteBytesAvailable =
           Output->writeToPage(Address, ReadBytesAvailable, WritePos);
       if (WriteBytesAvailable == 0) {
-        fprintf(stderr, "Unable to write address %d, returned zero bytes",
+        fprintf(stderr, "Unable to write address %d, returned zero bytes\n",
                 int(Address));
         return exit_status(EXIT_FAILURE);
       }
       if (WriteBytesAvailable > ReadBytesAvailable) {
-        fprintf(stderr, "Unable to write address %d, returned %d extra bytes",
+        fprintf(stderr, "Unable to write address %d, returned %d extra bytes\n",
                 int(Address), int(WriteBytesAvailable - ReadBytesAvailable));
         return exit_status(EXIT_FAILURE);
       }


### PR DESCRIPTION
Got most of the C API implemented. The remaining problem is returning the output.

Discovered that sharing a stream (i.e. Queue) between readers and writers is not currently possible because the current code doesn't have a way to not allow readers past writers. This is needed because in a block, a writer is kept at the beginning of the block, and then "backpatches" the size once it is known. Solved the problem by implementing a "Pipe" that uses two streams: an input and an output stream. The input stream is written to. As pages are filled in the input, and have no writers, they are copied to the output stream.

In addition, I discovered that we can't use a "write" cursor to fill an input stream. The reason is that writeFill() always created a new page (to reduce the number of calls to grow the stream). The code was modified to accept an argument for fill size. This allows the "write" cursor to cause the stream to only grow as data is available.

Also simplified the C api for decompression, simplying the implementation.
