### PR TITLE
Add helpers for abstracting weighted, counted objects.

### DIFF
--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -74,7 +74,7 @@ class IntCompressor FINAL {
   void compressUpToSize(size_t Size);
   void removeSmallUsageCounts() { removeSmallUsageCounts(UsageMap); }
   void removeSmallUsageCounts(IntCountUsageMap& UsageMap);
-  bool removeSmallUsageCounts(IntCountNode* Nd);
+  bool removeSmallUsageCounts(CountNode* Nd);
 };
 
 }  // end of namespace intcomp


### PR DESCRIPTION
Adds base class CountNode (with class hierarchy over counted objects), that abstracts out nodes based on weight (and count) to identify the best choices for abbreviating in the compressed file. Also allows comparison between CountNode's (or pointers to CountNode's using CountNodePtr), based on weight. This allows standard sorting algorithms to be used.