### PR TITLE
Use int streams to analyze when compressing

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -74,12 +74,15 @@ void usage(const char* AppName) {
             "Show progress (can be repeated for more detail).\n");
     fprintf(stderr,
             "\t\t\t-v          : "
-            "Trace progress of compression.\n");
+            "Add progress of compression.\n");
     fprintf(stderr,
             "\t\t\t-v -v       : "
-            "Add progress of parsing default files.\n");
+            "Add trace of parsing (wasm) input file..\n");
     fprintf(stderr,
             "\t\t\t-v -v -v    : "
+            "Add progress of parsing default files.\n");
+    fprintf(stderr,
+            "\t\t\t-v -v -v -v : "
             "Add progress of lexing default files.\n");
   }
 }
@@ -160,7 +163,7 @@ int main(int Argc, char* Argv[]) {
     CountCutoff = WeightCutoff;
   auto Symtab = std::make_shared<SymbolTable>();
   if (InstallPredefinedRules &&
-      !SymbolTable::installPredefinedDefaults(Symtab, Verbose >= 2)) {
+      !SymbolTable::installPredefinedDefaults(Symtab, Verbose >= 3)) {
     fprintf(stderr, "Unable to load compiled in default rules!\n");
     return exit_status(EXIT_FAILURE);
   }
@@ -171,14 +174,14 @@ int main(int Argc, char* Argv[]) {
       std::shared_ptr<RawStream> Stream = std::make_shared<FileReader>(Argv[i]);
       BinaryReader Reader(std::make_shared<ReadBackedQueue>(std::move(Stream)),
                           Symtab);
-      Reader.getTrace().setTraceProgress(Verbose >= 2);
+      Reader.getTrace().setTraceProgress(Verbose >= 3);
       if (Reader.readFile()) {
         continue;
       }
     }
     Driver Parser(Symtab);
-    Parser.setTraceParsing(Verbose >= 2);
-    Parser.setTraceLexing(Verbose >= 3);
+    Parser.setTraceParsing(Verbose >= 3);
+    Parser.setTraceLexing(Verbose >= 4);
     if (!Parser.parse(Argv[i])) {
       fprintf(stderr, "Unable to parse default algorithms: %s\n", Argv[i]);
       return exit_status(EXIT_FAILURE);
@@ -192,7 +195,7 @@ int main(int Argc, char* Argv[]) {
   Compressor.setWeightCutoff(WeightCutoff);
   Compressor.setTraceProgress(Verbose >= 1);
   Compressor.setMinimizeBlockSize(MinimizeBlockSize);
-  Compressor.compress();
+  Compressor.compress(Verbose >= 2);
   if (Compressor.errorsFound()) {
     fatal("Failed to compress due to errors!");
     exit_status(EXIT_FAILURE);

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -17,6 +17,7 @@
 // Implements the compressor of WASM fiels base on integer usage.
 
 #include "intcomp/IntCompress.h"
+#include "interp/IntReader.h"
 #include "interp/IntWriter.h"
 #include "interp/StreamReader.h"
 #include "utils/circular-vector.h"
@@ -36,20 +37,20 @@ using namespace utils;
 
 namespace intcomp {
 
-class CounterWriter : public Writer {
-  CounterWriter() = delete;
-  CounterWriter(const CounterWriter&) = delete;
-  CounterWriter& operator=(const CounterWriter&) = delete;
+class IntCounterWriter : public Writer {
+  IntCounterWriter() = delete;
+  IntCounterWriter(const IntCounterWriter&) = delete;
+  IntCounterWriter& operator=(const IntCounterWriter&) = delete;
 
  public:
-  CounterWriter(IntCountUsageMap& UsageMap)
-      : UsageMap(UsageMap),
+  IntCounterWriter(IntCompressor::IntCounter& Counter)
+      : Counter(Counter),
         input_seq(new circular_vector<IntType>(1)),
         CountCutoff(1),
         WeightCutoff(1),
         UpToSize(0) {}
 
-  ~CounterWriter() OVERRIDE;
+  ~IntCounterWriter() OVERRIDE;
 
   void setSequenceSize(size_t Size);
   void setCountCutoff(uint64_t NewValue) { CountCutoff = NewValue; }
@@ -79,16 +80,13 @@ class CounterWriter : public Writer {
   bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
   bool writeAction(const filt::CallbackNode* Action) OVERRIDE;
 
-  BlockCountNode& getBlockCount() { return BlockCount; }
-
 // For debugging
 #if DESCRIBE_INPUT
   void describeInput();
 #endif
 
  private:
-  IntCountUsageMap& UsageMap;
-  BlockCountNode BlockCount;
+  IntCompressor::IntCounter& Counter;
   circular_vector<IntType>* input_seq;
   uint64_t CountCutoff;
   uint64_t WeightCutoff;
@@ -97,7 +95,7 @@ class CounterWriter : public Writer {
 };
 
 #if DESCRIBE_INPUT
-void CounterWriter::describeInput() {
+void IntCounterWriter::describeInput() {
   fprintf(stderr, "input seq:");
   for (size_t i = 0; i < input_seq->size(); ++i)
     fprintf(stderr, " %" PRIuMAX, uintmax_t((*input_seq).at(i)));
@@ -105,22 +103,22 @@ void CounterWriter::describeInput() {
 }
 #endif
 
-CounterWriter::~CounterWriter() {
+IntCounterWriter::~IntCounterWriter() {
   // TODO(karlschimpf): Recover memory of input_seq. Not done now due to
   // (optimized) of destruction of circular_vector<IntType>
 }
 
-StreamType CounterWriter::getStreamType() const {
+StreamType IntCounterWriter::getStreamType() const {
   return StreamType::Int;
 }
 
-void CounterWriter::setSequenceSize(size_t Size) {
+void IntCounterWriter::setSequenceSize(size_t Size) {
   input_seq->clear();
   if (Size > 0)
     input_seq->resize(Size);
 }
 
-void CounterWriter::popValuesFromInputSeq(size_t Size) {
+void IntCounterWriter::popValuesFromInputSeq(size_t Size) {
   for (size_t i = 0; i < Size; ++i) {
     if (input_seq->empty())
       return;
@@ -128,11 +126,11 @@ void CounterWriter::popValuesFromInputSeq(size_t Size) {
   }
 }
 
-void CounterWriter::addInputSeqToUsageMap() {
+void IntCounterWriter::addInputSeqToUsageMap() {
 #if DESCRIBE_INPUT
   describeInput();
 #endif
-  IntCountUsageMap* Map = &UsageMap;
+  IntCountUsageMap* Map = &Counter.UsageMap;
   IntCountNode* Nd = nullptr;
   for (size_t i = 0, e = input_seq->size(); i < e; ++i) {
     IntType Val = (*input_seq)[i];
@@ -157,66 +155,66 @@ void CounterWriter::addInputSeqToUsageMap() {
   popValuesFromInputSeq(1);
 }
 
-void CounterWriter::addAllInputSeqsToUsageMap() {
+void IntCounterWriter::addAllInputSeqsToUsageMap() {
   while (!input_seq->empty())
     addInputSeqToUsageMap();
 }
 
-void CounterWriter::addToUsageMap(IntType Value) {
+void IntCounterWriter::addToUsageMap(IntType Value) {
   input_seq->push_back(Value);
   if (!input_seq->full())
     return;
   addInputSeqToUsageMap();
 }
 
-bool CounterWriter::writeUint8(uint8_t Value) {
+bool IntCounterWriter::writeUint8(uint8_t Value) {
   addToUsageMap(Value);
   return true;
 }
 
-bool CounterWriter::writeUint32(uint32_t Value) {
+bool IntCounterWriter::writeUint32(uint32_t Value) {
   addToUsageMap(Value);
   return true;
 }
 
-bool CounterWriter::writeUint64(uint64_t Value) {
+bool IntCounterWriter::writeUint64(uint64_t Value) {
   addToUsageMap(Value);
   return true;
 }
 
-bool CounterWriter::writeVarint32(int32_t Value) {
+bool IntCounterWriter::writeVarint32(int32_t Value) {
   addToUsageMap(Value);
   return true;
 }
 
-bool CounterWriter::writeVarint64(int64_t Value) {
+bool IntCounterWriter::writeVarint64(int64_t Value) {
   addToUsageMap(Value);
   return true;
 }
 
-bool CounterWriter::writeVaruint32(uint32_t Value) {
+bool IntCounterWriter::writeVaruint32(uint32_t Value) {
   addToUsageMap(Value);
   return true;
 }
 
-bool CounterWriter::writeVaruint64(uint64_t Value) {
+bool IntCounterWriter::writeVaruint64(uint64_t Value) {
   addToUsageMap(Value);
   return true;
 }
 
-bool CounterWriter::writeValue(decode::IntType Value, const filt::Node*) {
+bool IntCounterWriter::writeValue(decode::IntType Value, const filt::Node*) {
   addToUsageMap(Value);
   return true;
 }
 
-bool CounterWriter::writeAction(const filt::CallbackNode* Action) {
+bool IntCounterWriter::writeAction(const filt::CallbackNode* Action) {
   const auto* Sym = dyn_cast<SymbolNode>(Action->getKid(0));
   if (Sym == nullptr)
     return false;
   switch (Sym->getPredefinedSymbol()) {
     case PredefinedSymbol::Block_enter:
       addAllInputSeqsToUsageMap();
-      BlockCount.increment();
+      Counter.BlockCount.increment();
       return true;
     case PredefinedSymbol::Block_exit:
       addAllInputSeqsToUsageMap();
@@ -226,21 +224,19 @@ bool CounterWriter::writeAction(const filt::CallbackNode* Action) {
   }
 }
 
-IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> InputStream,
-                             std::shared_ptr<decode::Queue> OutputStream,
+IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> Input,
+                             std::shared_ptr<decode::Queue> Output,
                              std::shared_ptr<filt::SymbolTable> Symtab)
-    : Symtab(Symtab), CountCutoff(0), WeightCutoff(0), LengthLimit(1) {
-  readInput(InputStream, Symtab);
-  Counter = new CounterWriter(UsageMap);
-  Input = new StreamReader(InputStream, *Counter, Symtab);
-  (void)OutputStream;
-  getTrace().setTraceProgress(true);
+    : Input(Input), Output(Output), Symtab(Symtab),
+      CountCutoff(0), WeightCutoff(0), LengthLimit(1), ErrorsFound(false) {
 }
 
 void IntCompressor::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
   Trace = NewTrace;
+#if 0
   if (Trace)
     Input->setTrace(Trace);
+#endif
 }
 
 TraceClassSexp& IntCompressor::getTrace() {
@@ -249,36 +245,50 @@ TraceClassSexp& IntCompressor::getTrace() {
   return *Trace;
 }
 
-bool IntCompressor::readInput(std::shared_ptr<Queue> InputStream,
-                              std::shared_ptr<SymbolTable> Symtab) {
+void IntCompressor::readInput(std::shared_ptr<Queue> InputStream,
+                              std::shared_ptr<SymbolTable> Symtab,
+                              bool TraceParsing) {
   Contents = std::make_shared<IntStream>();
   IntWriter MyWriter(Contents);
   StreamReader MyReader(InputStream, MyWriter, Symtab);
-  TraceClassSexp& Trace = MyReader.getTrace();
-  Trace.addContext(MyReader.getTraceContext());
-  Trace.addContext(MyWriter.getTraceContext());
-  Trace.setTraceProgress(true);
+  if (TraceParsing) {
+    TraceClassSexp& Trace = MyReader.getTrace();
+    Trace.addContext(MyReader.getTraceContext());
+    Trace.addContext(MyWriter.getTraceContext());
+    Trace.setTraceProgress(true);
+  }
   MyReader.start();
   MyReader.readBackFilled();
-  return MyReader.isFinished() && MyReader.isSuccessful();
+  bool Successful = MyReader.isFinished() && MyReader.isSuccessful();
+  if (!Successful)
+    ErrorsFound = true;
+  Input.reset();
+  return;
 }
 
 IntCompressor::~IntCompressor() {
-  delete Input;
-  delete Counter;
+  Input.reset();
+  Output.reset();
   IntCountNode::clear(UsageMap);
 }
 
-void IntCompressor::compressUpToSize(size_t Size) {
-  fprintf(stderr,
-          "Collecting integer sequences of (up to) length: %" PRIuMAX "\n",
-          uintmax_t(Size));
-  Counter->setUpToSize(Size);
-  Input->startUsing(StartPos);
-  Input->readBackFilled();
-  // Flush any remaining values in input sequece.
-  Counter->addAllInputSeqsToUsageMap();
-  Counter->resetUpToSize();
+bool IntCompressor::compressUpToSize(size_t Size, bool TraceParsing) {
+  if (Size == 1)
+    fprintf(stderr, "Collecting integer sequences of length: 1\n");
+  else
+    fprintf(stderr,
+            "Collecting integer sequences of (up to) length: %" PRIuMAX "\n",
+            uintmax_t(Size));
+  IntCounterWriter Writer(Counter);
+  Writer.setCountCutoff(CountCutoff);
+  Writer.setWeightCutoff(WeightCutoff);
+  Writer.setUpToSize(Size);
+  IntReader Reader(Contents, Writer, Symtab);
+  Reader.getTrace().setTraceProgress(TraceParsing);
+  Reader.fastRead();
+  if (!Reader.errorsFound())
+    Writer.addAllInputSeqsToUsageMap();
+  return !Reader.errorsFound();
 }
 
 void IntCompressor::removeSmallUsageCounts(IntCountUsageMap& UsageMap) {
@@ -311,35 +321,33 @@ bool IntCompressor::removeSmallUsageCounts(CountNode* Nd) {
   return false;
 }
 
-void IntCompressor::compress() {
+void IntCompressor::compress(bool TraceParsing, bool TraceFirstPassOnly) {
   TRACE_METHOD("compress");
-#if 0
-  if (!readInput()) {
+  readInput(Input, Symtab, TraceParsing);
+  if (errorsFound()) {
     fprintf(stderr, "Unable to decompress, input malformed");
     return;
   }
-  Counter->setCountCutoff(CountCutoff);
-  Counter->setWeightCutoff(WeightCutoff);
   // Start by collecting number of occurrences of each integer, so
   // that we can use as a filter on integer sequence inclusion into the
   // IntCountNode trie.
-  compressUpToSize(1);
+  if (!compressUpToSize(1, TraceParsing))
+    return;
   removeSmallUsageCounts();
   describe(stderr, Flag(CollectionFlag::TopLevel));
   if (LengthLimit > 1) {
-    compressUpToSize(LengthLimit);
+    if (!compressUpToSize(LengthLimit, TraceParsing))
+      return;
     removeSmallUsageCounts();
   }
   describe(stderr, Flag(CollectionFlag::IntPaths));
-#endif
 }
 
 namespace {
 
 class CountNodeCollector {
  public:
-  IntCountUsageMap& UsageMap;
-  CounterWriter* Counter;
+  IntCompressor::IntCounter& Counter;
   std::vector<CountNode::HeapValueType> Values;
   std::shared_ptr<CountNode::HeapType> ValuesHeap;
   uint64_t WeightTotal;
@@ -350,10 +358,8 @@ class CountNodeCollector {
   uint64_t CountCutoff;
   uint64_t WeightCutoff;
 
-  explicit CountNodeCollector(IntCountUsageMap& UsageMap,
-                              CounterWriter* Counter)
-      : UsageMap(UsageMap),
-        Counter(Counter),
+  explicit CountNodeCollector(IntCompressor::IntCounter& Counter)
+      : Counter(Counter),
         ValuesHeap(std::make_shared<CountNode::HeapType>()),
         WeightTotal(0),
         CountTotal(0),
@@ -401,8 +407,8 @@ void CountNodeCollector::buildHeap() {
 
 void CountNodeCollector::collect(CollectionFlags Flags) {
   if (hasFlag(CollectionFlag::TopLevel, Flags))
-    collectNode(&Counter->getBlockCount(), Flags);
-  for (const auto& pair : UsageMap)
+    collectNode(&Counter.BlockCount, Flags);
+  for (const auto& pair : Counter.UsageMap)
     collectNode(pair.second, Flags);
 }
 
@@ -469,7 +475,7 @@ void CountNodeCollector::describe(FILE* Out) {
 
 void IntCompressor::describe(FILE* Out, CollectionFlags Flags) {
   fprintf(stderr, "Collecting results...\n");
-  CountNodeCollector Collector(UsageMap, Counter);
+  CountNodeCollector Collector(Counter);
   Collector.CountCutoff = CountCutoff;
   Collector.WeightCutoff = WeightCutoff;
   Collector.collect(Flags);

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -29,6 +29,8 @@ namespace wasm {
 
 namespace intcomp {
 
+class IntCounterWriter;
+
 typedef uint32_t CollectionFlags;
 
 enum class CollectionFlag : CollectionFlags {
@@ -46,7 +48,6 @@ inline bool hasFlag(CollectionFlag F, CollectionFlags Flags) {
   return Flag(F) & Flags;
 }
 
-class CounterWriter;
 
 class IntCompressor FINAL {
   IntCompressor() = delete;
@@ -54,18 +55,37 @@ class IntCompressor FINAL {
   IntCompressor& operator=(const IntCompressor&) = delete;
 
  public:
+  IntCountUsageMap UsageMap;
+  class IntCounter {
+    IntCounter(const IntCounter&) = delete;
+    IntCounter& operator=(const IntCounter&) = delete;
+   public:
+    IntCounter() {}
+    ~IntCounter() = default;
+    const IntCountUsageMap& getUsageMap() const {
+      return UsageMap;
+    }
+    IntCountUsageMap UsageMap;
+    BlockCountNode BlockCount;
+  };
   IntCompressor(std::shared_ptr<decode::Queue> InputStream,
                 std::shared_ptr<decode::Queue> OutputStream,
                 std::shared_ptr<filt::SymbolTable> Symtab);
 
   ~IntCompressor();
 
-  bool errorsFound() const { return Input == nullptr && Input->errorsFound(); }
+  bool errorsFound() const { return ErrorsFound; }
 
-  void compress();
+  void compress(bool TraceParsing = false,
+                bool TraceFirstPassOnly = true);
 
   void setTraceProgress(bool NewValue) {
+    // TODO: Don't force creation of trace object if not needed.
     getTrace().setTraceProgress(NewValue);
+  }
+  bool getTraceProgress() {
+    // TODO: Don't force creation of trace object if not needed.
+    return getTrace().getTraceProgress();
   }
   void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
   filt::TraceClassSexp& getTrace();
@@ -79,20 +99,21 @@ class IntCompressor FINAL {
   void describe(FILE* Out, CollectionFlags = Flag(CollectionFlag::All));
 
  private:
+  std::shared_ptr<decode::Queue> Input;
+  std::shared_ptr<decode::Queue> Output;
   std::shared_ptr<filt::SymbolTable> Symtab;
-  interp::StreamReader* Input;
   std::shared_ptr<interp::IntStream> Contents;
-  CounterWriter* Counter;
-  decode::ReadCursor StartPos;
-  IntCountUsageMap UsageMap;
+  IntCounter Counter;
   std::shared_ptr<filt::TraceClassSexp> Trace;
   uint64_t CountCutoff;
   uint64_t WeightCutoff;
   size_t LengthLimit;
-  bool readInput(std::shared_ptr<decode::Queue> InputStream,
-                 std::shared_ptr<filt::SymbolTable> Symtab);
-  void compressUpToSize(size_t Size);
-  void removeSmallUsageCounts() { removeSmallUsageCounts(UsageMap); }
+  bool ErrorsFound;
+  void readInput(std::shared_ptr<decode::Queue> InputStream,
+                 std::shared_ptr<filt::SymbolTable> Symtab,
+                 bool TraceParsing);
+  bool compressUpToSize(size_t Size, bool TraceParsing);
+  void removeSmallUsageCounts() { removeSmallUsageCounts(Counter.UsageMap); }
   void removeSmallUsageCounts(IntCountUsageMap& UsageMap);
   bool removeSmallUsageCounts(CountNode* Nd);
 };

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -20,6 +20,7 @@
 #define DECOMPRESSOR_SRC_INTCOMP_INTCOMPRESS_H
 
 #include "intcomp/IntCountNode.h"
+#include "interp/IntStream.h"
 #include "interp/StreamReader.h"
 #include "interp/StreamWriter.h"
 #include "sexp/TraceSexp.h"
@@ -80,6 +81,7 @@ class IntCompressor FINAL {
  private:
   std::shared_ptr<filt::SymbolTable> Symtab;
   interp::StreamReader* Input;
+  std::shared_ptr<interp::IntStream> Contents;
   CounterWriter* Counter;
   decode::ReadCursor StartPos;
   IntCountUsageMap UsageMap;
@@ -87,6 +89,8 @@ class IntCompressor FINAL {
   uint64_t CountCutoff;
   uint64_t WeightCutoff;
   size_t LengthLimit;
+  bool readInput(std::shared_ptr<decode::Queue> InputStream,
+                 std::shared_ptr<filt::SymbolTable> Symtab);
   void compressUpToSize(size_t Size);
   void removeSmallUsageCounts() { removeSmallUsageCounts(UsageMap); }
   void removeSmallUsageCounts(IntCountUsageMap& UsageMap);

--- a/src/interp/IntReader.h
+++ b/src/interp/IntReader.h
@@ -41,10 +41,15 @@ class IntReader : public Reader {
             std::shared_ptr<filt::SymbolTable> Symtab);
   ~IntReader() OVERRIDE;
 
-  void startAtBeginning();
+  // Parses inpuot structure of int stream using rules in Symtab.
+  void interpRead();
+
+  // Parses input structure of int stream (rather than using rules in
+  // Symtab).
+  void fastRead();
 
  private:
-  IntStream::ReadCursor Pos;
+  IntStream::ReadCursorWithTraceContext Pos;
   IntStream::StreamPtr Input;
   // Shows how many are still available since last call to
   // canProcessMoreInputNow().
@@ -53,7 +58,17 @@ class IntReader : public Reader {
   IntStream::ReadCursor PeekPos;
   utils::ValueStack<IntStream::Cursor> PeekPosStack;
 
+  std::shared_ptr<filt::TraceClassSexp> createTrace() OVERRIDE;
+
   void describePeekPosStack(FILE* Out) OVERRIDE;
+
+  bool fastReadUntil(size_t Eob);
+
+  decode::IntType read() {
+    return Pos.read();
+  }
+
+  utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
   bool canProcessMoreInputNow() OVERRIDE;
   bool stillMoreInputToProcessNow() OVERRIDE;
@@ -75,6 +90,8 @@ class IntReader : public Reader {
   uint32_t readVaruint32() OVERRIDE;
   uint64_t readVaruint64() OVERRIDE;
   decode::IntType readValue(const filt::Node* Format) OVERRIDE;
+
+  void fastReadBlock();
 };
 
 }  // end of namespace interp

--- a/src/interp/IntStream.cpp
+++ b/src/interp/IntStream.cpp
@@ -18,17 +18,6 @@
 
 #include "interp/IntStream.h"
 
-namespace {
-
-void describeBlockIndex(FILE* File, size_t Index) {
-  if (Index == std::numeric_limits<size_t>::max())
-    fputc('?', File);
-  else
-    fprintf(File, "%" PRIxMAX "", Index);
-}
-
-} // end of anonymous namespace
-
 namespace wasm {
 
 using namespace decode;
@@ -37,10 +26,9 @@ using namespace utils;
 namespace interp {
 
 void IntStream::Block::describe(FILE* File) {
-  fputc('[', File);
-  describeBlockIndex(File, BeginIndex);
-  fputc(':', File);
-  describeBlockIndex(File, EndIndex);
+  fprintf(File, "[%" PRIxMAX "", BeginIndex);
+  if (EndIndex != std::numeric_limits<size_t>::max())
+    fprintf(File, ":%" PRIxMAX "", EndIndex);
   fputc(']', File);
 }
 
@@ -166,6 +154,7 @@ bool IntStream::ReadCursor::openBlock() {
   std::shared_ptr<Block> CurBlock = EnclosingBlocks.back();
   assert(CurBlock);
   EnclosingBlocks.push_back(Blk);
+  ++NextBlock;
   return true;
 }
 

--- a/src/interp/IntStream.cpp
+++ b/src/interp/IntStream.cpp
@@ -18,11 +18,37 @@
 
 #include "interp/IntStream.h"
 
+namespace {
+
+void describeBlockIndex(FILE* File, size_t Index) {
+  if (Index == std::numeric_limits<size_t>::max())
+    fputc('?', File);
+  else
+    fprintf(File, "%" PRIxMAX "", Index);
+}
+
+} // end of anonymous namespace
+
 namespace wasm {
 
 using namespace decode;
+using namespace utils;
 
 namespace interp {
+
+void IntStream::Block::describe(FILE* File) {
+  fputc('[', File);
+  describeBlockIndex(File, BeginIndex);
+  fputc(':', File);
+  describeBlockIndex(File, EndIndex);
+  fputc(']', File);
+}
+
+IntStream::Cursor::TraceContext::~TraceContext() {}
+
+void IntStream::Cursor::TraceContext::describe(FILE* File) {
+  Pos.describe(File);
+}
 
 IntStream::Cursor::Cursor(StreamPtr Stream) : Index(0), Stream(Stream) {
   assert(Stream);
@@ -38,6 +64,19 @@ IntStream::Cursor& IntStream::Cursor::operator=(const IntStream::Cursor& C) {
   EnclosingBlocks = C.EnclosingBlocks;
   Stream = C.Stream;
   return *this;
+}
+
+FILE* IntStream::Cursor::describe(FILE* File, bool IncludeDetail, bool AddEoln) {
+  if (IncludeDetail)
+    fputs("IntStream::Cursor<", File);
+  fprintf(File, "@%" PRIxMAX "", uintmax_t(Index));
+  for (auto Blk : EnclosingBlocks)
+    Blk->describe(File);
+  if (IncludeDetail)
+    fputc('>', File);
+  if (AddEoln)
+    fputc('\n', File);
+  return File;
 }
 
 bool IntStream::Cursor::atEof() const {
@@ -68,6 +107,7 @@ bool IntStream::WriteCursor::write(IntType Value) {
   assert(!EnclosingBlocks.empty());
   assert(EnclosingBlocks.back()->getEndIndex() >= Index);
   Stream->Values.push_back(Value);
+  ++Index;
   return true;
 }
 
@@ -101,6 +141,13 @@ bool IntStream::WriteCursor::closeBlock() {
   return true;
 }
 
+TraceClass::ContextPtr
+IntStream::WriteCursorWithTraceContext::getTraceContext() {
+  if (!TraceContext)
+    TraceContext = std::make_shared<IntStream::Cursor::TraceContext>(*this);
+  return TraceContext;
+}
+
 IntType IntStream::ReadCursor::read() {
   // TODO(karlschimpf): Add capability to communicate failure to caller.
   assert(!EnclosingBlocks.empty());
@@ -127,6 +174,13 @@ bool IntStream::ReadCursor::closeBlock() {
   if (!Blk)
     return false;
   return Blk->getEndIndex() == Index;
+}
+
+TraceClass::ContextPtr
+IntStream::ReadCursorWithTraceContext::getTraceContext() {
+  if (!TraceContext)
+    TraceContext = std::make_shared<IntStream::Cursor::TraceContext>(*this);
+  return TraceContext;
 }
 
 }  // end of namespace interp

--- a/src/interp/IntStream.h
+++ b/src/interp/IntStream.h
@@ -151,6 +151,12 @@ class IntStream : public std::enable_shared_from_this<IntStream> {
     decode::IntType read();
     bool openBlock();
     bool closeBlock();
+    bool hasMoreBlocks() const {
+      return NextBlock != EndBlocks;
+    }
+    BlockPtr getNextBlock() const {
+      return *NextBlock;
+    }
 
    private:
     IntStream::BlockIterator NextBlock;
@@ -158,6 +164,7 @@ class IntStream : public std::enable_shared_from_this<IntStream> {
   };
 
   class ReadCursorWithTraceContext : public ReadCursor {
+   public:
     ReadCursorWithTraceContext() : ReadCursor() {}
     explicit ReadCursorWithTraceContext(StreamPtr Stream)
         : ReadCursor(Stream) {}

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -22,11 +22,16 @@ namespace wasm {
 
 using namespace decode;
 using namespace filt;
+using namespace utils;
 
 namespace interp {
 
 void IntWriter::reset() {
   Output.reset();
+}
+
+TraceClass::ContextPtr IntWriter::getTraceContext() {
+  return Pos.getTraceContext();
 }
 
 StreamType IntWriter::getStreamType() const {
@@ -101,7 +106,6 @@ bool IntWriter::writeAction(const filt::CallbackNode* Action) {
   switch (Sym->getPredefinedSymbol()) {
     case PredefinedSymbol::Block_enter:
       return Pos.openBlock();
-      return true;
     case PredefinedSymbol::Block_exit:
       return Pos.closeBlock();
     default:

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -50,9 +50,11 @@ class IntWriter : public Writer {
   bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
   bool writeAction(const filt::CallbackNode* Action) OVERRIDE;
 
+  utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
+
  private:
   std::shared_ptr<IntStream> Output;
-  IntStream::WriteCursor Pos;
+  IntStream::WriteCursorWithTraceContext Pos;
 };
 
 }  // end of namespace interp

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -103,13 +103,19 @@ TraceClass::ContextPtr Reader::getTraceContext() {
 
 void Reader::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
   Trace = NewTrace;
-  if (Trace)
+  if (Trace) {
     Trace->addContext(getTraceContext());
+    Trace->addContext(Output.getTraceContext());
+  }
+}
+
+std::shared_ptr<TraceClassSexp> Reader::createTrace() {
+  return std::make_shared<TraceClassSexp>("Reader");
 }
 
 TraceClassSexp& Reader::getTrace() {
   if (!Trace)
-    setTrace(std::make_shared<TraceClassSexp>("StreamReader"));
+    setTrace(createTrace());
   return *Trace;
 }
 
@@ -144,8 +150,8 @@ const char* Reader::getName(SectionCode Code) {
   return SectionCodeName[Index];
 }
 
-Reader::Reader(Writer& StrmOutput, std::shared_ptr<filt::SymbolTable> Symtab)
-    : Output(StrmOutput),
+Reader::Reader(Writer& Output, std::shared_ptr<filt::SymbolTable> Symtab)
+    : Output(Output),
       Symtab(Symtab),
       LastReadValue(0),
       DispatchedMethod(Method::NO_SUCH_METHOD),
@@ -275,8 +281,6 @@ void Reader::callTopLevel(Method Method, const filt::Node* Nd) {
 }
 
 bool Reader::writeAction(const filt::CallbackNode* Action) {
-  // TODO(karlschimpf) Capture symbol_name's so that we can
-  // dispatch on it.
   return Output.writeAction(Action);
 }
 

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -62,11 +62,6 @@ class Reader {
   // Force interpretation to fail.
   void fail(const std::string& Message);
 
-  // Returns the current read position of the input stream. NOTE:
-  // This (in general) should not be called unless you explicitly know
-  // that the input is a stream that can defined cursors.
-  virtual decode::ReadCursor& getPos() = 0;
-
   // Returns non-null context handler if applicable.
   virtual utils::TraceClass::ContextPtr getTraceContext();
   void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
@@ -82,6 +77,7 @@ class Reader {
   static const char* getName(SectionCode Code);
 
  protected:
+
   enum class Method {
 #define X(tag) tag,
     INTERPRETER_METHODS_TABLE
@@ -215,6 +211,8 @@ class Reader {
   OpcodeLocalsFrame OpcodeLocals;
   utils::ValueStack<OpcodeLocalsFrame> OpcodeLocalsStack;
 
+  virtual std::shared_ptr<filt::TraceClassSexp> createTrace();
+
   virtual void reset();
 
   // Initializes all internal stacks, for an initial call to Method with
@@ -232,7 +230,8 @@ class Reader {
   }
 
   void popAndReturn(decode::IntType Value = 0) {
-    FrameStack.pop();
+    if (!FrameStack.empty())
+      FrameStack.pop();
     Frame.ReturnValue = Value;
     TRACE(IntType, "returns", Value);
   }

--- a/src/interp/StreamReader.cpp
+++ b/src/interp/StreamReader.cpp
@@ -39,6 +39,10 @@ StreamReader::StreamReader(std::shared_ptr<decode::Queue> StrmInput,
 StreamReader::~StreamReader() {
 }
 
+std::shared_ptr<TraceClassSexp> StreamReader::createTrace() {
+  return std::make_shared<TraceClassSexp>("StreamReader");
+}
+
 void StreamReader::startUsing(const decode::ReadCursor& StartPos) {
   ReadPos = StartPos;
   start();

--- a/src/interp/StreamReader.h
+++ b/src/interp/StreamReader.h
@@ -37,7 +37,7 @@ class StreamReader : public Reader {
                std::shared_ptr<filt::SymbolTable> Symtab);
   ~StreamReader() OVERRIDE;
   void startUsing(const decode::ReadCursor& ReadPos);
-  decode::ReadCursor& getPos() OVERRIDE;
+  decode::ReadCursor& getPos();
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
  private:
@@ -52,6 +52,7 @@ class StreamReader : public Reader {
   decode::ReadCursor PeekPos;
   utils::ValueStack<decode::ReadCursor> PeekPosStack;
 
+  std::shared_ptr<filt::TraceClassSexp> createTrace() OVERRIDE;
   void describePeekPosStack(FILE* Out) OVERRIDE;
 
   bool canProcessMoreInputNow() OVERRIDE;

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -70,13 +70,13 @@ FILE* Cursor::describe(FILE* File, bool IncludeDetail, bool AddEoln) {
     fputc(' ', File);
     CurByte.describe(File);
   }
-  if (!IncludeDetail)
-    return File;
-  if (EobPtr->isDefined()) {
-    fprintf(File, ", eob=");
-    getEobAddress().describe(File);
+  if (IncludeDetail) {
+    if (EobPtr->isDefined()) {
+      fprintf(File, ", eob=");
+      getEobAddress().describe(File);
+    }
+    fputc('>', File);
   }
-  fputc('>', File);
   if (AddEoln)
     fputc('\n', File);
   return File;

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -88,7 +88,7 @@ class Cursor : public PageCursor {
     TraceContext& operator=(const TraceContext&) = delete;
    public:
     TraceContext(Cursor& Pos) : Pos(Pos) {}
-    ~TraceContext();
+    ~TraceContext() OVERRIDE;
     void describe(FILE* File) OVERRIDE;
    private:
     Cursor& Pos;

--- a/src/utils/Trace.cpp
+++ b/src/utils/Trace.cpp
@@ -66,7 +66,7 @@ void TraceClass::traceContext() const {
   if (ContextList.empty())
     return;
   for (size_t i = 0; i < ContextList.size(); ++i) {
-    if (i > 0 && (i + 1) < ContextList.size())
+    if (i > 0)
       fputc('/', File);
     ContextList[i]->describe(File);
   }


### PR DESCRIPTION
Fixes int streams, and then reads the WASM file into one. The int stream is then used to analyze the WASM file for compression.

Uses int streams because we can "fast" read/write them (when compared to byte streams).