### PR TITLE
Add new concept for file headers in s-expressions.

### DIFF
--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -427,6 +427,9 @@ void BinaryReader::resume() {
 #undef X
               case NO_SUCH_NODETYPE:
               case OpFile:
+              case OpHeader:
+              case OpInputHeader:
+              case OpOutputHeader:
               case OpSection:
               case OpUnknownSection:
                 fprintf(stderr, "Opcode = %u\n", unsigned(Opcode));

--- a/src/binary/BinaryWriter.cpp
+++ b/src/binary/BinaryWriter.cpp
@@ -90,6 +90,9 @@ void BinaryWriter::writeNode(const Node* Nd) {
   TRACE_SEXP(nullptr, Nd);
   switch (NodeType Opcode = Nd->getType()) {
     case NO_SUCH_NODETYPE:
+    case OpHeader:
+    case OpInputHeader:
+    case OpOutputHeader:
     case OpFileVersion:
     case OpUnknownSection: {
       fprintf(stderr, "Misplaced s-expression: %s\n", getNodeTypeName(Opcode));

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -449,6 +449,9 @@ void Reader::algorithmResume() {
 #endif
         switch (Frame.Nd->getType()) {
           case NO_SUCH_NODETYPE:
+          case OpHeader:
+          case OpInputHeader:
+          case OpOutputHeader:
           case OpConvert:
           case OpParams:
           case OpFilter:  // Method::Eval

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -220,6 +220,7 @@ letter	[a-zA-Z]
 "eval"            return Parser::make_EVAL(Driver.getLoc());
 "file"            return Parser::make_FILE(Driver.getLoc());
 "filter"          return Parser::make_FILTER(Driver.getLoc());
+"header"          return Parser::make_HEADER(Driver.getLoc());
 "if"              return Parser::make_IF(Driver.getLoc());
 "int"             return Parser::make_INT(Driver.getLoc());
 "in"              return Parser::make_IN(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -89,6 +89,7 @@ struct IntValue {
 %token EVAL          "eval"
 %token FILE          "file"
 %token FILTER        "filter"
+%token HEADER        "header"
 %token IF            "if"
 %token IN            "in"
 %token INT           "int"
@@ -156,12 +157,14 @@ struct IntValue {
 %type <wasm::filt::Node *> file_version
 %type <wasm::filt::Node *> fixed_format_directive
 %type <wasm::filt::Node *> format_directive
+%type <wasm::filt::Node *> input_header
 %type <wasm::filt::Node *> literal_expression
 %type <wasm::filt::Node *> locals_decl
 %type <wasm::filt::Node *> local_var
 %type <wasm::filt::Node *> loop_body
 %type <wasm::filt::MapNode *> map_args
 %type <wasm::filt::OpcodeNode *> opcode_args
+%type <wasm::filt::Node *> output_header
 %type <wasm::filt::Node *> params_decl
 %type <wasm::filt::Node *> stream
 %type <wasm::filt::Node *> convert
@@ -197,6 +200,27 @@ file    : file_version {
 file_version
         : "(" "file" "." "version" casm_magic casm_version wasm_version ")" {
             $$ = Driver.create<FileVersionNode>($5, $6, $7);
+          }
+        | "(" "header" "(" "in" input_header ")"
+                       "(" "out"  output_header ")"
+          ")" {
+            $$ = Driver.create<HeaderNode>($5, $9);
+        }
+        ;
+
+input_header
+        : %empty { $$ = Driver.create<InputHeaderNode>(); }
+        | input_header literal_expression {
+            $$ = $1;
+            $$->append($2);
+          }
+        ;
+
+output_header
+        : %empty { $$ = Driver.create<InputHeaderNode>(); }
+        | output_header literal_expression {
+            $$ = $1;
+            $$->append($2);
           }
         ;
 

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -92,6 +92,9 @@
   X(Define,            0x60, "define",           nullptr,           2, 1)      \
   X(File,              0x62, "file",             nullptr,           0, 0)      \
   X(FileVersion,       0x72, "file.version",     nullptr,           0, 0)      \
+  X(Header,            0x74, "header",           nullptr,           0, 0)      \
+  X(InputHeader,       0x75, "in",               "input.header",    0, 3)      \
+  X(OutputHeader,      0x76, "out",               "output.header",  0, 3)      \
   X(Section,           0x63, "section",          nullptr,           1, 0)      \
   X(Undefine,          0x64, "undefine",         nullptr,           1, 0)      \
   X(LiteralDef,        0x65, "literal",          nullptr,           2, 0)      \
@@ -187,6 +190,7 @@
   X(BitwiseOr,)                                                                \
   X(BitwiseXor,)                                                               \
   X(Case,)                                                                     \
+  X(Header,)                                                                   \
   X(IfThen,)                                                                   \
   X(Loop,)                                                                     \
   X(Or,)                                                                       \
@@ -202,9 +206,11 @@
 //#define X(tag, NODE_DECLS)
 #define AST_NARYNODE_TABLE                                                     \
   X(Define, DEFINE_DECLS)                                                      \
+  X(Eval, EVAL_DECLS)                                                          \
   X(File,)                                                                     \
   X(Filter,)                                                                   \
-  X(Eval, EVAL_DECLS)                                                          \
+  X(InputHeader,)                                                              \
+  X(OutputHeader,)                                                             \
   X(Section, SECTION_DECLS)                                                    \
   X(Sequence,)                                                                 \
   X(Write,)                                                                    \
@@ -252,6 +258,8 @@
   X(FileVersion)                                                               \
   X(IfThen)                                                                    \
   X(IfThenElse)                                                                \
+  X(InputHeader)                                                               \
+  X(OutputHeader)                                                              \
   X(Loop)                                                                      \
   X(LoopUnbounded)                                                             \
   X(Opcode)                                                                    \


### PR DESCRIPTION
Introduces a new header form to at that specifies arbitrary constant headers for both input and output.

The purpose of the header construct is to remove logic within the readers/writers and make it generic. This will allow it to be used on any file (not just WASM files).