### PR TITLE
Clean up compression by using estimates on bytes used.

### DIFF
--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -117,7 +117,7 @@ void IntCounterWriter::addInputSeqToUsageMap() {
   IntCountNode* Nd = nullptr;
   for (size_t i = 0, e = input_seq->size(); i < e; ++i) {
     IntType Val = (*input_seq)[i];
-    Nd = IntCountNode::lookup(*Map, Val, Nd);
+    Nd = IntCountNode::lookup(*Map, Counter.UsageMap, Val, Nd);
     if (UpToSize == 1 || i > 0)
       Nd->increment();
     if (e > 1) {
@@ -220,10 +220,6 @@ IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> Input,
 
 void IntCompressor::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
   Trace = NewTrace;
-#if 0
-  if (Trace)
-    Input->setTrace(Trace);
-#endif
 }
 
 TraceClassSexp& IntCompressor::getTrace() {
@@ -414,6 +410,9 @@ void CountNodeCollector::collect(CollectionFlags Flags) {
 }
 
 void CountNodeCollector::collectNode(CountNode* Nd, CollectionFlags Flags) {
+  // TODO(karlschimpf) Make this non-recursive.
+  if (Nd == nullptr)
+    return;
   uint64_t Weight = Nd->getWeight();
   uint64_t Count = Nd->getCount();
   auto* IntNd = dyn_cast<IntCountNode>(Nd);

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -62,7 +62,6 @@ class IntCompressor FINAL {
    public:
     IntCounter() {}
     ~IntCounter() = default;
-    const IntCountUsageMap& getUsageMap() const { return UsageMap; }
     IntCountUsageMap UsageMap;
     BlockCountNode BlockCount;
   };

--- a/src/intcomp/IntFormats.h
+++ b/src/intcomp/IntFormats.h
@@ -29,14 +29,16 @@ namespace intcomp {
 enum class IntTypeFormat {
   // Note: Sizes are listed in order of preference, if they contain the
   // same number of bytes.
+  // NOTE: If you change this list, change the definition of IntTypeFormatName
+  // (in cpp file) as well.
   Uint8,
-  Uint32,
-  Uint64,
-  Varuint32,
   Varint32,
-  Varuint64,
+  Varuint32,
+  Uint32,
   Varint64,
-  LAST = Varint64  // Note: worst case choice.
+  Varuint64,
+  Uint64,
+  LAST = Uint64  // Note: worst case choice.
 };
 
 const char* getName(IntTypeFormat Fmt);
@@ -53,15 +55,17 @@ class IntTypeFormats {
   IntTypeFormats(decode::IntType Value);
 
   decode::IntType getValue() const { return Value; }
-  int getByteSize(IntTypeFormat Fmt) const {
-    return ByteSize[size_t(Fmt)];
-  }
+  int getByteSize(IntTypeFormat Fmt) const { return ByteSize[size_t(Fmt)]; }
 
   // Returns the preferred format, based on the number of bytes.
   IntTypeFormat getFirstMinimumFormat() const;
 
   // Returns next format with same size, or Fmt if no more candidates.
   IntTypeFormat getNextMatchingFormat(IntTypeFormat Fmt) const;
+
+  int getMinFormatSize() const {
+    return ByteSize[size_t(getFirstMinimumFormat())];
+  }
 
  private:
   decode::IntType Value;
@@ -74,5 +78,4 @@ class IntTypeFormats {
 
 }  // end of namespace wasm
 
-
-#endif // DECOMPRESSOR_SRC_INTCOMP_INTFORMATS_H
+#endif  // DECOMPRESSOR_SRC_INTCOMP_INTFORMATS_H

--- a/src/interp/FormatHelpers.h
+++ b/src/interp/FormatHelpers.h
@@ -25,6 +25,8 @@ namespace wasm {
 
 namespace interp {
 
+namespace fmt {
+
 template <class Type, class ReadCursor>
 Type readFixed(ReadCursor& Pos) {
   Type Value = 0;
@@ -66,6 +68,41 @@ Type readSignedLEB128(ReadCursor& Pos) {
   if ((Chunk & 0x40) && (Shift < sizeof(Type) * CHAR_BIT))
     Value |= ~Type(0) << Shift;
   return Value;
+}
+
+template <class ReadCursor>
+uint8_t readUint8(ReadCursor& Pos) {
+  return Pos.readByte();
+}
+
+template <class ReadCursor>
+uint32_t readUint32(ReadCursor& Pos) {
+  return fmt::readFixed<uint32_t>(Pos);
+}
+
+template <class ReadCursor>
+uint64_t readUint64(ReadCursor& Pos) {
+  return fmt::readFixed<uint64_t>(Pos);
+}
+
+template <class ReadCursor>
+int32_t readVarint32(ReadCursor& Pos) {
+  return fmt::readSignedLEB128<uint32_t>(Pos);
+}
+
+template <class ReadCursor>
+int64_t readVarint64(ReadCursor& Pos) {
+  return fmt::readSignedLEB128<uint64_t>(Pos);
+}
+
+template <class ReadCursor>
+uint32_t readVaruint32(ReadCursor& Pos) {
+  return fmt::readLEB128<uint32_t>(Pos);
+}
+
+template <class ReadCursor>
+uint64_t readVaruint64(ReadCursor& Pos) {
+  return fmt::readLEB128<uint64_t>(Pos);
 }
 
 // Define LEB128 writers.
@@ -121,6 +158,54 @@ void writeFixed(Type Value, WriteCursor& Pos) {
     Value >>= CHAR_BIT;
   }
 }
+
+template <class WriteCursor>
+void writeUint8(uint8_t Value, WriteCursor& Pos) {
+  Pos.writeByte(Value);
+}
+
+template <class WriteCursor>
+void writeUint32(uint32_t Value, WriteCursor& Pos) {
+  writeFixed(Value, Pos);
+}
+
+template <class WriteCursor>
+void writeUint64(uint64_t Value, WriteCursor& Pos) {
+  writeFixed(Value, Pos);
+}
+
+template <class WriteCursor>
+void writeVarint32(int32_t Value, WriteCursor& Pos) {
+  if (Value < 0)
+    writeNegativeLEB128(Value, Pos);
+  else
+    writePositiveLEB128(Value, Pos);
+}
+
+template <class WriteCursor>
+void writeVarint64(int64_t Value, WriteCursor& Pos) {
+  if (Value < 0)
+    writeNegativeLEB128(Value, Pos);
+  else
+    writePositiveLEB128(Value, Pos);
+}
+
+template <class WriteCursor>
+void writeVaruint32(uint32_t Value, WriteCursor& Pos) {
+  writeLEB128(Value, Pos);
+}
+
+template <class WriteCursor>
+void writeVaruint64(uint64_t Value, WriteCursor& Pos) {
+  writeLEB128(Value, Pos);
+}
+
+template <class WriteCursor>
+void writeFixedVaruint32(uint32_t Value, WriteCursor& Pos) {
+  writeFixedLEB128(Value, Pos);
+}
+
+}  // end of namespace fmt
 
 }  // end of namespace decode
 

--- a/src/interp/ReadStream.cpp
+++ b/src/interp/ReadStream.cpp
@@ -31,31 +31,31 @@ ReadStream::~ReadStream() {
 }
 
 uint8_t ReadStream::readUint8(ReadCursor& Pos) {
-  return Pos.readByte();
+  return fmt::readUint8(Pos);
 }
 
 uint32_t ReadStream::readUint32(ReadCursor& Pos) {
-  return readFixed<uint32_t>(Pos);
+  return fmt::readUint32(Pos);
 }
 
 uint64_t ReadStream::readUint64(ReadCursor& Pos) {
-  return readFixed<uint64_t>(Pos);
+  return fmt::readUint64(Pos);
 }
 
 int32_t ReadStream::readVarint32(ReadCursor& Pos) {
-  return readSignedLEB128<uint32_t>(Pos);
+  return fmt::readVarint32(Pos);
 }
 
 int64_t ReadStream::readVarint64(ReadCursor& Pos) {
-  return readSignedLEB128<uint64_t>(Pos);
+  return fmt::readVarint64(Pos);
 }
 
 uint32_t ReadStream::readVaruint32(ReadCursor& Pos) {
-  return readLEB128<uint32_t>(Pos);
+  return fmt::readVaruint32(Pos);
 }
 
 uint64_t ReadStream::readVaruint64(ReadCursor& Pos) {
-  return readLEB128<uint64_t>(Pos);
+  return fmt::readVaruint64(Pos);
 }
 
 }  // end of namespace interp

--- a/src/interp/WriteStream.cpp
+++ b/src/interp/WriteStream.cpp
@@ -31,41 +31,35 @@ WriteStream::~WriteStream() {
 }
 
 void WriteStream::writeUint8(uint8_t Value, WriteCursor& Pos) {
-  Pos.writeByte(uint8_t(Value));
+  fmt::writeUint8(Value, Pos);
 }
 
 void WriteStream::writeUint32(uint32_t Value, WriteCursor& Pos) {
-  writeFixed<uint32_t>(Value, Pos);
+  fmt::writeUint32(Value, Pos);
 }
 
 void WriteStream::writeUint64(uint64_t Value, WriteCursor& Pos) {
-  writeFixed<uint64_t>(Value, Pos);
+  fmt::writeUint64(Value, Pos);
 }
 
 void WriteStream::writeVarint32(int32_t Value, WriteCursor& Pos) {
-  if (Value < 0)
-    writeNegativeLEB128<int32_t>(Value, Pos);
-  else
-    writePositiveLEB128<int32_t>(Value, Pos);
+  fmt::writeVarint32(Value, Pos);
 }
 
 void WriteStream::writeVarint64(int64_t Value, WriteCursor& Pos) {
-  if (Value < 0)
-    writeNegativeLEB128<int64_t>(Value, Pos);
-  else
-    writePositiveLEB128<int64_t>(Value, Pos);
+  fmt::writeVarint64(Value, Pos);
 }
 
 void WriteStream::writeVaruint32(uint32_t Value, WriteCursor& Pos) {
-  writeLEB128<uint32_t>(Value, Pos);
+  fmt::writeVaruint32(Value, Pos);
 }
 
 void WriteStream::writeVaruint64(uint64_t Value, WriteCursor& Pos) {
-  writeLEB128<uint64_t>(Value, Pos);
+  fmt::writeVaruint64(Value, Pos);
 }
 
 void WriteStream::writeFixedVaruint32(uint32_t Value, WriteCursor& Pos) {
-  writeFixedLEB128<uint32_t>(Value, Pos);
+  fmt::writeFixedVaruint32(Value, Pos);
 }
 
 }  // end of namespace decode


### PR DESCRIPTION
Now computes weights based on minimum number of bytes needed to represent each integer in an value sequence, rather than always assuming 1. This produces better estimates on space saved when building abbreviations for such paths.