### PR TITLE
Clean up trace messages.

### DIFF
--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -24,19 +24,6 @@ using namespace decode;
 
 namespace intcomp {
 
-namespace {
-
-void describeIntType(FILE* File, IntType Value) {
-  SignedIntType SignedValue = SignedIntType(Value);
-  if (SignedValue < 0) {
-    fputc('-', File);
-    Value = IntType(-SignedValue);
-  }
-  fprintf(File, "%" PRIuMAX "", uintmax_t(Value));
-}
-
-}  // end of anonymous namespace
-
 CountNode::~CountNode() {
 }
 
@@ -141,7 +128,7 @@ void IntCountNode::describePath(FILE* Out, size_t MaxPath) const {
   if (Parent)
     Parent->describePath(Out, MaxPath - 1);
   fputc(' ', Out);
-  describeIntType(Out, Value);
+  fprint_IntType(Out, Value);
 }
 
 size_t IntCountNode::pathLength() const {

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -24,6 +24,19 @@ using namespace decode;
 
 namespace intcomp {
 
+namespace {
+
+void describeIntType(FILE* File, IntType Value) {
+  SignedIntType SignedValue = SignedIntType(Value);
+  if (SignedValue < 0) {
+    fputc('-', File);
+    Value = IntType(-SignedValue);
+  }
+  fprintf(File, "%" PRIuMAX "", uintmax_t(Value));
+}
+
+}  // end of anonymous namespace
+
 CountNode::~CountNode() {
 }
 
@@ -117,7 +130,7 @@ void IntCountNode::describe(FILE* Out, size_t NestLevel) const {
   fputc(':', Out);
   // TODO(karlschimpf): Make this a programmable parameter.
   describePath(Out, 10);
-  fprintf(Out, "  Count: %" PRIuMAX "\n", uintmax_t(getCount()));
+  fprintf(Out, " Count: %" PRIuMAX "\n", uintmax_t(getCount()));
 }
 
 void IntCountNode::describePath(FILE* Out, size_t MaxPath) const {
@@ -127,7 +140,8 @@ void IntCountNode::describePath(FILE* Out, size_t MaxPath) const {
   }
   if (Parent)
     Parent->describePath(Out, MaxPath - 1);
-  fprintf(Out, " %" PRIuMAX "", uintmax_t(Value));
+  fputc(' ', Out);
+  describeIntType(Out, Value);
 }
 
 size_t IntCountNode::pathLength() const {

--- a/src/interp/IntStream.cpp
+++ b/src/interp/IntStream.cpp
@@ -187,8 +187,11 @@ void IntStream::describe(FILE* File) {
     fputc('\n', File);
   }
   fputs("Values:\n", File);
-  for (auto V : Values)
-    fprintf(File, "  %" PRIuMAX "\n", uintmax_t(V));
+  for (auto V : Values) {
+    fputs("  ", File);
+    fprint_IntType(File, V);
+    fputc('\n', File);
+  }
   fprintf(File, "*****************\n");
 }
 

--- a/src/interp/Interpreter.def
+++ b/src/interp/Interpreter.def
@@ -44,9 +44,9 @@ X(Finished)                                                   \
 X(GetFile)                                                    \
 X(GetSecName)                                                 \
 X(GetSection)                                                 \
+X(ReadIntBlock)                                               \
 X(ReadOpcode)                                                 \
-X(ReadFast)                                                   \
-X(ReadFastUntil)                                              \
+X(ReadIntValues)                                              \
 X(Started)                                                    \
 
 //#define X(tag)

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -188,8 +188,10 @@ void Reader::traceEnterFrameInternal() {
 }
 
 void Reader::CallFrame::describe(FILE* File, TextWriter* Writer) const {
-  fprintf(File, "%s.%s (%s) = %" PRIuMAX ": ", getName(CallMethod),
-          getName(CallState), getName(CallModifier), uintmax_t(ReturnValue));
+  fprintf(File, "%s.%s (%s) = ", getName(CallMethod), getName(CallState),
+          getName(CallModifier));
+  fprint_IntType(File, ReturnValue);
+  fputs(": ", File);
   if (Nd)
     Writer->writeAbbrev(File, Nd);
   else
@@ -237,7 +239,9 @@ void Reader::describeLocalsStack(FILE* File) {
   for (const auto& Index : LocalsBaseStack.iterRange(1)) {
     fprintf(File, "%" PRIuMAX ":\n", uintmax_t(Index));
     for (size_t i = BaseIndex; i < Index; ++i) {
-      fprintf(File, "  %" PRIuMAX "\n", LocalValues[i]);
+      fputs("  ", File);
+      fprint_IntType(File, LocalValues[i]);
+      fputc('\n', File);
     }
     BaseIndex = Index;
   }

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -446,9 +446,10 @@ bool ParamNode::validateNode(NodeVectorType& Parents) {
     TRACE_SEXP("Enclosing define", Nd);
     // Scope found. Check if parameter is legal.
     if (!Define->isValidParam(getValue())) {
-      fprintf(getTrace().getFile(),
-              "Error: Param %" PRIuMAX " not defined for method: %s\n",
-              uintmax_t(getValue()), Define->getName().c_str());
+      FILE* Out = getTrace().getFile();
+      fputs("Error: Param ", Out);
+      fprint_IntType(Out, getValue());
+      fprintf(Out, " not defined for method: %s\n", Define->getName().c_str());
       return false;
     }
     return true;

--- a/src/utils/Defs.cpp
+++ b/src/utils/Defs.cpp
@@ -34,6 +34,15 @@ namespace wasm {
 
 namespace decode {
 
+void fprint_IntType(FILE* File, IntType Value) {
+  SignedIntType SignedValue = SignedIntType(Value);
+  if (SignedValue < 0) {
+    fputc('-', File);
+    Value = IntType(-SignedValue);
+  }
+  fprintf(File, "%" PRIuMAX "", uintmax_t(Value));
+}
+
 bool ExpectExitFail = false;
 
 const char* getName(StreamType Type) {

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -86,6 +86,11 @@ namespace decode {
 typedef uint64_t IntType;
 typedef int64_t SignedIntType;
 
+void fprint_IntType(FILE* File, IntType Value);
+inline void print_IntType(IntType Value) {
+  fprint_IntType(stdout, Value);
+}
+
 #define PRI_IntType PRIu64
 static constexpr size_t kBitsInIntType = 64;
 

--- a/src/utils/Trace.cpp
+++ b/src/utils/Trace.cpp
@@ -21,6 +21,8 @@
 
 namespace wasm {
 
+using namespace decode;
+
 namespace utils {
 
 void TraceClass::init() {
@@ -137,6 +139,13 @@ void TraceClass::traceIntInternal(const char* Name, intmax_t Value) {
 void TraceClass::traceUintInternal(const char* Name, uintmax_t Value) {
   indent();
   fprintf(File, "%s = %" PRIuMAX "\n", Name, Value);
+}
+
+void TraceClass::traceIntTypeInternal(const char* Name, IntType Value) {
+  indent();
+  fprintf(File, "%s = ", Name);
+  fprint_IntType(File, Value);
+  fputc('\n', File);
 }
 
 void TraceClass::traceHexInternal(const char* Name, uintmax_t Value) {

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -220,7 +220,7 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
     traceUintInternal(Name, Value);
   }
   void trace_IntType(const char* Name, decode::IntType Value) {
-    traceUintInternal(Name, Value);
+    traceIntTypeInternal(Name, Value);
   }
   void trace_size_t(const char* Name, size_t Value) {
     traceUintInternal(Name, Value);
@@ -250,6 +250,7 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
   void traceStringInternal(const char* Name, const char* Value);
   void traceIntInternal(const char* Name, intmax_t Value);
   void traceUintInternal(const char* Name, uintmax_t Value);
+  void traceIntTypeInternal(const char* Name, decode::IntType Value);
   void traceHexInternal(const char* Name, uintmax_t Value);
   void tracePointerInternal(const char* Name, void* Value);
 


### PR DESCRIPTION
1) uses signed values to print IntType (stream integers). This makes the text size smaller. Put in separate function so that it can be changed in one place.
2) Clean up trace messages from IntReader