### PR TITLE
Start removing interpreter methods Read and Write

### DIFF
--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -223,7 +223,7 @@ int main(int Argc, char* Argv[]) {
   auto Symtab = std::make_shared<SymbolTable>();
   Symtab->getTrace().setTraceProgress(Verbose >= 4);
   if (InstallPredefinedRules &&
-      !SymbolTable::installPredefinedDefaults(Symtab, Verbose)) {
+      !SymbolTable::installPredefinedDefaults(Symtab, Verbose >= 2)) {
     fprintf(stderr, "Unable to load compiled in default rules!\n");
     return exit_status(EXIT_FAILURE);
   }

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -280,9 +280,13 @@ void Interpreter::callTopLevel(Method Method, const filt::Node* Nd) {
 }
 
 void Interpreter::traceEnterFrameInternal() {
-  TRACE_ENTER(getName(Frame.CallMethod));
-  if (Frame.CallModifier != MethodModifier::ReadAndWrite)
-    TRACE_MESSAGE(std::string("(") + getName(Frame.CallModifier) + ")");
+  // Note: Enclosed in TRACE_BLOCK so that g++ will not complain when
+  // compiled in release mode.
+  TRACE_BLOCK({
+    TRACE_ENTER(getName(Frame.CallMethod));
+    if (Frame.CallModifier != MethodModifier::ReadAndWrite)
+      TRACE_MESSAGE(std::string("(") + getName(Frame.CallModifier) + ")");
+  });
 }
 
 void Interpreter::readBackFilled() {

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -63,32 +63,59 @@ static constexpr uint32_t MaxExpectedSectionNameSize = 32;
 static constexpr size_t DefaultStackSize = 256;
 static constexpr size_t DefaultExpectedLocals = 3;
 
-#define X(tag, name) constexpr const char* Method##tag##Name = name;
-INTERPRETER_METHODS_TABLE
+const char* SectionCodeName[] = {
+#define X(code, value) #code
+  SECTION_CODES_TABLE
 #undef X
+};
 
 const char* MethodName[] = {
-#define X(tag, name) Method##tag##Name,
+#define X(tag) #tag,
     INTERPRETER_METHODS_TABLE
 #undef X
     "NO_SUCH_METHOD"};
 
 const char* StateName[] = {
-#define X(tag, name) name,
-    INTERPRETER_STATES_TABLE
+#define X(tag) #tag,
+  INTERPRETER_STATES_TABLE
 #undef X
     "NO_SUCH_STATE"};
+
+const char* MethodModifierName[] = {
+#define X(tag, flags) #tag,
+  INTERPRETER_METHOD_MODIFIERS_TABLE
+#undef X
+  "NO_SUCH_METHOD_MODIFIER"
+};
 
 }  // end of anonymous namespace
 
 const char* Interpreter::getName(Method M) {
   size_t Index = size_t(M);
-  return Index < size(MethodName) ? MethodName[Index] : "NO_SUCH_METHOD";
+  if (Index >= size(MethodName))
+    Index = size_t(Method::NO_SUCH_METHOD);
+  return MethodName[Index];
+}
+
+const char* Interpreter::getName(MethodModifier Modifier) {
+  size_t Index = size_t(Modifier);
+  if (Index >= size(MethodModifierName))
+    Index = size_t(MethodModifier::NO_SUCH_METHOD_MODIFIER);
+  return MethodModifierName[Index];
 }
 
 const char* Interpreter::getName(State S) {
   size_t Index = size_t(S);
-  return Index < size(StateName) ? StateName[Index] : "NO_SUCH_STATE";
+  if (Index >= size(StateName))
+    Index = size_t(State::NO_SUCH_STATE);
+  return StateName[Index];
+}
+
+const char* Interpreter::getName(SectionCode Code) {
+  size_t Index = size_t(Code);
+  if (Index >= size(SectionCodeName))
+    Index = size_t(SectionCode::NO_SUCH_SECTION_CODE);
+  return SectionCodeName[Index];
 }
 
 Interpreter::Interpreter(std::shared_ptr<Queue> Input,
@@ -124,8 +151,8 @@ Interpreter::Interpreter(std::shared_ptr<Queue> Input,
 }
 
 void Interpreter::CallFrame::describe(FILE* File, TextWriter* Writer) const {
-  fprintf(File, "%s.%s = %" PRIuMAX ": ", getName(CallMethod),
-          getName(CallState), uintmax_t(ReturnValue));
+  fprintf(File, "%s.%s (%s) = %" PRIuMAX ": ", getName(CallMethod),
+          getName(CallState), getName(CallModifier), uintmax_t(ReturnValue));
   if (Nd)
     Writer->writeAbbrev(File, Nd);
   else
@@ -253,6 +280,12 @@ void Interpreter::callTopLevel(Method Method, const filt::Node* Nd) {
   call(Method, Nd);
 }
 
+void Interpreter::traceEnterFrameInternal() {
+  TRACE_ENTER(getName(Frame.CallMethod));
+  if (Frame.CallModifier != MethodModifier::ReadAndWrite)
+    TRACE_MESSAGE(std::string("(") + getName(Frame.CallModifier) + ")");
+}
+
 void Interpreter::readBackFilled() {
 #if LOG_RUNMETHODS
   TRACE_METHOD("readBackFilled");
@@ -268,7 +301,7 @@ void Interpreter::readBackFilled() {
 void Interpreter::fail() {
   TRACE_MESSAGE("method failed");
   while (!FrameStack.empty()) {
-    TraceExitFrame();
+    traceExitFrame();
     popAndReturn();
   }
   Frame.fail();
@@ -321,7 +354,7 @@ void Interpreter::resume() {
       case Method::CopyBlock:
         switch (Frame.CallState) {
           case State::Enter:
-            TraceEnterFrame();
+            traceEnterFrame();
             Frame.CallState = State::Loop;
             break;
           case State::Loop:
@@ -333,7 +366,7 @@ void Interpreter::resume() {
             break;
           case State::Exit:
             popAndReturn();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           default:
             failBadState();
@@ -374,37 +407,54 @@ void Interpreter::resume() {
           case OpUnknownSection:
           case OpCasmVersion:
           case OpWasmVersion:  // Method::Eval
-            fail("Not allowed!");
+            failNotImplemented();
             break;
           case OpError:  // Method::Eval
-            TraceEnterFrame();
+            traceEnterFrame();
             fail("Algorithm error!");
             break;
           case OpCallback:  // Method::Eval
             // TODO(karlschimpf): All virtual calls to class so that derived
             // classes can override.
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturn(Frame.ReturnValue);
-            TraceExitFrame();
+            traceExitFrame();
             break;
+            /* here */
           case OpI32Const:
           case OpI64Const:
           case OpU8Const:
           case OpU32Const:
-          case OpU64Const:
+          case OpU64Const: // Method::Eval
+            traceEnterFrame();
+            switch (Frame.CallModifier) {
+              case MethodModifier::NoReadOrWrite:
+              case MethodModifier::NO_SUCH_METHOD_MODIFIER:
+                fail("Bad method modifier on integer constant");
+                break;
+              case MethodModifier::ReadOnly:
+              case MethodModifier::ReadAndWrite:
+                popAndReturnReadValue(dyn_cast<IntegerNode>(Frame.Nd)->getValue());
+                break;
+              case MethodModifier::WriteOnly:
+                popAndReturnWriteValue();
+                break;
+            }
+            traceExitFrame();
+            break;
           case OpLastRead:
           case OpLocal:
           case OpPeek:
           case OpRead:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 call(Method::Read, Frame.Nd);
                 break;
               case State::Exit:
                 popAndReturn(Frame.ReturnValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -422,7 +472,7 @@ void Interpreter::resume() {
           case OpOpcode:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Read, Frame.Nd);
                 break;
@@ -432,7 +482,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturn(Frame.ReturnValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -442,7 +492,7 @@ void Interpreter::resume() {
           case OpSet:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 call(Method::Eval, Frame.Nd->getKid(1));
                 break;
@@ -455,7 +505,7 @@ void Interpreter::resume() {
                 }
                 LocalValues[LocalsBase + Index] = Frame.ReturnValue;
                 popAndReturn(Frame.ReturnValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               }
               default:
@@ -466,7 +516,7 @@ void Interpreter::resume() {
           case OpWrite:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Read, Frame.Nd->getKid(0));
                 break;
@@ -477,7 +527,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturn(Frame.ReturnValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -485,14 +535,14 @@ void Interpreter::resume() {
             }
             break;
           case OpStream: {  // Method::Eval
-            TraceEnterFrame();
+            traceEnterFrame();
             const auto* Stream = cast<StreamNode>(Frame.Nd);
             switch (Stream->getStreamKind()) {
               case StreamKind::Input:
                 switch (Stream->getStreamType()) {
                   case StreamType::Byte:
                     popAndReturn(int(isa<ByteReadStream>(Reader.get())));
-                    TraceExitFrame();
+                    traceExitFrame();
                     break;
                   case StreamType::Bit:
                   case StreamType::Int:
@@ -506,7 +556,7 @@ void Interpreter::resume() {
                 switch (Stream->getStreamType()) {
                   case StreamType::Byte:
                     popAndReturn(int(isa<ByteReadStream>(Writer.get())));
-                    TraceExitFrame();
+                    traceExitFrame();
                     break;
                   case StreamType::Bit:
                   case StreamType::Int:
@@ -522,13 +572,13 @@ void Interpreter::resume() {
           case OpNot:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 call(Method::Eval, Frame.Nd->getKid(0));
                 break;
               case State::Exit:
                 popAndReturn(Frame.ReturnValue != 0);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -538,7 +588,7 @@ void Interpreter::resume() {
           case OpAnd:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Eval, Frame.Nd->getKid(0));
                 break;
@@ -549,7 +599,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturn(Frame.ReturnValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -559,7 +609,7 @@ void Interpreter::resume() {
           case OpOr:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Eval, Frame.Nd->getKid(0));
                 break;
@@ -570,7 +620,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturn(Frame.ReturnValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -580,7 +630,7 @@ void Interpreter::resume() {
           case OpSequence:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 LoopCounterStack.push(0);
                 Frame.CallState = State::Loop;
                 break;
@@ -594,7 +644,7 @@ void Interpreter::resume() {
               case State::Exit:
                 LoopCounterStack.pop();
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -604,7 +654,7 @@ void Interpreter::resume() {
           case OpLoop:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Eval, Frame.Nd->getKid(0));
                 break;
@@ -622,7 +672,7 @@ void Interpreter::resume() {
               case State::Exit:
                 LoopCounterStack.pop();
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -632,7 +682,7 @@ void Interpreter::resume() {
           case OpLoopUnbounded:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Loop;
                 break;
               case State::Loop:
@@ -644,7 +694,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -654,7 +704,7 @@ void Interpreter::resume() {
           case OpIfThen:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Eval, Frame.Nd->getKid(0));
                 break;
@@ -665,7 +715,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -675,7 +725,7 @@ void Interpreter::resume() {
           case OpIfThenElse:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Eval, Frame.Nd->getKid(0));
                 break;
@@ -688,7 +738,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -698,7 +748,7 @@ void Interpreter::resume() {
           case OpSwitch:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Eval, Frame.Nd->getKid(0));
                 break;
@@ -713,7 +763,7 @@ void Interpreter::resume() {
               }
               case State::Exit:
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -723,13 +773,13 @@ void Interpreter::resume() {
           case OpCase:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 call(Method::Eval, Frame.Nd->getKid(1));
                 break;
               case State::Exit:
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -739,7 +789,7 @@ void Interpreter::resume() {
           case OpDefine:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 if (size_t NumLocals =
                         cast<DefineNode>(Frame.Nd)->getNumLocals()) {
                   LocalsBaseStack.push(LocalValues.size());
@@ -756,7 +806,7 @@ void Interpreter::resume() {
                   LocalsBaseStack.pop();
                 }
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -766,14 +816,14 @@ void Interpreter::resume() {
           case OpParam:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 DispatchedMethod = Method::Eval;
                 call(Method::EvalParam, Frame.Nd);
                 break;
               case State::Exit:
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -783,7 +833,7 @@ void Interpreter::resume() {
           case OpEval:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter: {
-                TraceEnterFrame();
+                traceEnterFrame();
                 auto* Sym = dyn_cast<SymbolNode>(Frame.Nd->getKid(0));
                 assert(Sym);
                 auto* Defn = dyn_cast<DefineNode>(Sym->getDefineDefinition());
@@ -810,7 +860,7 @@ void Interpreter::resume() {
               case State::Exit:
                 CallingEvalStack.pop();
                 popAndReturn(Frame.ReturnValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -820,7 +870,7 @@ void Interpreter::resume() {
           case OpBlock:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
 #if LOG_FUNCTIONS || LOG_NUMBERED_BLOCK
                 // NOTE: This assumes that blocks (outside of sections) are only
                 // used to define functions.
@@ -847,7 +897,7 @@ void Interpreter::resume() {
                 ++LogBlockCount;
 #endif
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -856,16 +906,16 @@ void Interpreter::resume() {
             break;
           case OpLocals:
           case OpVoid:  // Method::Eval
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturn();
-            TraceExitFrame();
+            traceExitFrame();
             break;
         }
         break;
       case Method::EvalBlock:
         switch (Frame.CallState) {
           case State::Enter: {
-            TraceEnterFrame();
+            traceEnterFrame();
             const uint32_t OldSize = Reader->readBlockSize(ReadPos);
             TRACE(uint32_t, "block size", OldSize);
             Reader->pushEobAddress(ReadPos, OldSize);
@@ -913,7 +963,7 @@ void Interpreter::resume() {
             BlockStartStack.pop();
             ReadPos.popEobAddress();
             popAndReturn();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           default:
             failBadState();
@@ -939,7 +989,7 @@ void Interpreter::resume() {
       case Method::EvalParam:
         switch (Frame.CallState) {
           case State::Enter: {
-            TraceEnterFrame();
+            traceEnterFrame();
             if (CallingEvalStack.empty()) {
               fail(
                   "Not inside a call frame, can't evaluate parameter "
@@ -964,7 +1014,7 @@ void Interpreter::resume() {
           case State::Exit:
             CallingEvalStack.pop();
             popAndReturn(Frame.ReturnValue);
-            TraceExitFrame();
+            traceExitFrame();
             break;
           default:
             failBadState();
@@ -1010,21 +1060,32 @@ void Interpreter::resume() {
             failNotImplemented();
             break;
           case OpCallback:  // Method::Read
-            TraceEnterFrame();
+#if 0
+#endif
+            traceEnterFrame();
+            call(Method::Eval, MethodModifier::ReadOnly, Frame.Nd);
             popAndReturnReadValue(LastReadValue);
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpI32Const:
           case OpI64Const:
           case OpU8Const:
           case OpU32Const:
           case OpU64Const:  // Method::Read
-            TraceEnterFrame();
-            popAndReturnReadValue(dyn_cast<IntegerNode>(Frame.Nd)->getValue());
-            TraceExitFrame();
+#if 1
+            traceEnterFrame();
+            call(Method::Eval, MethodModifier::ReadOnly, Frame.Nd);
+            popAndReturnReadValue(LastReadValue);
+            traceExitFrame();
             break;
+#else
+            traceEnterFrame();
+            popAndReturnReadValue(dyn_cast<IntegerNode>(Frame.Nd)->getValue());
+            traceExitFrame();
+            break;
+#endif
           case OpLocal: {  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             const auto* Local = dyn_cast<LocalNode>(Frame.Nd);
             size_t Index = Local->getValue();
             if (LocalsBase + Index >= LocalValues.size()) {
@@ -1032,20 +1093,20 @@ void Interpreter::resume() {
               break;
             }
             popAndReturnReadValue(LocalValues[LocalsBase + Index]);
-            TraceExitFrame();
+            traceExitFrame();
             break;
           }
           case OpParam:  // Method::Read
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 DispatchedMethod = Method::Read;
                 call(Method::EvalParam, Frame.Nd);
                 break;
               case State::Exit:
                 popAndReturnReadValue(LastReadValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1055,7 +1116,7 @@ void Interpreter::resume() {
           case OpPeek: {  // Method::Read
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 PeekPosStack.push(ReadPos);
                 Frame.CallState = State::Exit;
                 call(Method::Read, Frame.Nd->getKid(0));
@@ -1064,7 +1125,7 @@ void Interpreter::resume() {
                 ReadPos = PeekPos;
                 PeekPosStack.pop();
                 popAndReturnReadValue(LastReadValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1073,56 +1134,56 @@ void Interpreter::resume() {
             break;
           }
           case OpLastRead:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(LastReadValue);
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpUint8:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(Reader->readUint8Bits(
                 ReadPos, cast<Uint8Node>(Frame.Nd)->getValue()));
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpUint32:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(Reader->readUint32Bits(
                 ReadPos, cast<Uint32Node>(Frame.Nd)->getValue()));
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpUint64:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(Reader->readUint64Bits(
                 ReadPos, cast<Uint64Node>(Frame.Nd)->getValue()));
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpVarint32:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(Reader->readVarint32Bits(
                 ReadPos, cast<Varint32Node>(Frame.Nd)->getValue()));
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpVarint64:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(Reader->readVarint64Bits(
                 ReadPos, cast<Varint64Node>(Frame.Nd)->getValue()));
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpVaruint32:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(Reader->readVaruint32Bits(
                 ReadPos, cast<Varuint32Node>(Frame.Nd)->getValue()));
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpVaruint64:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(Reader->readVaruint64Bits(
                 ReadPos, cast<Varuint64Node>(Frame.Nd)->getValue()));
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpOpcode:  // Method::Read
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 OpcodeLocalsStack.push();
                 OpcodeLocals.reset();
                 Frame.CallState = State::Exit;
@@ -1132,7 +1193,7 @@ void Interpreter::resume() {
                 LastReadValue = OpcodeLocals.CaseMask;
                 OpcodeLocalsStack.pop();
                 popAndReturn(LastReadValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1142,7 +1203,7 @@ void Interpreter::resume() {
           case OpMap: {  // Method::Read
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::Read, Frame.Nd);
                 break;
@@ -1153,7 +1214,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturn(Frame.ReturnValue);
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1163,16 +1224,16 @@ void Interpreter::resume() {
           }
           case OpLocals:
           case OpVoid:  // Method::Read
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnReadValue(0);
-            TraceExitFrame();
+            traceExitFrame();
             break;
         }
         break;
       case Method::GetFile:
         switch (Frame.CallState) {
           case State::Enter:
-            TraceEnterFrame();
+            traceEnterFrame();
             MagicNumber = Reader->readUint32(ReadPos);
             TRACE(hex_uint32_t, "magic number", MagicNumber);
             if (MagicNumber != WasmBinaryMagic) {
@@ -1200,7 +1261,7 @@ void Interpreter::resume() {
           case State::Exit:
             WritePos.freezeEof();
             popAndReturn();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           default:
             failBadState();
@@ -1210,7 +1271,7 @@ void Interpreter::resume() {
       case Method::GetSecName:
         switch (Frame.CallState) {
           case State::Enter:
-            TraceEnterFrame();
+            traceEnterFrame();
             CurSectionName.clear();
             LoopCounterStack.push(Reader->readVaruint32(ReadPos));
             Writer->writeVaruint32(LoopCounter, WritePos);
@@ -1229,7 +1290,7 @@ void Interpreter::resume() {
           }
           case State::Exit:
             popAndReturn();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           default:
             failBadState();
@@ -1239,7 +1300,7 @@ void Interpreter::resume() {
       case Method::GetSection:
         switch (Frame.CallState) {
           case State::Enter:
-            TraceEnterFrame();
+            traceEnterFrame();
             assert(isa<ByteReadStream>(Reader.get()));
 #if LOG_SECTIONS
             TRACE(hex_size_t, "SectionAddress", ReadPos.getCurByteAddress());
@@ -1263,7 +1324,7 @@ void Interpreter::resume() {
             Reader->alignToByte(ReadPos);
             Writer->alignToByte(WritePos);
             popAndReturn();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           default:
             failBadState();
@@ -1279,7 +1340,7 @@ void Interpreter::resume() {
           case OpOpcode:  // Method::ReadOpcode
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Step2;
                 call(Method::ReadOpcode, Frame.Nd->getKid(0));
                 break;
@@ -1307,7 +1368,7 @@ void Interpreter::resume() {
               }
               case State::Exit:
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1316,7 +1377,7 @@ void Interpreter::resume() {
           case OpUint8:  // Method::ReadOpcode
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 call(Method::Read, Frame.Nd);
                 break;
@@ -1324,7 +1385,7 @@ void Interpreter::resume() {
                 OpcodeLocals.CaseMask = Frame.ReturnValue;
                 OpcodeLocals.SelShift = cast<Uint8Node>(Frame.Nd)->getValue();
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1333,7 +1394,7 @@ void Interpreter::resume() {
           case OpUint32:  // Method::ReadOpcode
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 call(Method::Read, Frame.Nd);
                 break;
@@ -1341,7 +1402,7 @@ void Interpreter::resume() {
                 OpcodeLocals.CaseMask = Frame.ReturnValue;
                 OpcodeLocals.SelShift = cast<Uint32Node>(Frame.Nd)->getValue();
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1351,7 +1412,7 @@ void Interpreter::resume() {
           case OpUint64:  // Method::ReadOpcode
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 call(Method::Read, Frame.Nd);
                 break;
@@ -1359,7 +1420,7 @@ void Interpreter::resume() {
                 OpcodeLocals.CaseMask = Frame.ReturnValue;
                 OpcodeLocals.SelShift = cast<Uint64Node>(Frame.Nd)->getValue();
                 popAndReturn();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1418,21 +1479,22 @@ void Interpreter::resume() {
             failNotImplemented();
             break;
           case OpCallback:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
+            call(Method::Eval, MethodModifier::WriteOnly, Frame.Nd);
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpParam:  // Method::Write
             switch (Frame.CallState) {
               case State::Enter:
-                TraceEnterFrame();
+                traceEnterFrame();
                 Frame.CallState = State::Exit;
                 DispatchedMethod = Method::Write;
                 callWrite(Method::EvalParam, Frame.Nd, WriteValue);
                 break;
               case State::Exit:
                 popAndReturnWriteValue();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();
@@ -1440,73 +1502,85 @@ void Interpreter::resume() {
             }
             break;
           case OpUint8:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
             Writer->writeUint8Bits(WriteValue, WritePos,
                                    cast<Uint8Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpUint32:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
             Writer->writeUint32Bits(WriteValue, WritePos,
                                     cast<Uint32Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpUint64:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
             Writer->writeUint64Bits(WriteValue, WritePos,
                                     cast<Uint64Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpVarint32:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
             Writer->writeVarint32Bits(WriteValue, WritePos,
                                       cast<Varint32Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpVarint64:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
             Writer->writeVarint64Bits(WriteValue, WritePos,
                                       cast<Varint64Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpVaruint32:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
             Writer->writeVaruint32Bits(
                 WriteValue, WritePos,
                 cast<Varuint32Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpVaruint64:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
             Writer->writeVaruint64Bits(
                 WriteValue, WritePos,
                 cast<Varuint64Node>(Frame.Nd)->getValue());
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpI32Const:
           case OpI64Const:
           case OpU8Const:
           case OpU32Const:
           case OpU64Const:
+#if 1
+            traceEnterFrame();
+            call(Method::Eval, MethodModifier::WriteOnly, Frame.Nd);
+            popAndReturn(Frame.ReturnValue);
+            traceExitFrame();
+            break;
+#else
+            traceEnterFrame();
+            popAndReturnWriteValue();
+            traceExitFrame();
+            break;
+#endif
           case OpPeek:
           case OpMap:
           case OpLocals:
           case OpVoid:  // Method::Write
-            TraceEnterFrame();
+            traceEnterFrame();
             popAndReturnWriteValue();
-            TraceExitFrame();
+            traceExitFrame();
             break;
           case OpOpcode: {  // Method::Write
             switch (Frame.CallState) {
               case State::Enter: {
-                TraceEnterFrame();
+                traceEnterFrame();
                 const auto* Sel = cast<OpcodeNode>(Frame.Nd);
                 OpcodeLocalsStack.push();
                 OpcodeLocals.Case = Sel->getWriteCase(
@@ -1527,7 +1601,7 @@ void Interpreter::resume() {
                 break;
               case State::Exit:
                 popAndReturnWriteValue();
-                TraceExitFrame();
+                traceExitFrame();
                 break;
               default:
                 failBadState();

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -65,7 +65,7 @@ static constexpr size_t DefaultExpectedLocals = 3;
 
 const char* SectionCodeName[] = {
 #define X(code, value) #code
-  SECTION_CODES_TABLE
+    SECTION_CODES_TABLE
 #undef X
 };
 
@@ -77,16 +77,15 @@ const char* MethodName[] = {
 
 const char* StateName[] = {
 #define X(tag) #tag,
-  INTERPRETER_STATES_TABLE
+    INTERPRETER_STATES_TABLE
 #undef X
     "NO_SUCH_STATE"};
 
 const char* MethodModifierName[] = {
 #define X(tag, flags) #tag,
-  INTERPRETER_METHOD_MODIFIERS_TABLE
+    INTERPRETER_METHOD_MODIFIERS_TABLE
 #undef X
-  "NO_SUCH_METHOD_MODIFIER"
-};
+    "NO_SUCH_METHOD_MODIFIER"};
 
 }  // end of anonymous namespace
 
@@ -420,12 +419,12 @@ void Interpreter::resume() {
             popAndReturn(Frame.ReturnValue);
             traceExitFrame();
             break;
-            /* here */
+          /* here */
           case OpI32Const:
           case OpI64Const:
           case OpU8Const:
           case OpU32Const:
-          case OpU64Const: // Method::Eval
+          case OpU64Const:  // Method::Eval
             traceEnterFrame();
             switch (Frame.CallModifier) {
               case MethodModifier::NoReadOrWrite:
@@ -434,7 +433,8 @@ void Interpreter::resume() {
                 break;
               case MethodModifier::ReadOnly:
               case MethodModifier::ReadAndWrite:
-                popAndReturnReadValue(dyn_cast<IntegerNode>(Frame.Nd)->getValue());
+                popAndReturnReadValue(
+                    dyn_cast<IntegerNode>(Frame.Nd)->getValue());
                 break;
               case MethodModifier::WriteOnly:
                 popAndReturnWriteValue();
@@ -442,6 +442,7 @@ void Interpreter::resume() {
             }
             traceExitFrame();
             break;
+          /* here */
           case OpLastRead:
           case OpLocal:
           case OpPeek:

--- a/src/interp/Interpreter.def
+++ b/src/interp/Interpreter.def
@@ -19,32 +19,53 @@
 #ifndef DECOMPRESSOR_SRC_INTERP_INTERPRETER_DEF
 #define DECOMPRESSOR_SRC_INTERP_INTERPRETER_DEF
 
-//#define X(tag, name)
-#define INTERPRETER_METHODS_TABLE                                              \
-  /* enum name , text name */                                                  \
-  X(CopyBlock,   "copyBlock")                                                  \
-  X(Eval,        "eval")                                                       \
-  X(EvalBlock,   "evalBlock")                                                  \
-  X(EvalParam,   "evalParam")                                                  \
-  X(Finished,    "finished")                                                   \
-  X(GetFile,     "getFile")                                                    \
-  X(GetSecName,  "getSecName")                                                 \
-  X(GetSection,  "getSection")                                                 \
-  X(Read,        "read")                                                       \
-  X(ReadOpcode,  "readOpcode")                                                 \
-  X(Started,     "started")                                                    \
-  X(Write,       "write")                                                      \
+//#define X(code, value)
+#define SECTION_CODES_TABLE \
+X(Unknown, 0)               \
+X(Type, 1)                  \
+X(Import, 2)                \
+X(Function, 3)              \
+X(Table, 4)                 \
+X(Memory, 5)                \
+X(Global, 6)                \
+X(Export, 7)                \
+X(Start, 8)                 \
+X(Elem, 9)                  \
+X(Code, 10)                 \
+X(Data, 11)
 
-//#define X(tag, name)
-#define INTERPRETER_STATES_TABLE                                               \
-  /* enum name, text name */                                                   \
-  X(Enter,     "enter")                                                        \
-  X(Exit,      "exit")                                                         \
-  X(Loop,      "loop")                                                         \
-  X(Failed,    "failed")                                                       \
-  X(MinBlock,  "minimize block")                                               \
-  X(Step2,     "Step2")                                                        \
-  X(Step3,     "Step3")                                                        \
-  X(Succeeded, "Succeeded")                                                    \
+//#define X(tag)
+#define INTERPRETER_METHODS_TABLE                             \
+X(CopyBlock)                                                  \
+X(Eval)                                                       \
+X(EvalBlock)                                                  \
+X(EvalParam)                                                  \
+X(Finished)                                                   \
+X(GetFile)                                                    \
+X(GetSecName)                                                 \
+X(GetSection)                                                 \
+X(Read)                                                       \
+X(ReadOpcode)                                                 \
+X(Started)                                                    \
+X(Write)                                                      \
+
+//#define X(tag)
+#define INTERPRETER_STATES_TABLE                              \
+X(Enter)                                                      \
+X(Exit)                                                       \
+X(Loop)                                                       \
+X(Failed)                                                     \
+X(MinBlock)                                                   \
+X(Step2)                                                      \
+X(Step3)                                                      \
+X(Succeeded)                                                  \
+
+//#define X(tag, flags)
+// flags: bit(0)==1 => Read, bit(1)==1 => Write
+#define INTERPRETER_METHOD_MODIFIERS_TABLE                     \
+X(NoReadOrWrite, 0x0)                                         \
+X(ReadOnly,      0x1)                                         \
+X(WriteOnly,     0x2)                                         \
+X(ReadAndWrite,  0x3)                                         \
 
 #endif // DECOMPRESSOR_SRC_INTERP_INTERPRETER_DEF

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -85,7 +85,7 @@ class Interpreter {
 #define X(code, value) code = value,
     SECTION_CODES_TABLE
 #undef X
-    NO_SUCH_SECTION_CODE
+        NO_SUCH_SECTION_CODE
   };
 
   static const char* getName(SectionCode Code);
@@ -103,14 +103,15 @@ class Interpreter {
 #define X(tag, flags) tag = flags,
     INTERPRETER_METHOD_MODIFIERS_TABLE
 #undef X
-    NO_SUCH_METHOD_MODIFIER
+        NO_SUCH_METHOD_MODIFIER
   };
   static const char* getName(MethodModifier Modifier);
   bool isReadModifier(MethodModifier Modifier) {
     return uint32_t(Modifier) & 0x1;
   }
   bool isWriteModifier(MethodModifier Modifier) {
-    return uint32_t(Modifier) & 0x2; }
+    return uint32_t(Modifier) & 0x2;
+  }
 
   enum class State {
 #define X(tag) tag,


### PR DESCRIPTION
In order to handle "callbacks" for the reader of version 0xc, we need to simplify Read and Write into Eval. This is done by adding a modifier to Eval that states if Read and/or Write should be applied.
