### PR TITLE
Turn on generating abbreviated integer stream.

### DIFF
--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -101,6 +101,7 @@ class IntCompressor FINAL {
   std::shared_ptr<decode::Queue> Output;
   std::shared_ptr<filt::SymbolTable> Symtab;
   std::shared_ptr<interp::IntStream> Contents;
+  std::shared_ptr<interp::IntStream> IntOutput;
   std::shared_ptr<filt::TraceClassSexp> Trace;
   uint64_t CountCutoff;
   uint64_t WeightCutoff;
@@ -113,6 +114,7 @@ class IntCompressor FINAL {
   bool compressUpToSize(size_t Size, bool TraceParsing);
   void removeSmallUsageCounts();
   void assignInitialAbbreviations();
+  bool generateIntOutput(bool TraceParsing);
 };
 
 }  // end of namespace intcomp

--- a/src/interp/IntReader.cpp
+++ b/src/interp/IntReader.cpp
@@ -43,8 +43,8 @@ TraceClass::ContextPtr IntReader::getTraceContext() {
   return Pos.getTraceContext();
 }
 
-std::shared_ptr<TraceClassSexp> IntReader::createTrace() {
-  return std::make_shared<TraceClassSexp>("IntReader");
+const char* IntReader::getDefaultTraceName() const {
+  return "IntReader";
 }
 
 bool IntReader::canFastRead() const {

--- a/src/interp/IntReader.h
+++ b/src/interp/IntReader.h
@@ -56,8 +56,7 @@ class IntReader : public Reader {
   IntStream::ReadCursor PeekPos;
   utils::ValueStack<IntStream::Cursor> PeekPosStack;
 
-  std::shared_ptr<filt::TraceClassSexp> createTrace() OVERRIDE;
-
+  const char* getDefaultTraceName() const OVERRIDE;
   void describePeekPosStack(FILE* Out) OVERRIDE;
 
 #if 0

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -34,6 +34,10 @@ TraceClass::ContextPtr IntWriter::getTraceContext() {
   return Pos.getTraceContext();
 }
 
+const char* IntWriter::getDefaultTraceName() const {
+  return "IntWriter";
+}
+
 StreamType IntWriter::getStreamType() const {
   return StreamType::Int;
 }

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -55,6 +55,8 @@ class IntWriter : public Writer {
  private:
   std::shared_ptr<IntStream> Output;
   IntStream::WriteCursorWithTraceContext Pos;
+
+  const char* getDefaultTraceName() const OVERRIDE;
 };
 
 }  // end of namespace interp

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -111,14 +111,14 @@ void Reader::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
   }
 }
 
