### PR TITLE
Aggressively strip out integer sequences that won't be compressed. 

### DIFF
--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -48,9 +48,15 @@ class CounterWriter : public Writer {
   void setSequenceSize(size_t Size);
   void setCountCutoff(uint64_t NewValue) { CountCutoff = NewValue; }
   void setWeightCutoff(uint64_t NewValue) { WeightCutoff = NewValue; }
-  void setUpToSize(size_t NewSize) { UpToSize = NewSize; }
-  void resetUpToSize() { UpToSize = 0; }
-  size_t geUpToSize() const { return UpToSize; }
+  void setUpToSize(size_t NewSize) {
+    UpToSize = NewSize;
+    setSequenceSize(NewSize);
+  }
+  void resetUpToSize() {
+    UpToSize = 0;
+    setSequenceSize(UpToSize);
+  }
+  size_t getUpToSize() const { return UpToSize; }
 
   void addToUsageMap(IntType Value);
   void addInputSeqToUsageMap();
@@ -101,7 +107,8 @@ StreamType CounterWriter::getStreamType() const {
 
 void CounterWriter::setSequenceSize(size_t Size) {
   input_seq->clear();
-  input_seq->resize(Size);
+  if (Size > 0)
+    input_seq->resize(Size);
 }
 
 void CounterWriter::popValuesFromInputSeq(size_t Size) {
@@ -224,7 +231,7 @@ IntCompressor::~IntCompressor() {
   delete Input;
   delete Counter;
   delete Trace;
-  IntCountNode::destroy(UsageMap);
+  IntCountNode::clear(UsageMap);
 }
 
 void IntCompressor::compressUpToSize(size_t Size) {
@@ -232,7 +239,6 @@ void IntCompressor::compressUpToSize(size_t Size) {
           "Collecting integer sequences of (up to) length: %" PRIuMAX "\n",
           uintmax_t(Size));
   Counter->setUpToSize(Size);
-  Counter->setSequenceSize(Size);
   Input->start(StartPos);
   Input->readBackFilled();
   // Flush any remaining values in input sequece.
@@ -240,31 +246,31 @@ void IntCompressor::compressUpToSize(size_t Size) {
   Counter->resetUpToSize();
 }
 
-void IntCompressor::removeSmallUsageCounts(IntCountUsageMap &UsageMap) {
+void IntCompressor::removeSmallUsageCounts(IntCountUsageMap& UsageMap) {
   std::vector<IntType> KeysToRemove;
   for (const auto& pair : UsageMap) {
-    if (removeSmallUsageCounts(pair.second))
+    if (pair.second == nullptr || removeSmallUsageCounts(pair.second))
       KeysToRemove.push_back(pair.first);
   }
-  for (const auto key : KeysToRemove) {
-    delete UsageMap[key];
-    UsageMap.erase(key);
-  }
+  for (const auto Key : KeysToRemove)
+    IntCountNode::erase(UsageMap, Key);
 }
 
 bool IntCompressor::removeSmallUsageCounts(IntCountNode* Nd) {
   if (Nd == nullptr)
     return true;
-  bool RemoveNode = false;
-  if (Nd->getCount() < CountCutoff)
-    RemoveNode = true;
-  else if (Nd->getWeight() < WeightCutoff)
-    RemoveNode = true;
-  if (!RemoveNode)
-    return false;
+  {
+    bool RemoveNode = false;
+    if (Nd->getCount() < CountCutoff)
+      RemoveNode = true;
+    else if (Nd->getWeight() < WeightCutoff)
+      RemoveNode = true;
+    if (!RemoveNode)
+      return false;
+  }
   IntCountUsageMap& NdUsageMap = Nd->getNextUsageMap();
   removeSmallUsageCounts(NdUsageMap);
-  return !NdUsageMap.empty();
+  return NdUsageMap.empty();
 }
 
 void IntCompressor::compress() {
@@ -275,9 +281,12 @@ void IntCompressor::compress() {
   // that we can use as a filter on integer sequence inclusion into the
   // IntCountNode trie.
   compressUpToSize(1);
+  removeSmallUsageCounts();
   describe(stderr, 1);
-  if (LengthLimit > 1)
+  if (LengthLimit > 1) {
     compressUpToSize(LengthLimit);
+    removeSmallUsageCounts();
+  }
   describe(stderr, 2);
 }
 
@@ -323,28 +332,33 @@ void IntSeqCollector::collect() {
 void IntSeqCollector::collectNode(IntCountNode* Nd) {
   uint64_t Weight = Nd->getWeight();
   uint64_t Count = Nd->getCount();
-  CountTotal += Count;
-  WeightTotal += Weight;
+  size_t PathLength = Nd->pathLength();
+  if (PathLength >= MinPathLength) {
+    CountTotal += Count;
+    WeightTotal += Weight;
+  }
   if (Count < CountCutoff)
     return;
   if (Weight < WeightCutoff)
     return;
-  if (Nd->pathLength() >= MinPathLength)
+  if (PathLength >= MinPathLength) {
     Values.push_back(std::make_pair(Weight, Nd));
-  CountReported += Count;
-  WeightReported += Weight;
-  ++NumNodesReported;
+    CountReported += Count;
+    WeightReported += Weight;
+    ++NumNodesReported;
+  }
   IntCountUsageMap& NdUsageMap = Nd->getNextUsageMap();
   for (const auto& pair : NdUsageMap)
     collectNode(pair.second);
 }
 
 void IntSeqCollector::describe(FILE* Out) {
-  fprintf(Out, "Total weight: %" PRIuMAX " Reported Weight %" PRIuMAX
-               " Number nodes reported: %" PRIuMAX "\n",
+  fprintf(Out,
+          "Number nodes reported: %" PRIuMAX "\n"
+          "Total weight: %" PRIuMAX " Reported Weight %" PRIuMAX "\n"
+          "Total count: %" PRIuMAX " Reported count %" PRIuMAX "\n",
+          uintmax_t(NumNodesReported),
           uintmax_t(WeightTotal), uintmax_t(WeightReported),
-          uintmax_t(NumNodesReported));
-  fprintf(Out, "Total count: %" PRIuMAX " Reported count %" PRIuMAX "\n",
           uintmax_t(CountTotal), uintmax_t(CountReported));
   size_t Count = 0;
   for (const auto& pair : Values) {

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -72,7 +72,8 @@ class IntCompressor FINAL {
   uint64_t WeightCutoff;
   size_t LengthLimit;
   void compressUpToSize(size_t Size);
-  void removeSmallUsageCounts(IntCountUsageMap &UsageMap);
+  void removeSmallUsageCounts() { removeSmallUsageCounts(UsageMap); }
+  void removeSmallUsageCounts(IntCountUsageMap& UsageMap);
   bool removeSmallUsageCounts(IntCountNode* Nd);
 };
 

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -72,6 +72,8 @@ class IntCompressor FINAL {
   uint64_t WeightCutoff;
   size_t LengthLimit;
   void compressUpToSize(size_t Size);
+  void removeSmallUsageCounts(IntCountUsageMap &UsageMap);
+  bool removeSmallUsageCounts(IntCountNode* Nd);
 };
 
 }  // end of namespace intcomp

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -28,7 +28,7 @@ IntCountNode::IntCountNode(IntType Value, IntCountNode* Parent)
     : Count(0), Value(Value), Parent(Parent) {}
 
 IntCountNode::~IntCountNode() {
-  destroy(NextUsageMap);
+  clear(NextUsageMap);
 }
 
 size_t IntCountNode::getWeight() const {
@@ -58,10 +58,10 @@ void IntCountNode::describePath(FILE* Out, size_t MaxPath) const {
   fprintf(Out, " %" PRIuMAX "", uintmax_t(Value));
 }
 
-size_t IntCountNode::pathLength(size_t MaxPath) const {
+size_t IntCountNode::pathLength() const {
   size_t len = 0;
   IntCountNode* Nd = const_cast<IntCountNode*>(this);
-  while (Nd && MaxPath > 0) {
+  while (Nd) {
     ++len;
     Nd = Nd->Parent;
   }
@@ -78,7 +78,7 @@ IntCountNode* IntCountNode::lookup(IntCountUsageMap& UsageMap,
   return Nd;
 }
 
-void IntCountNode::destroy(IntCountUsageMap& UsageMap) {
+void IntCountNode::clear(IntCountUsageMap& UsageMap) {
   for (auto& pair : UsageMap)
     delete pair.second;
   UsageMap.clear();

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -45,12 +45,19 @@ class IntCountNode : public std::enable_shared_from_this<IntCountNode> {
   void increment() { ++Count; }
   void describe(FILE* Out, size_t NestLevel=0) const;
   void describePath(FILE* Out, size_t MaxPath=10) const;
-  size_t pathLength(size_t MaxPath=10) const;
+  size_t pathLength() const;
+  bool isSingletonPath() const { return Parent == nullptr; }
   static IntCountNode* lookup(IntCountUsageMap& UsageMap,
                               decode::IntType Value,
                               IntCountNode* Parent = nullptr);
   IntCountUsageMap& getNextUsageMap() { return NextUsageMap; }
-  static void destroy(IntCountUsageMap& UsageMap);
+  // Removes all entries in usage map, deleting unreachable count nodes.
+  static void clear(IntCountUsageMap& UsageMap);
+  // Removes the given key from the usage map, deleting unreachable count nodes.
+  static void erase(IntCountUsageMap& UsageMap, decode::IntType Key) {
+    delete UsageMap[Key];
+    UsageMap.erase(Key);
+  }
  private:
   size_t Count;
   decode::IntType Value;

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -49,7 +49,7 @@ class IntCountNode : public std::enable_shared_from_this<IntCountNode> {
   static IntCountNode* lookup(IntCountUsageMap& UsageMap,
                               decode::IntType Value,
                               IntCountNode* Parent = nullptr);
-  IntCountUsageMap* getNextUsageMap() { return &NextUsageMap; }
+  IntCountUsageMap& getNextUsageMap() { return NextUsageMap; }
   static void destroy(IntCountUsageMap& UsageMap);
  private:
   size_t Count;

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -166,8 +166,8 @@ extern "C" {
 
 void* create_decompressor() {
   auto* Decomp = new Decompressor();
-  bool InstalledDefaults = SymbolTable::installPredefinedDefaults(
-      Decomp->Symtab, false);
+  bool InstalledDefaults =
+      SymbolTable::installPredefinedDefaults(Decomp->Symtab, false);
   Decomp->Interp = std::make_shared<Interpreter>(
       Decomp->Input, Decomp->OutputPipe.getInput(), Decomp->Symtab);
   // Decomp->Interp->setTraceProgress(true);


### PR DESCRIPTION
This is done to speed up execution.