### PR TITLE
Allow write position to flow across write flows in compression.

### DIFF
--- a/src/binary/BinaryWriter.h
+++ b/src/binary/BinaryWriter.h
@@ -51,6 +51,8 @@ class BinaryWriter {
     writeFile(File);
   }
 
+  const decode::WriteCursor& getWritePos() const { return WritePos; }
+
   void freezeEof() { WritePos.freezeEof(); }
 
   void setMinimizeBlockSize(bool NewValue) { MinimizeBlockSize = NewValue; }

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -93,9 +93,10 @@ class IntCompressor FINAL {
   IntTypeFormat AbbrevFormat;
   bool ErrorsFound;
   void readInput(bool Trace = false);
-  void writeCodeOutput(std::shared_ptr<filt::SymbolTable> Symtab,
-                       bool Trace = false);
-  void writeDataOutput(std::shared_ptr<filt::SymbolTable> Symtab,
+  const decode::WriteCursor writeCodeOutput(
+      std::shared_ptr<filt::SymbolTable> Symtab, bool Trace = false);
+  void writeDataOutput(const decode::WriteCursor& StartPos,
+                       std::shared_ptr<filt::SymbolTable> Symtab,
                        bool Trace = false);
   bool compressUpToSize(size_t Size, bool TraceParsing);
   void removeSmallUsageCounts();

--- a/src/interp/StreamWriter.h
+++ b/src/interp/StreamWriter.h
@@ -39,6 +39,8 @@ class StreamWriter : public Writer {
   decode::WriteCursor& getPos();
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
+  void setPos(const decode::WriteCursor& NewPos) { Pos = NewPos; }
+
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
   bool writeUint8(uint8_t Value) OVERRIDE;

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -42,6 +42,9 @@ class WriteCursor : public WriteCursorBase {
   WriteCursor(const Cursor& C, size_t StartAddress)
       : WriteCursorBase(C, StartAddress) {}
 
+  WriteCursor(const WriteCursorBase& C)
+      : WriteCursorBase(C) {}
+
   ~WriteCursor() OVERRIDE;
 
  protected:
@@ -64,7 +67,7 @@ class WriteCursorWithTraceContext : public WriteCursor {
   WriteCursorWithTraceContext(const Cursor& C, size_t StartAddress)
       : WriteCursor(C, StartAddress) {}
 
-  WriteCursorWithTraceContext& operator=(WriteCursor& C) {
+  WriteCursorWithTraceContext& operator=(const WriteCursor& C) {
     WriteCursor::operator=(C);
     return *this;
   }


### PR DESCRIPTION
Note that there is still a bug in that the code writer "freezes" the eof in the destructor.

This makes the following writer error out (doesn't allow writing past eof).

However, the rest of the connectivity to pipe the continuation point is handled.