### PR TITLE
Fix UPDATE option of build to generate needed test files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -922,7 +922,12 @@ clean-unit-tests:
 
 ifneq ($(UPDATE), 0)
 
-update-all: wabt-submodule $(TEST_WASM_SRC_FILES) $(TEST_WASM_W_SRC_FILES)
+update-all: wabt-submodule \
+	$(TEST_WASM_SRC_FILES) \
+	$(TEST_WASM_W_SRC_FILES) \
+	$(TEST_DEFAULT_DF) \
+	$(TEST_DEFAULT_WASM) \
+	$(TEST_DEFAULT_WASM_W)
 
 $(TEST_WASM_SRC_FILES): $(TEST_0XD_SRCDIR)/%.wasm: $(WABT_WAST_DIR)/%.wast \
 		wabt-submodule


### PR DESCRIPTION
That is,

% make UPDATE=1

now generates all needed test files. To generate a single needed test file (FILE) run:

% make UPDATE=1 FILE