### PR TITLE
Turn off destructor of circular_vector to avoid memory problem.

### DIFF
--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -24,7 +24,6 @@
 
 namespace wasm {
 
-using namespace alloc;
 using namespace decode;
 using namespace interp;
 using namespace utils;

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -27,7 +27,9 @@ namespace intcomp {
 IntCountNode::IntCountNode(IntType Value, IntCountNode* Parent)
     : Count(0), Value(Value), Parent(Parent) {}
 
-IntCountNode::~IntCountNode() {}
+IntCountNode::~IntCountNode() {
+  destroy(NextUsageMap);
+}
 
 size_t IntCountNode::getWeight() const {
   size_t Len = pathLength();
@@ -75,17 +77,13 @@ size_t IntCountNode::pathLength(size_t MaxPath) const {
 IntCountNode* IntCountNode::lookup(IntCountUsageMap& UsageMap,
                                    IntType Value, IntCountNode* Parent) {
   if (UsageMap.count(Value) == 0)
-    UsageMap[Value].reset(new IntCountNode(Value, Parent));
-  return UsageMap[Value].get();
+    UsageMap[Value] = new IntCountNode(Value, Parent);
+  return UsageMap[Value];
 }
 
-IntCountUsageMap* IntCountNode::getNextUsageMap(bool CreateIfNull) {
-  IntCountUsageMap* Map = NextUsageMap.get();
-  if (Map || !CreateIfNull)
-    return Map;
-  Map = new IntCountUsageMap();
-  NextUsageMap.reset(Map);
-  return Map;
+void IntCountNode::destroy(IntCountUsageMap& UsageMap) {
+  for (auto& pair : UsageMap)
+    delete pair.second;
 }
 
 } // end of namespace intcomp

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -30,8 +30,7 @@ namespace intcomp {
 
 class IntCountNode;
 
-typedef std::map<decode::IntType,
-                 std::unique_ptr<IntCountNode>> IntCountUsageMap;
+typedef std::map<decode::IntType, IntCountNode*> IntCountUsageMap;
 
 // Implements a notion of a trie on value usage counts.
 class IntCountNode : public std::enable_shared_from_this<IntCountNode> {
@@ -50,11 +49,12 @@ class IntCountNode : public std::enable_shared_from_this<IntCountNode> {
   static IntCountNode* lookup(IntCountUsageMap& UsageMap,
                               decode::IntType Value,
                               IntCountNode* Parent = nullptr);
-  IntCountUsageMap* getNextUsageMap(bool CreateIfNull=false);
+  IntCountUsageMap* getNextUsageMap() { return &NextUsageMap; }
+  static void destroy(IntCountUsageMap& UsageMap);
  private:
   size_t Count;
   decode::IntType Value;
-  std::unique_ptr<IntCountUsageMap> NextUsageMap;
+  IntCountUsageMap NextUsageMap;
   IntCountNode* Parent;
 };
 

--- a/src/interp/TraceSexpReader.cpp
+++ b/src/interp/TraceSexpReader.cpp
@@ -40,8 +40,7 @@ TraceClassSexpReader::TraceClassSexpReader(decode::Cursor* ReadPos,
     : TraceClassSexp(Label, File), ReadPos(ReadPos) {
 }
 
-TraceClassSexpReader::~TraceClassSexpReader() {
-}
+TraceClassSexpReader::~TraceClassSexpReader() {}
 
 void TraceClassSexpReader::traceContext() const {
   if (ReadPos == nullptr)

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -21,7 +21,6 @@
 #define DECOMPRESSOR_PROTOTYPE_SRC_SEXP_PARSER_DRIVER_H
 
 #include "sexp-parser/Parser.tab.hpp"
-#include "utils/Allocator.h"
 
 #include <map>
 #include <memory>

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -28,7 +28,6 @@
 
 namespace wasm {
 
-using namespace alloc;
 using namespace decode;
 using namespace utils;
 

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -34,7 +34,6 @@
 #include "sexp/Strings.def"
 #include "sexp/TraceSexp.h"
 #include "stream/WriteUtils.h"
-#include "utils/Allocator.h"
 #include "utils/Casting.h"
 #include "utils/Defs.h"
 #include "utils/initialized_ptr.h"
@@ -644,7 +643,7 @@ class SelectBaseNode : public NaryNode {
   const CaseNode* getCase(decode::IntType Key) const;
 
  protected:
-  // TODO(karlschimpf) Hook this up to allocator.
+  // TODO(karlschimpf) Hook this up to an allocator?
   std::unordered_map<decode::IntType, const CaseNode*> LookupMap;
 
   SelectBaseNode(SymbolTable& Symtab, NodeType Type) : NaryNode(Symtab, Type) {}

--- a/src/utils/circular-vector.h
+++ b/src/utils/circular-vector.h
@@ -134,7 +134,8 @@ class circular_vector {
       contents.push_back(v);
   }
 
-  ~circular_vector() {}
+  ~circular_vector() {
+  }
 
   size_type size() const { return vector_size; }
 


### PR DESCRIPTION
Some type of "optimization" (free) bug occurs when it tries to destruct the underlying vector of the circular_vector. For now, by allocating (but not freeing) the circular_vector avoids this. Instead it just leaks the corresponding memory.

Note: TODO's have been added about this in the code.
