### PR TITLE
Remove nodes from the compression trie that aren't useful.

### DIFF
--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -106,7 +106,6 @@ class IntCompressor FINAL {
                  std::shared_ptr<filt::SymbolTable> Symtab,
                  bool TraceParsing);
   bool compressUpToSize(size_t Size, bool TraceParsing);
-  bool removeSmallUsageCounts(CountNode::Ptr Nd);
   void removeSmallUsageCounts();
   void assignInitialAbbreviations();
 };

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -106,8 +106,8 @@ class IntCompressor FINAL {
                  std::shared_ptr<filt::SymbolTable> Symtab,
                  bool TraceParsing);
   bool compressUpToSize(size_t Size, bool TraceParsing);
-  void removeSmallUsageCounts() { removeSmallUsageCounts(Root); }
-  bool removeSmallUsageCounts(std::shared_ptr<CountNode> Nd);
+  bool removeSmallUsageCounts(CountNode::Ptr Nd);
+  void removeSmallUsageCounts();
   void assignInitialAbbreviations();
 };
 

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -53,6 +53,7 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
   typedef std::shared_ptr<BlockCountNode> BlockPtr;
   typedef std::weak_ptr<IntCountNode> ParentPtr;
   typedef std::shared_ptr<RootCountNode> RootPtr;
+  typedef std::shared_ptr<CountNodeWithSuccs> WithSuccsPtr;
   typedef std::map<decode::IntType, CountNode::IntPtr> SuccMap;
   typedef SuccMap::const_iterator SuccMapIterator;
   typedef Ptr HeapValueType;


### PR DESCRIPTION
This is done to:

a) recover (lots) of memory.

b) speed up searches by removing needs from the trie.