### PR TITLE
Simplify trace contexts when tracing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ INTERP_SRCS = \
 	ByteReadStream.cpp \
 	ByteWriteStream.cpp \
 	Decompress.cpp \
+	Interpreter.cpp \
 	IntReader.cpp \
 	IntStream.cpp \
 	IntWriter.cpp \

--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -548,12 +548,26 @@ BinaryReader::BinaryReader(std::shared_ptr<decode::Queue> Input,
       Input(Input),
       Symtab(Symtab),
       SectionSymtab(Symtab),
-      Trace(&ReadPos, "BinaryReader"),
       CurFile(nullptr),
       CurBlockApplyFcn(Method::NO_SUCH_METHOD),
       FrameStack(Frame),
       Counter(0),
       CounterStack(Counter) {
+}
+
+void BinaryReader::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
+  Trace = NewTrace;
+  if (!Trace)
+    return;
+  Trace->addContext(ReadPos.getTraceContext());
+}
+
+TraceClassSexp& BinaryReader::getTrace() const {
+  if (!Trace) {
+    const_cast<BinaryReader*>(this)
+        ->setTrace(std::make_shared<TraceClassSexp>("BinaryReader"));
+  }
+  return *Trace;
 }
 
 template <class T>

--- a/src/binary/BinaryReader.h
+++ b/src/binary/BinaryReader.h
@@ -23,8 +23,8 @@
 #include "binary/SectionSymbolTable.h"
 #include "interp/ByteReadStream.h"
 #include "interp/ReadStream.h"
-#include "interp/TraceSexpReader.h"
 #include "sexp/Ast.h"
+#include "sexp/TraceSexp.h"
 #include "stream/Queue.h"
 #include "stream/ReadCursor.h"
 #include "stream/WriteCursor.h"
@@ -106,9 +106,13 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
 
   SectionNode* readSection();
 
-  TraceClassSexpReader& getTrace() { return Trace; }
+  void setTraceProgress(bool NewValue) {
+    getTrace().setTraceProgress(NewValue);
+  }
+  void setTrace(std::shared_ptr<TraceClassSexp> Trace);
+  TraceClassSexp& getTrace() const;
 
-  TextWriter* getTextWriter() const { return Trace.getTextWriter(); }
+  TextWriter* getTextWriter() const { return getTrace().getTextWriter(); }
 
  private:
   struct CallFrame {
@@ -131,7 +135,7 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
   };
 
   std::shared_ptr<interp::ByteReadStream> Reader;
-  decode::ReadCursor ReadPos;
+  decode::ReadCursorWithTraceContext ReadPos;
   decode::WriteCursor FillPos;
   std::shared_ptr<decode::Queue> Input;
   std::shared_ptr<SymbolTable> Symtab;
