### PR TITLE
Extract out trace from reader/writer of interpreter.

### DIFF
--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -230,7 +230,8 @@ IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> InputStream,
     : Symtab(Symtab), CountCutoff(0), WeightCutoff(0), LengthLimit(1) {
   Counter = new CounterWriter(UsageMap);
   Trace = new TraceClassSexpReader(nullptr, "IntCompress");
-  Input = new Reader(InputStream, *Counter, Symtab, *Trace);
+  Input = new Reader(InputStream, *Counter, Symtab);
+  Input->setTrace(*Trace);
   StartPos = Input->getPos();
   (void)OutputStream;
 }

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -45,9 +45,12 @@ class Interpreter FINAL {
               std::shared_ptr<decode::Queue> OutputStream,
               std::shared_ptr<filt::SymbolTable> Symtab)
       : Symtab(Symtab),
-        Input(InputStream, Output, Symtab, Trace),
-        Output(OutputStream, Trace),
-        Trace(&Input.getPos(), &Output.getPos(), "InterpSexp") {}
+        Input(InputStream, Output, Symtab),
+        Output(OutputStream),
+        Trace(&Input.getPos(), &Output.getPos(), "InterpSexp") {
+    Input.setTrace(Trace);
+    Output.setTrace(Trace);
+  }
 
   ~Interpreter() {}
 

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -23,7 +23,7 @@
 #include "stream/ReadCursor.h"
 #include "interp/Interpreter.def"
 #include "interp/ReadStream.h"
-#include "interp/TraceSexpReader.h"
+#include "sexp/TraceSexp.h"
 #include "interp/Writer.h"
 #include "utils/ValueStack.h"
 
@@ -39,8 +39,7 @@ class Reader {
  public:
   Reader(std::shared_ptr<decode::Queue> Input,
          Writer& Output,
-         std::shared_ptr<filt::SymbolTable> Symtab,
-         TraceClassSexpReader& Trace);
+         std::shared_ptr<filt::SymbolTable> Symtab);
   virtual ~Reader();
 
   // Starts up decompression.
