### PR TITLE
Abstract out the input from the interpreter reader.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ INTERP_SRCS = \
 	Decompress.cpp \
 	Reader.cpp \
 	ReadStream.cpp \
+	StreamReader.cpp \
 	StreamWriter.cpp \
 	Writer.cpp \
 	WriteStream.cpp \

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<RawStream> getInput() {
   if (InputFilename == std::string("-")) {
     if (UseFileStreams)
       return std::make_shared<FdReader>(STDIN_FILENO, false);
-    return std::make_shared<StreamReader>(std::cin);
+    return std::make_shared<decode::StreamReader>(std::cin);
   }
   if (UseFileStreams)
     return std::make_shared<FileReader>(InputFilename);

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -17,6 +17,7 @@
 // Implements the compressor of WASM fiels base on integer usage.
 
 #include "intcomp/IntCompress.h"
+#include "interp/StreamReader.h"
 #include "utils/circular-vector.h"
 #include "utils/heap.h"
 
@@ -230,7 +231,7 @@ IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> InputStream,
     : Symtab(Symtab), CountCutoff(0), WeightCutoff(0), LengthLimit(1) {
   Counter = new CounterWriter(UsageMap);
   Trace = new TraceClassSexpReader(nullptr, "IntCompress");
-  Input = new Reader(InputStream, *Counter, Symtab);
+  Input = new StreamReader(InputStream, *Counter, Symtab);
   Input->setTrace(*Trace);
   StartPos = Input->getPos();
   (void)OutputStream;
@@ -248,7 +249,7 @@ void IntCompressor::compressUpToSize(size_t Size) {
           "Collecting integer sequences of (up to) length: %" PRIuMAX "\n",
           uintmax_t(Size));
   Counter->setUpToSize(Size);
-  Input->start(StartPos);
+  Input->startUsing(StartPos);
   Input->readBackFilled();
   // Flush any remaining values in input sequece.
   Counter->addAllInputSeqsToUsageMap();

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -20,7 +20,7 @@
 #define DECOMPRESSOR_SRC_INTCOMP_INTCOMPRESS_H
 
 #include "intcomp/IntCountNode.h"
-#include "interp/Reader.h"
+#include "interp/StreamReader.h"
 #include "interp/TraceSexpReader.h"
 #include "interp/StreamWriter.h"
 
@@ -79,7 +79,7 @@ class IntCompressor FINAL {
 
  private:
   std::shared_ptr<filt::SymbolTable> Symtab;
-  interp::Reader* Input;
+  interp::StreamReader* Input;
   CounterWriter* Counter;
   decode::ReadCursor StartPos;
   IntCountUsageMap UsageMap;

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -19,7 +19,7 @@
 #ifndef DECOMPRESSOR_SRC_INTERP_INTERPRETER_H
 #define DECOMPRESSOR_SRC_INTERP_INTERPRETER_H
 
-#include "interp/Reader.h"
+#include "interp/StreamReader.h"
 #include "interp/TraceSexpReaderWriter.h"
 #include "interp/StreamWriter.h"
 
@@ -78,7 +78,7 @@ class Interpreter FINAL {
 
  private:
   std::shared_ptr<filt::SymbolTable> Symtab;
-  Reader Input;
+  StreamReader Input;
   StreamWriter Output;
   TraceClassSexpReaderWriter Trace;
 };

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -1287,8 +1287,9 @@ void Reader::readBackFilled() {
 #if LOG_RUNMETHODS
   TRACE_METHOD("readBackFilled");
 #endif
+  readFillStart();
   while (!isFinished()) {
-    if (!readFillInput()) {
+    if (!readFillMoreInput()) {
       fail("Can't readBackFilled, input doesn't allow");
       break;
     }

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -1289,10 +1289,7 @@ void Reader::readBackFilled() {
 #endif
   readFillStart();
   while (!isFinished()) {
-    if (!readFillMoreInput()) {
-      fail("Can't readBackFilled, input doesn't allow");
-      break;
-    }
+    readFillMoreInput();
     resume();
   }
 }

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -276,8 +276,8 @@ class Reader {
   virtual bool processedInputCorrectly() = 0;
   virtual void enterBlock() = 0;
   virtual void exitBlock() = 0;
-  // Read fills input with some more bytes if possible. Returns true if ability possible.
-  virtual bool readFillInput() = 0;
+  virtual void readFillStart() = 0;
+  virtual bool readFillMoreInput() = 0;
   // Hard coded reads.
   virtual uint8_t readUint8() = 0;
   virtual uint32_t readUint32() = 0;

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -277,7 +277,7 @@ class Reader {
   virtual void enterBlock() = 0;
   virtual void exitBlock() = 0;
   virtual void readFillStart() = 0;
-  virtual bool readFillMoreInput() = 0;
+  virtual void readFillMoreInput() = 0;
   // Hard coded reads.
   virtual uint8_t readUint8() = 0;
   virtual uint32_t readUint32() = 0;

--- a/src/interp/StreamReader.cpp
+++ b/src/interp/StreamReader.cpp
@@ -1,0 +1,164 @@
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements a stream reader for wasm/casm files.
+
+#include "interp/StreamReader.h"
+
+namespace wasm {
+
+using namespace decode;
+using namespace filt;
+
+namespace interp {
+
+StreamReader::StreamReader(std::shared_ptr<decode::Queue> StrmInput,
+                           Writer& Output,
+                           std::shared_ptr<filt::SymbolTable> Symtab)
+    : Reader(Output, Symtab),
+      ReadPos(StreamType::Byte, StrmInput),
+      Input(std::make_shared<ByteReadStream>()),
+      Trace(&ReadPos),
+      FillPos(0),
+      PeekPosStack(PeekPos)
+{
+  setTrace(Trace);
+  getTrace().setReadPos(&ReadPos);
+}
+
+StreamReader::~StreamReader() {
+}
+
+void StreamReader::startUsing(const ReadCursor& NewCursor) {
+  ReadPos = NewCursor;
+  start();
+}
+
+namespace {
+
+// Headroom is used to guarantee that several (integer) reads
+// can be done in a single iteration of the loop.
+constexpr size_t kResumeHeadroom = 100;
+
+} // end of anonymous namespace
+
+bool StreamReader::canProcessMoreInputNow() {
+  FillPos = ReadPos.fillSize();
+  if (!ReadPos.isEofFrozen()) {
+    if (FillPos < kResumeHeadroom)
+      return false;
+    FillPos -= kResumeHeadroom;
+  }
+  return true;
+}
+
+bool StreamReader::stillMoreInputToProcessNow() {
+  return ReadPos.getCurByteAddress() <= FillPos;
+}
+
+ReadCursor& StreamReader::getPos() {
+  return ReadPos;
+}
+
+bool StreamReader::atInputEob() {
+  return ReadPos.atByteEob();
+}
+
+void StreamReader::resetPeekPosStack() {
+  PeekPos = ReadCursor();
+  PeekPosStack.clear();
+}
+
+void StreamReader::pushPeekPos() {
+  PeekPosStack.push(ReadPos);
+}
+
+void StreamReader::popPeekPos() {
+  ReadPos = PeekPos;
+  PeekPosStack.pop();
+}
+
+decode::StreamType StreamReader::getStreamType() {
+  return Input->getType();
+}
+
+bool StreamReader::processedInputCorrectly() {
+  return ReadPos.atEof() && ReadPos.isQueueGood();
+}
+
+void StreamReader::enterBlock() {
+  const uint32_t OldSize = Input->readBlockSize(ReadPos);
+  TRACE(uint32_t, "block size", OldSize);
+  Input->pushEobAddress(ReadPos, OldSize);
+}
+
+void StreamReader::exitBlock() {
+  ReadPos.popEobAddress();
+}
+
+bool StreamReader::readFillInput() {
+  if (ReadPos.atEof())
+    return true;
+  ReadCursor FillPos(ReadPos);
+  FillPos.advance(Page::Size);
+  return true;
+}
+
+uint8_t StreamReader::readUint8() {
+  return Input->readUint8(ReadPos);
+}
+
+uint32_t StreamReader::readUint32() {
+  return Input->readUint32(ReadPos);
+}
+
+uint64_t StreamReader::readUint64() {
+  return Input->readUint64(ReadPos);
+}
+
+int32_t StreamReader::readVarint32() {
+  return Input->readVarint32(ReadPos);
+}
+
+int64_t StreamReader::readVarint64() {
+  return Input->readVarint64(ReadPos);
+}
+
+uint32_t StreamReader::readVaruint32() {
+  return Input->readVaruint32(ReadPos);
+}
+
+uint64_t StreamReader::readVaruint64() {
+  return Input->readVaruint64(ReadPos);
+}
+
+IntType StreamReader::readValue(const filt::Node* Format) {
+  return Input->readValue(ReadPos, Frame.Nd);
+}
+
+void StreamReader::describePeekPosStack(FILE* File) {
+  if (PeekPosStack.empty())
+    return;
+  fprintf(File, "*** Peek Pos Stack ***\n");
+  fprintf(File, "**********************\n");
+  for (const auto& Pos : PeekPosStack.iterRange(1))
+    fprintf(File, "@%" PRIxMAX "\n", uintmax_t(Pos.getCurAddress()));
+  fprintf(File, "**********************\n");
+}
+
+}  // end of namespace interp
+
+}  // end of namespace wasm

--- a/src/interp/StreamReader.cpp
+++ b/src/interp/StreamReader.cpp
@@ -113,7 +113,7 @@ bool StreamReader::readFillInput() {
   if (ReadPos.atEof())
     return true;
   ReadCursor FillPos(ReadPos);
-  FillPos.advance(Page::Size);
+  FillPos.advance(ReadPos.fillSize() + Page::Size);
   return true;
 }
 

--- a/src/interp/StreamReader.cpp
+++ b/src/interp/StreamReader.cpp
@@ -109,12 +109,14 @@ void StreamReader::exitBlock() {
   ReadPos.popEobAddress();
 }
 
-bool StreamReader::readFillInput() {
-  if (ReadPos.atEof())
-    return true;
-  ReadCursor FillPos(ReadPos);
-  FillPos.advance(ReadPos.fillSize() + Page::Size);
-  return true;
+void StreamReader::readFillStart() {
+  FillCursor = ReadPos;
+}
+
+void StreamReader::readFillMoreInput() {
+  if (FillCursor.atEof())
+    return;
+  FillCursor.advance(Page::Size);
 }
 
 uint8_t StreamReader::readUint8() {

--- a/src/interp/StreamReader.h
+++ b/src/interp/StreamReader.h
@@ -45,7 +45,10 @@ class StreamReader : public Reader {
   decode::ReadCursor ReadPos;
   std::shared_ptr<ReadStream> Input;
   TraceClassSexpReader Trace;
+  // The input position needed to fill to process now.
   size_t FillPos;
+  // The input cursor position if back filling.
+  ReadCursor FillCursor;
   // The stack of read cursors (used by peek)
   decode::ReadCursor PeekPos;
   utils::ValueStack<decode::ReadCursor> PeekPosStack;

--- a/src/interp/StreamReader.h
+++ b/src/interp/StreamReader.h
@@ -1,0 +1,82 @@
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a stream reader for wasm/casm files.
+
+#ifndef DECOMPRESSOR_SRC_INTERP_STREAM_READER_H
+#define DECOMPRESSOR_SRC_INTERP_STREAM_READER_H
+
+#include "interp/Reader.h"
+#include "interp/ReadStream.h"
+#include "interp/TraceSexpReader.h"
+#include "stream/ReadCursor.h"
+
+namespace wasm {
+
+namespace interp {
+
+class StreamReader : public Reader {
+  StreamReader() = delete;
+  StreamReader(const StreamReader&) = delete;
+  StreamReader& operator=(const StreamReader&) = delete;
+ public:
+  StreamReader(std::shared_ptr<decode::Queue> Input,
+               Writer& Output,
+               std::shared_ptr<filt::SymbolTable> Symtab);
+  ~StreamReader() OVERRIDE;
+  void startUsing(const decode::ReadCursor& ReadPos);
+  decode::ReadCursor& getPos() OVERRIDE;
+
+ private:
+
+  decode::ReadCursor ReadPos;
+  std::shared_ptr<ReadStream> Input;
+  TraceClassSexpReader Trace;
+  size_t FillPos;
+  // The stack of read cursors (used by peek)
+  decode::ReadCursor PeekPos;
+  utils::ValueStack<decode::ReadCursor> PeekPosStack;
+
+  virtual void describePeekPosStack(FILE* Out) OVERRIDE;
+
+  bool canProcessMoreInputNow() OVERRIDE;
+  bool stillMoreInputToProcessNow() OVERRIDE;
+  bool atInputEob() OVERRIDE;
+  void resetPeekPosStack() OVERRIDE;
+  void pushPeekPos() OVERRIDE;
+  void popPeekPos() OVERRIDE;
+  decode::StreamType getStreamType() OVERRIDE;
+  bool processedInputCorrectly() OVERRIDE;
+  void enterBlock() OVERRIDE;
+  void exitBlock() OVERRIDE;
+  bool readFillInput() OVERRIDE;
+  uint8_t readUint8() OVERRIDE;
+  uint32_t readUint32() OVERRIDE;
+  uint64_t readUint64() OVERRIDE;
+  int32_t readVarint32() OVERRIDE;
+  int64_t readVarint64() OVERRIDE;
+  uint32_t readVaruint32() OVERRIDE;
+  uint64_t readVaruint64() OVERRIDE;
+  decode::IntType readValue(const filt::Node* Format) OVERRIDE;
+};
+
+
+}  // end of namespace interp
+
+}  // end of namespace wasm
+
+
+#endif // DECOMPRESSOR_SRC_INTERP_STREAM_READER_H

--- a/src/interp/StreamReader.h
+++ b/src/interp/StreamReader.h
@@ -48,7 +48,7 @@ class StreamReader : public Reader {
   // The input position needed to fill to process now.
   size_t FillPos;
   // The input cursor position if back filling.
-  ReadCursor FillCursor;
+  decode::ReadCursor FillCursor;
   // The stack of read cursors (used by peek)
   decode::ReadCursor PeekPos;
   utils::ValueStack<decode::ReadCursor> PeekPosStack;
@@ -65,7 +65,8 @@ class StreamReader : public Reader {
   bool processedInputCorrectly() OVERRIDE;
   void enterBlock() OVERRIDE;
   void exitBlock() OVERRIDE;
-  bool readFillInput() OVERRIDE;
+  void readFillStart() OVERRIDE;
+  void readFillMoreInput() OVERRIDE;
   uint8_t readUint8() OVERRIDE;
   uint32_t readUint32() OVERRIDE;
   uint64_t readUint64() OVERRIDE;

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -30,6 +30,8 @@
 
 namespace wasm {
 
+#define WASM_IGNORE(V) (void)(V);
+
 #ifdef NDEBUG
 inline bool isRelease() {
   return true;


### PR DESCRIPTION
This is in preparation of allowing non-paged streams as intermediate streams.

Note: Still need to fix up the Interpreter class to better understand this.