### PR TITLE
Remove write value fields no longer needed by interpreter.

### DIFF
--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -34,12 +34,6 @@ using namespace utils;
 
 namespace interp {
 
-namespace {
-
-static constexpr size_t DefaultStackSize = 256;
-
-}  // end of anonymous namespace
-
 Interpreter::Interpreter(std::shared_ptr<Queue> Input,
                          std::shared_ptr<Queue> Output,
                          std::shared_ptr<SymbolTable> Symtab)
@@ -49,17 +43,8 @@ Interpreter::Interpreter(std::shared_ptr<Queue> Input,
       Writer(std::make_shared<ByteWriteStream>()),
       MinimizeBlockSize(false),
       Trace(ReadPos, WritePos, "InterpSexp"),
-      WriteValueStack(WriteValue),
       BlockStartStack(BlockStart) {
   DefaultFormat = Symtab->getVaruint64Definition();
-  WriteValueStack.reserve(DefaultStackSize);
-}
-
-void Interpreter::describeWriteValueStack(FILE* File) {
-  fprintf(File, "*** WriteValue Stack ***\n");
-  for (auto& Value : WriteValueStack.iterRange(1))
-    fprintf(File, "%" PRIuMAX "\n", uintmax_t(Value));
-  fprintf(File, "************************\n");
 }
 
 void Interpreter::describeBlockStartStack(FILE* File) {
@@ -71,15 +56,11 @@ void Interpreter::describeBlockStartStack(FILE* File) {
 
 void Interpreter::describeAllNonemptyStacks(FILE* File) {
   Reader::describeAllNonemptyStacks(File);
-  if (!WriteValueStack.empty())
-    describeWriteValueStack(File);
   if (!BlockStartStack.empty())
     describeBlockStartStack(File);
 }
 
 void Interpreter::clearStacksExceptFrame() {
-  WriteValue = 0;
-  WriteValueStack.clear();
   BlockStart = WriteCursor();
   BlockStartStack.clear();
 }

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -66,9 +66,6 @@ class Interpreter FINAL : public Reader {
   bool MinimizeBlockSize;
   TraceClassSexpReaderWriter Trace;
 
-  // The stack of passed write Values.
-  decode::IntType WriteValue;
-  utils::ValueStack<decode::IntType> WriteValueStack;
   // The stack of block patch locations.
   decode::WriteCursor BlockStart;
   utils::ValueStack<decode::WriteCursor> BlockStartStack;
@@ -85,16 +82,6 @@ class Interpreter FINAL : public Reader {
   bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
   bool writeAction(const filt::CallbackNode* Action) OVERRIDE;
   bool isWriteToByteStream() const OVERRIDE;
-
-  // Sets up code to call write method Method with arguments Nd and WriteValue.
-  // Note: Method may not be Method::Write. Rather, it may be some intermediate
-  // method that sets up a call to Method::Write using field DispatchesMethod.
-  void callWrite(Method Method,
-                 const filt::Node* Nd,
-                 decode::IntType WriteValue) {
-    call(Method, MethodModifier::ReadAndWrite, Nd);
-    WriteValueStack.push(WriteValue);
-  }
 
   // For debugging only.
   void describeWriteValueStack(FILE* Out);

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -1002,7 +1002,7 @@ void Reader::resume() {
           }
           case State::Exit:
             if (!writeAction(Symtab->getBlockExitCallback()))
-                break;
+              break;
             ReadPos.popEobAddress();
             popAndReturn();
             traceExitFrame();

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -52,7 +52,6 @@ class Reader {
   // Resume should be called until isFinished() is true.
   void resume();
 
-
   // Reads from backfilled input stream.
   void readBackFilled();
 

--- a/src/interp/WriteStream.h
+++ b/src/interp/WriteStream.h
@@ -93,7 +93,6 @@ class WriteStream : public std::enable_shared_from_this<WriteStream> {
  protected:
   WriteStream(decode::StreamType Type) : Type(Type) {}
   decode::StreamType Type;
-
 };
 
 }  // end of namespace decode

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -178,7 +178,9 @@ class SymbolTable : public std::enable_shared_from_this<SymbolTable> {
   AST_INTEGERNODE_TABLE
 #undef X
   // Gets actions corresponding to enter/exit block.
-  const CallbackNode* getBlockEnterCallback() const { return BlockEnterCallback; }
+  const CallbackNode* getBlockEnterCallback() const {
+    return BlockEnterCallback;
+  }
   const CallbackNode* getBlockExitCallback() const { return BlockExitCallback; }
   // Install definitions in tree defined by root.
   void install(Node* Root);


### PR DESCRIPTION
Also clang-format's sources.