@@ -67,7 +66,8 @@ class Reader {
 
   virtual decode::ReadCursor& getPos();
 
-  TraceClassSexpReader& getTrace() { return Trace; }
+  void setTrace(filt::TraceClassSexp& Trace) { TracePtr = &Trace; }
+  filt::TraceClassSexp& getTrace() { return *TracePtr; }
 
   enum class SectionCode : uint32_t {
 #define X(code, value) code = value,
@@ -181,7 +181,8 @@ class Reader {
   // Holds the method to call (i.e. dispatch) if code expects a method to be
   // provided by the caller.
   Method DispatchedMethod;
-  TraceClassSexpReader& Trace;
+  filt::TraceClassSexp DefaultTrace;
+  filt::TraceClassSexp* TracePtr;
 
   // The stack of called methods.
   CallFrame Frame;

--- a/src/interp/StreamWriter.cpp
+++ b/src/interp/StreamWriter.cpp
@@ -27,11 +27,9 @@ using namespace filt;
 
 namespace interp {
 
-StreamWriter::StreamWriter(std::shared_ptr<decode::Queue> Output,
-                           TraceClassSexp& Trace)
+StreamWriter::StreamWriter(std::shared_ptr<decode::Queue> Output)
     : Pos(StreamType::Byte, Output),
       Stream(std::make_shared<ByteWriteStream>()),
-      Trace(Trace),
       BlockStartStack(BlockStart) {
 }
 

--- a/src/interp/StreamWriter.h
+++ b/src/interp/StreamWriter.h
@@ -34,8 +34,7 @@ class StreamWriter : public Writer {
   StreamWriter& operator=(const StreamWriter&) = delete;
 
  public:
-  StreamWriter(std::shared_ptr<decode::Queue> Output,
-               filt::TraceClassSexp& Trace);
+  StreamWriter(std::shared_ptr<decode::Queue> Output);
   ~StreamWriter() OVERRIDE;
   decode::WriteCursor& getPos();
 
@@ -53,12 +52,10 @@ class StreamWriter : public Writer {
   bool writeAction(const filt::CallbackNode* Action) OVERRIDE;
 
   void describeState(FILE* File) OVERRIDE;
-  filt::TraceClassSexp& getTrace() { return Trace; }
 
  private:
   decode::WriteCursor Pos;
   std::shared_ptr<WriteStream> Stream;
-  filt::TraceClassSexp& Trace;
   // The stack of block patch locations.
   decode::WriteCursor BlockStart;
   utils::ValueStack<decode::WriteCursor> BlockStartStack;

--- a/src/interp/TraceSexpReader.cpp
+++ b/src/interp/TraceSexpReader.cpp
@@ -43,6 +43,10 @@ TraceClassSexpReader::TraceClassSexpReader(decode::Cursor* ReadPos,
 TraceClassSexpReader::~TraceClassSexpReader() {
 }
 
+void TraceClassSexpReader::setReadPos(decode::Cursor* NewPos) {
+  ReadPos = NewPos;
+}
+
 void TraceClassSexpReader::traceContext() const {
   if (ReadPos == nullptr)
     return;

--- a/src/interp/TraceSexpReader.h
+++ b/src/interp/TraceSexpReader.h
@@ -35,12 +35,12 @@ class TraceClassSexpReader : public filt::TraceClassSexp {
   TraceClassSexpReader(decode::Cursor* ReadPos, const char* Label);
   TraceClassSexpReader(decode::Cursor* ReadPos, FILE* File);
   TraceClassSexpReader(decode::Cursor* ReadPos, const char* Label, FILE* File);
-  ~TraceClassSexpReader();
+  ~TraceClassSexpReader() OVERRIDE;
 
   void traceContext() const OVERRIDE;
 
   decode::Cursor* getReadPos() const { return ReadPos; }
-  void setReadPos(decode::Cursor* NewPos) { ReadPos = NewPos; }
+  void setReadPos(decode::Cursor* NewPos) OVERRIDE;
 
  protected:
   decode::Cursor* ReadPos;

--- a/src/interp/TraceSexpReaderWriter.cpp
+++ b/src/interp/TraceSexpReaderWriter.cpp
@@ -48,6 +48,10 @@ TraceClassSexpReaderWriter::TraceClassSexpReaderWriter(decode::Cursor* ReadPos,
 TraceClassSexpReaderWriter::~TraceClassSexpReaderWriter() {
 }
 
+void TraceClassSexpReaderWriter::setWritePos(decode::Cursor* NewPos) {
+  WritePos = NewPos;
+}
+
 void TraceClassSexpReaderWriter::traceContext() const {
   if (ReadPos)
     ReadPos->describe(File);

--- a/src/interp/TraceSexpReaderWriter.h
+++ b/src/interp/TraceSexpReaderWriter.h
@@ -44,9 +44,10 @@ class TraceClassSexpReaderWriter : public TraceClassSexpReader {
                              decode::Cursor* WritePos,
                              const char* Label,
                              FILE* File);
-  ~TraceClassSexpReaderWriter();
+  ~TraceClassSexpReaderWriter() OVERRIDE;
 
   void traceContext() const OVERRIDE;
+  void setWritePos(decode::Cursor* NewPos) OVERRIDE;
 
  protected:
   decode::Cursor* WritePos;

--- a/src/interp/Writer.h
+++ b/src/interp/Writer.h
@@ -32,7 +32,7 @@ class Writer {
   Writer& operator=(const Writer&) = delete;
 
  public:
-  explicit Writer() : MinimizeBlockSize(false) {}
+  explicit Writer() : MinimizeBlockSize(false), TracePtr(&DefaultTrace) {}
   virtual ~Writer();
 
   virtual void reset();
@@ -55,8 +55,14 @@ class Writer {
   void setMinimizeBlockSize(bool NewValue) { MinimizeBlockSize = NewValue; }
   virtual void describeState(FILE* File);
 
+  filt::TraceClassSexp& getTrace() { return *TracePtr; }
+
+  void setTrace(filt::TraceClassSexp& Trace) { TracePtr = &Trace; }
+
  protected:
   bool MinimizeBlockSize;
+  filt::TraceClassSexp DefaultTrace;
+  filt::TraceClassSexp* TracePtr;
 };
 
 }  // end of namespace interp

--- a/src/sexp/TraceSexp.cpp
+++ b/src/sexp/TraceSexp.cpp
@@ -46,6 +46,14 @@ TraceClassSexp::~TraceClassSexp() {
   delete Writer;
 }
 
+void TraceClassSexp::setReadPos(decode::Cursor* NewPos) {
+  (void) NewPos;
+}
+
+void TraceClassSexp::setWritePos(decode::Cursor* NewPos) {
+  (void) NewPos;
+}
+
 TextWriter* TraceClassSexp::getNewTextWriter() {
   return new TextWriter();
 }

--- a/src/sexp/TraceSexp.h
+++ b/src/sexp/TraceSexp.h
@@ -35,6 +35,7 @@
 namespace wasm {
 
 namespace decode {
+class Cursor;
 class ReadCursor;
 class WriteCursor;
 }
@@ -53,7 +54,10 @@ class TraceClassSexp : public utils::TraceClass {
   TraceClassSexp(const char* Label);
   TraceClassSexp(FILE* File);
   TraceClassSexp(const char* Label, FILE* File);
-  ~TraceClassSexp();
+  virtual ~TraceClassSexp();
+
+  virtual void setReadPos(decode::Cursor* NewPos);
+  virtual void setWritePos(decode::Cursor* NewPos);
 
   void trace_node_ptr(const char* Name, const Node* Nd) {
     traceSexpInternal(Name, Nd);

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -68,9 +68,6 @@ constexpr T const_maximum(T V, Args... args) {
 
 static constexpr uint32_t WasmBinaryMagic = 0x6d736100;
 static constexpr uint32_t WasmBinaryVersionD = 0x0d;
-#if 0
-static constexpr uint32_t WasmBinaryVersionB = 0x0b;
-#endif
 
 static constexpr uint32_t CasmBinaryMagic = 0x6d736163;
 static constexpr uint32_t CasmBinaryVersion = 0x0;


### PR DESCRIPTION
This is in preparation of adding non-cursor based reader/writers.