-std::shared_ptr<TraceClassSexp> Reader::createTrace() {
-  return std::make_shared<TraceClassSexp>("Reader");
+const char* Reader::getDefaultTraceName() const {
+  return "Reader";
 }
 
-TraceClassSexp& Reader::getTrace() {
+std::shared_ptr<TraceClassSexp> Reader::getTracePtr() {
   if (!Trace)
-    setTrace(createTrace());
-  return *Trace;
+    setTrace(std::make_shared<TraceClassSexp>(getDefaultTraceName()));
+  return Trace;
 }
 
 const char* Reader::getName(Method M) {

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -80,8 +80,9 @@ class Reader {
 
   // Returns non-null context handler if applicable.
   virtual utils::TraceClass::ContextPtr getTraceContext();
-  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
-  filt::TraceClassSexp& getTrace();
+  virtual void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
+  std::shared_ptr<filt::TraceClassSexp> getTracePtr();
+  filt::TraceClassSexp& getTrace() { return *getTracePtr(); }
 
   enum class SectionCode : uint32_t {
 #define X(code, value) code = value,
@@ -226,8 +227,6 @@ class Reader {
   OpcodeLocalsFrame OpcodeLocals;
   utils::ValueStack<OpcodeLocalsFrame> OpcodeLocalsStack;
 
-  virtual std::shared_ptr<filt::TraceClassSexp> createTrace();
-
   virtual void reset();
 
   void handleOtherMethods();
@@ -290,6 +289,7 @@ class Reader {
   virtual uint32_t readVaruint32() = 0;
   virtual uint64_t readVaruint64() = 0;
   virtual decode::IntType readValue(const filt::Node* Format) = 0;
+  virtual const char* getDefaultTraceName() const;
 };
 
 }  // end of namespace interp

--- a/src/interp/StreamReader.cpp
+++ b/src/interp/StreamReader.cpp
@@ -39,8 +39,8 @@ StreamReader::StreamReader(std::shared_ptr<decode::Queue> StrmInput,
 StreamReader::~StreamReader() {
 }
 
-std::shared_ptr<TraceClassSexp> StreamReader::createTrace() {
-  return std::make_shared<TraceClassSexp>("StreamReader");
+const char* StreamReader::getDefaultTraceName() const {
+  return "StreamReader";
 }
 
 void StreamReader::startUsing(const decode::ReadCursor& StartPos) {

--- a/src/interp/StreamReader.h
+++ b/src/interp/StreamReader.h
@@ -52,7 +52,8 @@ class StreamReader : public Reader {
   decode::ReadCursor PeekPos;
   utils::ValueStack<decode::ReadCursor> PeekPosStack;
 
-  std::shared_ptr<filt::TraceClassSexp> createTrace() OVERRIDE;
+  const char* getDefaultTraceName() const OVERRIDE;
+
   void describePeekPosStack(FILE* Out) OVERRIDE;
 
   bool canProcessMoreInputNow() OVERRIDE;

--- a/src/interp/StreamWriter.cpp
+++ b/src/interp/StreamWriter.cpp
@@ -50,6 +50,10 @@ TraceClass::ContextPtr StreamWriter::getTraceContext() {
   return Pos.getTraceContext();
 }
 
+const char* StreamWriter::getDefaultTraceName() const {
+  return "StreamWriter";
+}
+
 decode::StreamType StreamWriter::getStreamType() const {
   return Stream->getType();
 }

--- a/src/interp/StreamWriter.h
+++ b/src/interp/StreamWriter.h
@@ -61,6 +61,7 @@ class StreamWriter : public Writer {
   decode::WriteCursor BlockStart;
   utils::ValueStack<decode::WriteCursor> BlockStartStack;
   void describeBlockStartStack(FILE* File);
+  const char* getDefaultTraceName() const OVERRIDE;
 };
 
 }  // end of namespace interp

--- a/src/interp/Writer.cpp
+++ b/src/interp/Writer.cpp
@@ -34,16 +34,20 @@ TraceClass::ContextPtr Writer::getTraceContext() {
   return Ptr;
 }
 
-TraceClassSexp& Writer::getTrace() {
+std::shared_ptr<TraceClassSexp> Writer::getTracePtr() {
   if (!Trace)
-    setTrace(std::make_shared<TraceClassSexp>("Writer"));
-  return *Trace;
+    setTrace(std::make_shared<TraceClassSexp>(getDefaultTraceName()));
+  return Trace;
 }
 
 void Writer::setTrace(std::shared_ptr<filt::TraceClassSexp> NewTrace) {
   Trace = NewTrace;
   if (Trace)
     Trace->addContext(getTraceContext());
+}
+
+const char* Writer::getDefaultTraceName() const {
+  return "Writer";
 }
 
 void Writer::reset() {

--- a/src/interp/Writer.h
+++ b/src/interp/Writer.h
@@ -56,12 +56,15 @@ class Writer {
   virtual void describeState(FILE* File);
 
   virtual utils::TraceClass::ContextPtr getTraceContext();
-  filt::TraceClassSexp& getTrace();
-  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
+  virtual void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
+  std::shared_ptr<filt::TraceClassSexp> getTracePtr();
+  filt::TraceClassSexp& getTrace() { return *getTracePtr(); }
 
  protected:
   bool MinimizeBlockSize;
   std::shared_ptr<filt::TraceClassSexp> Trace;
+
+  virtual const char* getDefaultTraceName() const;
 };
 
 }  // end of namespace interp

--- a/src/utils/circular-vector.h
+++ b/src/utils/circular-vector.h
@@ -139,7 +139,7 @@ class circular_vector {
 
   bool full() const { return vector_size == vector_max_size; }
 
-  iterator begin() { return circ_iterator(*this, 0); }
+  iterator begin() { return circ_iterator(this, 0); }
 
   const_iterator begin() const {
     return circ_iterator(const_cast<circular_vector*>(this), 0);


### PR DESCRIPTION
Turns on generating the initial abbreviated integer stream (minus the algorithm to decompress). Still has a few bugs. However, this CL is relatively large, and so I'm checking it in before it gets any larger.