@@ -141,7 +145,7 @@ class BinaryReader : public std::enable_shared_from_this<BinaryReader> {
   // The version of the input.
   uint32_t CasmVersion;
   uint32_t WasmVersion;
-  mutable TraceClassSexpReader Trace;
+  mutable std::shared_ptr<TraceClassSexp> Trace;
   std::string Name;
   FileNode* CurFile;
   SectionNode* CurSection;

--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -37,8 +37,20 @@ BinaryWriter::BinaryWriter(std::shared_ptr<decode::Queue> Output,
     : WritePos(decode::StreamType::Byte, Output),
       Writer(std::make_shared<ByteWriteStream>()),
       SectionSymtab(Symtab),
-      MinimizeBlockSize(false),
-      Trace(WritePos, "BinaryWriter") {
+      MinimizeBlockSize(false) {
+}
+
+void BinaryWriter::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
+  Trace = NewTrace;
+  if (!Trace)
+    return;
+  Trace->addContext(WritePos.getTraceContext());
+}
+
+TraceClassSexp& BinaryWriter::getTrace() {
+  if (!Trace)
+    setTrace(std::make_shared<TraceClassSexp>("BinaryWriter"));
+  return *Trace;
 }
 
 void BinaryWriter::writePreamble() {

--- a/src/binary/BinaryWriter.h
+++ b/src/binary/BinaryWriter.h
@@ -21,10 +21,10 @@
 #define DECOMPRESSOR_SRC_BINARY_BINGEN_H
 
 #include "binary/SectionSymbolTable.h"
+#include "interp/WriteStream.h"
+#include "sexp/TraceSexp.h"
 #include "stream/Queue.h"
 #include "stream/WriteCursor.h"
-#include "interp/TraceSexpWriter.h"
-#include "interp/WriteStream.h"
 #include "utils/Defs.h"
 
 #include <functional>
@@ -53,18 +53,20 @@ class BinaryWriter {
   void writeFile(const FileNode* File);
   void writeSection(const SectionNode* Section);
 
-  void setTraceProgress(bool NewValue) { Trace.setTraceProgress(NewValue); }
-
   void setMinimizeBlockSize(bool NewValue) { MinimizeBlockSize = NewValue; }
 
-  interp::TraceClassSexpWriter& getTrace() { return Trace; }
+  void setTraceProgress(bool NewValue) {
+    getTrace().setTraceProgress(NewValue);
+  }
+  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
+  TraceClassSexp& getTrace();
 
  private:
-  decode::WriteCursor WritePos;
+  decode::WriteCursorWithTraceContext WritePos;
   std::shared_ptr<interp::WriteStream> Writer;
   SectionSymbolTable SectionSymtab;
   bool MinimizeBlockSize;
-  interp::TraceClassSexpWriter Trace;
+  std::shared_ptr<TraceClassSexp> Trace;
 
   void writeNode(const Node* Nd);
   void writeBlock(std::function<void()> ApplyFn);

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -227,6 +227,7 @@ int main(int Argc, char* Argv[]) {
     fprintf(stderr, "Unable to load compiled in default rules!\n");
     return exit_status(EXIT_FAILURE);
   }
+  fprintf(stderr, "Reading default files...\n");
   for (int i : DefaultIndices) {
     if (Verbose)
       fprintf(stderr, "Loading default: %s\n", Argv[i]);
@@ -248,11 +249,13 @@ int main(int Argc, char* Argv[]) {
     }
   }
   for (size_t i = 0; i < NumTries; ++i) {
+    fprintf(stderr, "Building decompressor...\n");
     Interpreter Decompressor(std::make_shared<ReadBackedQueue>(getInput()),
                              std::make_shared<WriteBackedQueue>(getOutput()),
                              Symtab);
     Decompressor.setTraceProgress(Verbose >= 1);
     Decompressor.setMinimizeBlockSize(MinimizeBlockSize);
+    fprintf(stderr, "Decompressing...\n");
     Decompressor.decompress();
     if (Decompressor.errorsFound()) {
       fatal("Failed to decompress due to errors!");

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -227,7 +227,6 @@ int main(int Argc, char* Argv[]) {
     fprintf(stderr, "Unable to load compiled in default rules!\n");
     return exit_status(EXIT_FAILURE);
   }
-  fprintf(stderr, "Reading default files...\n");
   for (int i : DefaultIndices) {
     if (Verbose)
       fprintf(stderr, "Loading default: %s\n", Argv[i]);
@@ -249,13 +248,11 @@ int main(int Argc, char* Argv[]) {
     }
   }
   for (size_t i = 0; i < NumTries; ++i) {
-    fprintf(stderr, "Building decompressor...\n");
     Interpreter Decompressor(std::make_shared<ReadBackedQueue>(getInput()),
                              std::make_shared<WriteBackedQueue>(getOutput()),
                              Symtab);
     Decompressor.setTraceProgress(Verbose >= 1);
     Decompressor.setMinimizeBlockSize(MinimizeBlockSize);
-    fprintf(stderr, "Decompressing...\n");
     Decompressor.decompress();
     if (Decompressor.errorsFound()) {
       fatal("Failed to decompress due to errors!");

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -230,17 +230,26 @@ IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> InputStream,
                              std::shared_ptr<filt::SymbolTable> Symtab)
     : Symtab(Symtab), CountCutoff(0), WeightCutoff(0), LengthLimit(1) {
   Counter = new CounterWriter(UsageMap);
-  Trace = new TraceClassSexpReader(nullptr, "IntCompress");
   Input = new StreamReader(InputStream, *Counter, Symtab);
-  Input->setTrace(*Trace);
   StartPos = Input->getPos();
   (void)OutputStream;
+}
+
+void IntCompressor::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
+  Trace = NewTrace;
+  if (Trace)
+    Input->setTrace(Trace);
+}
+
+TraceClassSexp& IntCompressor::getTrace() {
+  if (!Trace)
+    setTrace(std::make_shared<TraceClassSexp>("IntCompress"));
+  return *Trace;
 }
 
 IntCompressor::~IntCompressor() {
   delete Input;
   delete Counter;
-  delete Trace;
   IntCountNode::clear(UsageMap);
 }
 

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -21,8 +21,8 @@
 
 #include "intcomp/IntCountNode.h"
 #include "interp/StreamReader.h"
-#include "interp/TraceSexpReader.h"
 #include "interp/StreamWriter.h"
+#include "sexp/TraceSexp.h"
 
 namespace wasm {
 
@@ -64,17 +64,16 @@ class IntCompressor FINAL {
   void compress();
 
   void setTraceProgress(bool NewValue) {
-    if (Trace)
-      Trace->setTraceProgress(NewValue);
+    getTrace().setTraceProgress(NewValue);
   }
+  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
+  filt::TraceClassSexp& getTrace();
 
   void setCountCutoff(uint64_t NewCutoff) { CountCutoff = NewCutoff; }
   void setWeightCutoff(uint64_t NewCutoff) { WeightCutoff = NewCutoff; }
   void setLengthLimit(size_t NewLimit) { LengthLimit = NewLimit; }
 
   void setMinimizeBlockSize(bool NewValue) { (void)NewValue; }
-
-  interp::TraceClassSexpReader& getTrace() { return *Trace; }
 
   void describe(FILE* Out, CollectionFlags = Flag(CollectionFlag::All));
 
@@ -84,7 +83,7 @@ class IntCompressor FINAL {
   CounterWriter* Counter;
   decode::ReadCursor StartPos;
   IntCountUsageMap UsageMap;
-  interp::TraceClassSexpReader* Trace;
+  std::shared_ptr<filt::TraceClassSexp> Trace;
   uint64_t CountCutoff;
   uint64_t WeightCutoff;
   size_t LengthLimit;

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -68,9 +68,7 @@ Decompressor::Decompressor()
       Symtab(std::make_shared<SymbolTable>()),
       Input(std::make_shared<Queue>()),
       MyState(State::NeedsMoreInput) {
-  fprintf(stderr, "Builing inputpos...\n");
   InputPos = std::make_shared<WriteCursor2ReadQueue>(Input);
-  fprintf(stderr, "Builing outputpos...\n");
   OutputPos = std::make_shared<ReadCursor>(OutputPipe.getOutput());
 }
 

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -52,7 +52,7 @@ struct Decompressor {
   int32_t getOutputSize() {
     return OutputPipe.getOutput()->fillSize() - OutputPos->getCurByteAddress();
   }
-  TraceClassSexpReaderWriter& getTrace() { return Interp->getTrace(); }
+  TraceClassSexp& getTrace() { return Interp->getTrace(); }
   void setTraceProgress(bool NewValue) { Interp->setTraceProgress(NewValue); }
 
  private:
@@ -68,7 +68,9 @@ Decompressor::Decompressor()
       Symtab(std::make_shared<SymbolTable>()),
       Input(std::make_shared<Queue>()),
       MyState(State::NeedsMoreInput) {
+  fprintf(stderr, "Builing inputpos...\n");
   InputPos = std::make_shared<WriteCursor2ReadQueue>(Input);
+  fprintf(stderr, "Builing outputpos...\n");
   OutputPos = std::make_shared<ReadCursor>(OutputPipe.getOutput());
 }
 

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -*- C++ -*- */
 //
 // Copyright 2016 WebAssembly Community Group participants
 //
@@ -14,30 +14,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "stream/WriteCursor.h"
+// Defines the interpretater for filter s-expressions.
+
+#include "interp/Interpreter.h"
 
 namespace wasm {
 
-using namespace utils;
+using namespace filt;
 
-namespace decode {
+namespace interp {
 
-WriteCursor::~WriteCursor() {
+void Interpreter::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
+  Trace = NewTrace;
+  if (Trace) {
+    Input.setTrace(Trace);
+    Output.setTrace(Trace);
+  }
 }
 
-void WriteCursor::writeFillWriteByte(uint8_t Byte) {
-  if (isIndexAtEndOfPage())
-    writeFillBuffer();
-  updateGuaranteedBeforeEob();
-  writeOneByte(Byte);
+TraceClassSexp& Interpreter::getTrace() {
+  if (!Trace)
+    setTrace(std::make_shared<TraceClassSexp>("InterpSexp"));
+  return *Trace;
 }
 
-TraceClass::ContextPtr WriteCursorWithTraceContext::getTraceContext() {
-  if (!TraceContext)
-    TraceContext = std::make_shared<Cursor::TraceContext>(*this);
-  return TraceContext;
-}
+}  // end of namespace interp.
 
-}  // end of namespace decode
-
-}  // end of namespace wasm
+}  // end of namespace wasm.

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -20,8 +20,8 @@
 #define DECOMPRESSOR_SRC_INTERP_INTERPRETER_H
 
 #include "interp/StreamReader.h"
-#include "interp/TraceSexpReaderWriter.h"
 #include "interp/StreamWriter.h"
+#include "sexp/TraceSexp.h"
 
 namespace wasm {
 
@@ -44,13 +44,9 @@ class Interpreter FINAL {
   Interpreter(std::shared_ptr<decode::Queue> InputStream,
               std::shared_ptr<decode::Queue> OutputStream,
               std::shared_ptr<filt::SymbolTable> Symtab)
-      : Symtab(Symtab),
-        Input(InputStream, Output, Symtab),
-        Output(OutputStream),
-        Trace(&Input.getPos(), &Output.getPos(), "InterpSexp") {
-    Input.setTrace(Trace);
-    Output.setTrace(Trace);
-  }
+  : Symtab(Symtab),
+    Input(InputStream, Output, Symtab),
+    Output(OutputStream) {}
 
   ~Interpreter() {}
 
@@ -68,19 +64,20 @@ class Interpreter FINAL {
     Input.readBackFilled();
   }
 
-  void setTraceProgress(bool NewValue) { Trace.setTraceProgress(NewValue); }
+  void setTraceProgress(bool NewValue) { getTrace().setTraceProgress(NewValue); }
 
   void setMinimizeBlockSize(bool NewValue) {
     Output.setMinimizeBlockSize(NewValue);
   }
 
-  TraceClassSexpReaderWriter& getTrace() { return Trace; }
+  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
+  filt::TraceClassSexp& getTrace();
 
  private:
   std::shared_ptr<filt::SymbolTable> Symtab;
   StreamReader Input;
   StreamWriter Output;
-  TraceClassSexpReaderWriter Trace;
+  std::shared_ptr<filt::TraceClassSexp> Trace;
 };
 
 }  // end of namespace interp.

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -54,6 +54,7 @@ namespace wasm {
 
 using namespace decode;
 using namespace filt;
+using namespace utils;
 
 namespace interp {
 
@@ -95,6 +96,23 @@ struct {
 
 }  // end of anonymous namespace
 
+TraceClass::ContextPtr Reader::getTraceContext() {
+  TraceClass::ContextPtr Ptr;
+  return Ptr;
+}
+
+void Reader::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
+  Trace = NewTrace;
+  if (Trace)
+    Trace->addContext(getTraceContext());
+}
+
+TraceClassSexp& Reader::getTrace() {
+  if (!Trace)
+    setTrace(std::make_shared<TraceClassSexp>("StreamReader"));
+  return *Trace;
+}
+
 const char* Reader::getName(Method M) {
   size_t Index = size_t(M);
   if (Index >= size(MethodName))
@@ -131,7 +149,6 @@ Reader::Reader(Writer& StrmOutput, std::shared_ptr<filt::SymbolTable> Symtab)
       Symtab(Symtab),
       LastReadValue(0),
       DispatchedMethod(Method::NO_SUCH_METHOD),
-      TracePtr(&DefaultTrace),
       FrameStack(Frame),
       CallingEvalStack(CallingEval),
       LoopCounter(0),

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -67,8 +67,10 @@ class Reader {
   // that the input is a stream that can defined cursors.
   virtual decode::ReadCursor& getPos() = 0;
 
-  void setTrace(filt::TraceClassSexp& Trace) { TracePtr = &Trace; }
-  filt::TraceClassSexp& getTrace() { return *TracePtr; }
+  // Returns non-null context handler if applicable.
+  virtual utils::TraceClass::ContextPtr getTraceContext();
+  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
+  filt::TraceClassSexp& getTrace();
 
   enum class SectionCode : uint32_t {
 #define X(code, value) code = value,
@@ -180,8 +182,7 @@ class Reader {
   // Holds the method to call (i.e. dispatch) if code expects a method to be
   // provided by the caller.
   Method DispatchedMethod;
-  filt::TraceClassSexp DefaultTrace;
-  filt::TraceClassSexp* TracePtr;
+  std::shared_ptr<filt::TraceClassSexp> Trace;
 
   // The stack of called methods.
   CallFrame Frame;

--- a/src/interp/StreamReader.cpp
+++ b/src/interp/StreamReader.cpp
@@ -22,6 +22,7 @@ namespace wasm {
 
 using namespace decode;
 using namespace filt;
+using namespace utils;
 
 namespace interp {
 
@@ -31,12 +32,8 @@ StreamReader::StreamReader(std::shared_ptr<decode::Queue> StrmInput,
     : Reader(Output, Symtab),
       ReadPos(StreamType::Byte, StrmInput),
       Input(std::make_shared<ByteReadStream>()),
-      Trace(&ReadPos),
       FillPos(0),
-      PeekPosStack(PeekPos)
-{
-  setTrace(Trace);
-  getTrace().setReadPos(&ReadPos);
+      PeekPosStack(PeekPos) {
 }
 
 StreamReader::~StreamReader() {
@@ -45,6 +42,10 @@ StreamReader::~StreamReader() {
 void StreamReader::startUsing(const decode::ReadCursor& StartPos) {
   ReadPos = StartPos;
   start();
+}
+
+TraceClass::ContextPtr StreamReader::getTraceContext() {
+  return ReadPos.getTraceContext();
 }
 
 namespace {

--- a/src/interp/StreamReader.h
+++ b/src/interp/StreamReader.h
@@ -21,7 +21,6 @@
 
 #include "interp/Reader.h"
 #include "interp/ReadStream.h"
-#include "interp/TraceSexpReader.h"
 #include "stream/ReadCursor.h"
 
 namespace wasm {
@@ -39,12 +38,12 @@ class StreamReader : public Reader {
   ~StreamReader() OVERRIDE;
   void startUsing(const decode::ReadCursor& ReadPos);
   decode::ReadCursor& getPos() OVERRIDE;
+  utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
  private:
 
-  decode::ReadCursor ReadPos;
+  decode::ReadCursorWithTraceContext ReadPos;
   std::shared_ptr<ReadStream> Input;
-  TraceClassSexpReader Trace;
   // The input position needed to fill to process now.
   size_t FillPos;
   // The input cursor position if back filling.

--- a/src/interp/StreamWriter.cpp
+++ b/src/interp/StreamWriter.cpp
@@ -24,6 +24,7 @@ namespace wasm {
 
 using namespace decode;
 using namespace filt;
+using namespace utils;
 
 namespace interp {
 
@@ -43,6 +44,10 @@ void StreamWriter::reset() {
 
 WriteCursor& StreamWriter::getPos() {
   return Pos;
+}
+
+TraceClass::ContextPtr StreamWriter::getTraceContext() {
+  return Pos.getTraceContext();
 }
 
 decode::StreamType StreamWriter::getStreamType() const {

--- a/src/interp/StreamWriter.h
+++ b/src/interp/StreamWriter.h
@@ -37,6 +37,7 @@ class StreamWriter : public Writer {
   StreamWriter(std::shared_ptr<decode::Queue> Output);
   ~StreamWriter() OVERRIDE;
   decode::WriteCursor& getPos();
+  utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
@@ -54,7 +55,7 @@ class StreamWriter : public Writer {
   void describeState(FILE* File) OVERRIDE;
 
  private:
-  decode::WriteCursor Pos;
+  decode::WriteCursorWithTraceContext Pos;
   std::shared_ptr<WriteStream> Stream;
   // The stack of block patch locations.
   decode::WriteCursor BlockStart;

--- a/src/interp/Writer.cpp
+++ b/src/interp/Writer.cpp
@@ -22,10 +22,28 @@ namespace wasm {
 
 using namespace decode;
 using namespace filt;
+using namespace utils;
 
 namespace interp {
 
 Writer::~Writer() {
+}
+
+TraceClass::ContextPtr Writer::getTraceContext() {
+  TraceClass::ContextPtr Ptr;
+  return Ptr;
+}
+
+TraceClassSexp& Writer::getTrace() {
+  if (!Trace)
+    setTrace(std::make_shared<TraceClassSexp>("Writer"));
+  return *Trace;
+}
+
+void Writer::setTrace(std::shared_ptr<filt::TraceClassSexp> NewTrace) {
+  Trace = NewTrace;
+  if (Trace)
+    Trace->addContext(getTraceContext());
 }
 
 void Writer::reset() {

--- a/src/interp/Writer.h
+++ b/src/interp/Writer.h
@@ -32,7 +32,7 @@ class Writer {
   Writer& operator=(const Writer&) = delete;
 
  public:
-  explicit Writer() : MinimizeBlockSize(false), TracePtr(&DefaultTrace) {}
+  explicit Writer() : MinimizeBlockSize(false) {}
   virtual ~Writer();
 
   virtual void reset();
@@ -55,14 +55,13 @@ class Writer {
   void setMinimizeBlockSize(bool NewValue) { MinimizeBlockSize = NewValue; }
   virtual void describeState(FILE* File);
 
-  filt::TraceClassSexp& getTrace() { return *TracePtr; }
-
-  void setTrace(filt::TraceClassSexp& Trace) { TracePtr = &Trace; }
+  virtual utils::TraceClass::ContextPtr getTraceContext();
+  filt::TraceClassSexp& getTrace();
+  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
 
  protected:
   bool MinimizeBlockSize;
-  filt::TraceClassSexp DefaultTrace;
-  filt::TraceClassSexp* TracePtr;
+  std::shared_ptr<filt::TraceClassSexp> Trace;
 };
 
 }  // end of namespace interp

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -25,6 +25,12 @@ FILE* WorkingByte::describe(FILE* File) {
   return File;
 }
 
+Cursor::TraceContext::~TraceContext() {}
+
+void Cursor::TraceContext::describe(FILE* File) {
+  Pos.describe(File);
+}
+
 void Cursor::close() {
   CurPage = Que->getErrorPage();
   CurByte.reset();

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -20,6 +20,7 @@
 #define DECOMPRESSOR_SRC_STREAM_CURSOR_H
 
 #include "stream/Queue.h"
+#include "utils/Trace.h"
 
 namespace wasm {
 
@@ -81,6 +82,17 @@ class Cursor : public PageCursor {
   Cursor& operator=(const Cursor&) = delete;
 
  public:
+  class TraceContext : public utils::TraceClass::Context {
+    TraceContext() = delete;
+    TraceContext(const TraceContext&) = delete;
+    TraceContext& operator=(const TraceContext&) = delete;
+   public:
+    TraceContext(Cursor& Pos) : Pos(Pos) {}
+    ~TraceContext();
+    void describe(FILE* File) OVERRIDE;
+   private:
+    Cursor& Pos;
+  };
   ~Cursor() {}
 
   void swap(Cursor& C) {

--- a/src/stream/ReadCursor.cpp
+++ b/src/stream/ReadCursor.cpp
@@ -18,6 +18,8 @@
 
 namespace wasm {
 
+using namespace utils;
+
 namespace decode {
 
 uint8_t ReadCursor::readByteAfterReadFill() {
@@ -65,6 +67,12 @@ uint8_t ReadCursor::readOneByte() {
   uint8_t Byte = *getBufferPtr();
   ++CurAddress;
   return Byte;
+}
+
+TraceClass::ContextPtr ReadCursorWithTraceContext::getTraceContext() {
+  if (!TraceContext)
+    TraceContext = std::make_shared<Cursor::TraceContext>(*this);
+  return TraceContext;
 }
 
 }  // end of namespace decode

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -26,7 +26,7 @@ namespace wasm {
 
 namespace decode {
 
-class ReadCursor FINAL : public Cursor {
+class ReadCursor : public Cursor {
  public:
   // Note: The nullary read cursor should not be used until it has been assigned
   // a valid value.

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -20,6 +20,7 @@
 #define DECOMPRESSOR_SRC_STREAM_READCURSOR_H
 
 #include "stream/Cursor.h"
+#include "utils/Trace.h"
 
 namespace wasm {
 
@@ -100,6 +101,28 @@ class ReadCursor FINAL : public Cursor {
   uint8_t readOneByte();
 
   uint8_t readByteAfterReadFill();
+};
+
+class ReadCursorWithTraceContext : public ReadCursor {
+ public:
+  ReadCursorWithTraceContext() : ReadCursor() {}
+
+  ReadCursorWithTraceContext(std::shared_ptr<Queue> Que) : ReadCursor(Que) {}
+
+  ReadCursorWithTraceContext(StreamType Type, std::shared_ptr<Queue> Que)
+      : ReadCursor(Type, Que) {}
+
+  explicit ReadCursorWithTraceContext(const Cursor& C) : ReadCursor(C) {}
+
+  ReadCursorWithTraceContext& operator=(const ReadCursor& C) {
+    ReadCursor::operator=(C);
+    return *this;
+  }
+
+  utils::TraceClass::ContextPtr getTraceContext();
+
+ private:
+  utils::TraceClass::ContextPtr TraceContext;
 };
 
 }  // end of namespace decode

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -25,7 +25,7 @@ namespace wasm {
 
 namespace decode {
 
-class WriteCursor FINAL : public WriteCursorBase {
+class WriteCursor : public WriteCursorBase {
  public:
   // Note: The nullary write cursor should not be used until it has been
   // assigned a value.

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -48,6 +48,33 @@ class WriteCursor FINAL : public WriteCursorBase {
   void writeFillWriteByte(uint8_t Byte) OVERRIDE;
 };
 
+class WriteCursorWithTraceContext : public WriteCursor {
+ public:
+  // Note: The nullary write cursor should not be used until it has been
+  // assigned a value.
+  WriteCursorWithTraceContext() : WriteCursor() {}
+
+  WriteCursorWithTraceContext(std::shared_ptr<Queue> Que) : WriteCursor(Que) {}
+
+  WriteCursorWithTraceContext(StreamType Type, std::shared_ptr<Queue> Que)
+      : WriteCursor(Type, Que) {}
+
+  explicit WriteCursorWithTraceContext(const WriteCursor& C)
+      : WriteCursor(C) {}
+
+  WriteCursorWithTraceContext(const Cursor& C, size_t StartAddress)
+      : WriteCursor(C, StartAddress) {}
+
+  WriteCursorWithTraceContext& operator=(WriteCursor& C) {
+    WriteCursor::operator=(C);
+    return *this;
+  }
+
+  utils::TraceClass::ContextPtr getTraceContext();
+
+ private:
+  utils::TraceClass::ContextPtr TraceContext;
+};
 }  // end of namespace decode
 
 }  // end of namespace wasm

--- a/src/utils/Trace.cpp
+++ b/src/utils/Trace.cpp
@@ -53,7 +53,24 @@ TraceClass::TraceClass(const char* Lbl, FILE* Fl) {
 TraceClass::~TraceClass() {
 }
 
+void TraceClass::addContext(ContextPtr NewCtx) {
+  if (!NewCtx)
+    return;
+  for (auto Ctx : ContextList)
+    if (NewCtx.get() == Ctx.get())
+      return;
+  ContextList.push_back(NewCtx);
+}
+
 void TraceClass::traceContext() const {
+  if (ContextList.empty())
+    return;
+  for (size_t i = 0; i < ContextList.size(); ++i) {
+    if (i > 0 && (i + 1) < ContextList.size())
+      fputc('/', File);
+    ContextList[i]->describe(File);
+  }
+  fputc(' ', File);
 }
 
 void TraceClass::enter(const char* Name) {

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -91,11 +91,12 @@ namespace wasm {
 
 namespace utils {
 
-class TraceClass : std::enable_shared_from_this<TraceClass> {
+class TraceClass : public std::enable_shared_from_this<TraceClass> {
   TraceClass(const TraceClass&) = delete;
   TraceClass& operator=(const TraceClass&) = delete;
 
  public:
+  // Models called methods in traces.
   class Method {
     Method() = delete;
     Method(const Method&) = delete;
@@ -116,6 +117,17 @@ class TraceClass : std::enable_shared_from_this<TraceClass> {
    private:
     TraceClass& Cls;
   };
+  // Models calling contexts to be associated with each trace line.
+  class Context : public std::enable_shared_from_this<Context> {
+    Context(const Context&) = delete;
+    Context& operator=(const Context&) = delete;
+   public:
+    virtual ~Context() {}
+    virtual void describe(FILE* File) = 0;
+   protected:
+    Context() {}
+  };
+  typedef std::shared_ptr<Context> ContextPtr;
 
   TraceClass();
   explicit TraceClass(const char* Label);
@@ -125,6 +137,8 @@ class TraceClass : std::enable_shared_from_this<TraceClass> {
   void enter(const char* Name);
   void exit(const char* Name = nullptr);
   virtual void traceContext() const;
+  void addContext(ContextPtr Ctx);
+
   // Prints trace prefix only.
   FILE* indent();
   void trace_message(const char* Message) { traceMessageInternal(Message); }
@@ -227,6 +241,7 @@ class TraceClass : std::enable_shared_from_this<TraceClass> {
   int IndentLevel;
   bool TraceProgress;
   std::vector<const char*> CallStack;
+  std::vector<ContextPtr> ContextList;
   void traceMessageInternal(const std::string& Message);
   void traceBoolInternal(const char* Name, bool Value);
   void traceCharInternal(const char* Name, char Ch);


### PR DESCRIPTION
All trace classes now stores (read/write) contexts, rather than defining derived classes to add context.

To do this, trace class instantiation is late bound inside method getTrace(), and a new method setTrace() has been added to add appropriate trace contexts.

In addition, added method getTraceContext() to classes ReadCursor and WriteCursor, using derived classes ReadCursorWithTraceContext and WriteCursorWithTraceContext.
