### PR TITLE
Exract out flattening s-expressions into an integer sequence.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ SEXP_OBJDIR = $(OBJDIR)/sexp
 SEXP_OBJDIR_BOOT = $(OBJDIR_BOOT)/sexp
 SEXP_SRCS_BASE = \
 	Ast.cpp \
+	AstToCasm.cpp \
 	TextWriter.cpp \
 	TraceSexp.cpp
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ SEXP_OBJDIR = $(OBJDIR)/sexp
 SEXP_OBJDIR_BOOT = $(OBJDIR_BOOT)/sexp
 SEXP_SRCS_BASE = \
 	Ast.cpp \
-	AstToCasm.cpp \
+	FlattenAst.cpp \
 	TextWriter.cpp \
 	TraceSexp.cpp
 

--- a/src/interp/IntFormats.cpp
+++ b/src/interp/IntFormats.cpp
@@ -86,62 +86,12 @@ class TestBuffer {
   size_t Index;
 };
 
-bool extractIntTypeFormat(const Node* Nd, IntTypeFormat& Format) {
-  Format = IntTypeFormat::Uint8;
-  if (Nd == nullptr)
-    return false;
-  switch (Nd->getType()) {
-    case OpU8Const:
-      Format = IntTypeFormat::Uint8;
-      return true;
-    case OpI32Const:
-      Format = IntTypeFormat::Varint32;
-      return true;
-    case OpU32Const:
-      Format = IntTypeFormat::Uint32;
-      return true;
-    case OpI64Const:
-      Format = IntTypeFormat::Varint64;
-      return true;
-    case OpU64Const:
-      Format = IntTypeFormat::Uint64;
-      return true;
-    default:
-      return false;
-  }
-}
-
 }  // end of anonymous namespace
 
 const char* getName(IntTypeFormat Fmt) {
   size_t Index = size_t(Fmt);
   assert(Index < NumIntTypeFormats);
   return IntTypeFormatName[Index];
-}
-
-bool definesIntTypeFormat(const Node* Nd) {
-  IntTypeFormat Format;
-  return extractIntTypeFormat(Nd, Format);
-}
-
-bool definesLitIntTypeFormat(const Node* Nd) {
-  if (!definesIntTypeFormat(Nd))
-    return false;
-  switch (Nd->getType()) {
-    case OpU8Const:
-    case OpU32Const:
-    case OpU64Const:
-      return true;
-    default:
-      break;
-  }
-  return false;
-}
-
-IntTypeFormat getIntTypeFormat(const Node* Nd) {
-  IntTypeFormat Format;
-  extractIntTypeFormat(Nd, Format);
-  return Format;
 }
 
 IntTypeFormats::IntTypeFormats(IntType Value) : Value(Value) {

--- a/src/interp/IntFormats.h
+++ b/src/interp/IntFormats.h
@@ -47,10 +47,6 @@ enum class IntTypeFormat {
 
 const char* getName(IntTypeFormat Fmt);
 
-extern bool definesIntTypeFormat(const filt::Node* Nd);
-extern bool definesLitIntTypeFormat(const filt::Node* Nd);
-extern IntTypeFormat getIntTypeFormat(const filt::Node* Nd);
-
 static constexpr size_t NumIntTypeFormats = size_t(IntTypeFormat::LAST) + 1;
 
 class IntTypeFormats {

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -43,31 +43,31 @@ StreamType IntWriter::getStreamType() const {
 }
 
 bool IntWriter::writeUint8(uint8_t Value) {
-  return Pos.write(Value);
+  return write(Value);
 }
 
 bool IntWriter::writeUint32(uint32_t Value) {
-  return Pos.write(Value);
+  return write(Value);
 }
 
 bool IntWriter::writeUint64(uint64_t Value) {
-  return Pos.write(Value);
+  return write(Value);
 }
 
 bool IntWriter::writeVarint32(int32_t Value) {
-  return Pos.write(Value);
+  return write(Value);
 }
 
 bool IntWriter::writeVarint64(int64_t Value) {
-  return Pos.write(Value);
+  return write(Value);
 }
 
 bool IntWriter::writeVaruint32(uint32_t Value) {
-  return Pos.write(Value);
+  return write(Value);
 }
 
 bool IntWriter::writeVaruint64(uint64_t Value) {
-  return Pos.write(Value);
+  return write(Value);
 }
 
 bool IntWriter::writeFreezeEof() {

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -39,6 +39,7 @@ class IntWriter : public Writer {
   ~IntWriter() OVERRIDE {}
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
+  bool write(decode::IntType Value) { return Pos.write(Value); }
   bool writeUint8(uint8_t Value) OVERRIDE;
   bool writeUint32(uint32_t Value) OVERRIDE;
   bool writeUint64(uint64_t Value) OVERRIDE;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -18,6 +18,8 @@
 /* Implements AST's for modeling filter s-expressions */
 
 #include "sexp/Ast.h"
+
+#include "interp/IntFormats.h"
 #include "sexp/TextWriter.h"
 #include "utils/Defs.h"
 
@@ -29,6 +31,7 @@
 namespace wasm {
 
 using namespace decode;
+using namespace interp;
 using namespace utils;
 
 namespace filt {
@@ -47,6 +50,31 @@ static const char* PredefinedName[NumPredefinedSymbols]{
     PREDEFINED_SYMBOLS_TABLE
 #undef X
 };
+
+bool extractIntTypeFormat(const Node* Nd, IntTypeFormat& Format) {
+  Format = IntTypeFormat::Uint8;
+  if (Nd == nullptr)
+    return false;
+  switch (Nd->getType()) {
+    case OpU8Const:
+      Format = IntTypeFormat::Uint8;
+      return true;
+    case OpI32Const:
+      Format = IntTypeFormat::Varint32;
+      return true;
+    case OpU32Const:
+      Format = IntTypeFormat::Uint32;
+      return true;
+    case OpI64Const:
+      Format = IntTypeFormat::Varint64;
+      return true;
+    case OpU64Const:
+      Format = IntTypeFormat::Uint64;
+      return true;
+    default:
+      return false;
+  }
+}
 
 }  // end of anonymous namespace
 
@@ -105,6 +133,18 @@ const char* getNodeTypeName(NodeType Type) {
   if (Name == nullptr)
     Mapping[static_cast<int>(Type)] = Name = getNodeSexpName(Type);
   return Name;
+}
+
+
+bool definesIntTypeFormat(const Node* Nd) {
+  IntTypeFormat Format;
+  return extractIntTypeFormat(Nd, Format);
+}
+
+IntTypeFormat getIntTypeFormat(const Node* Nd) {
+  IntTypeFormat Format;
+  extractIntTypeFormat(Nd, Format);
+  return Format;
 }
 
 void IntegerValue::describe(FILE* Out) const {

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -135,7 +135,6 @@ const char* getNodeTypeName(NodeType Type) {
   return Name;
 }
 
-
 bool definesIntTypeFormat(const Node* Nd) {
   IntTypeFormat Format;
   return extractIntTypeFormat(Nd, Format);

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -29,6 +29,7 @@
 #ifndef DECOMPRESSOR_SRC_SEXP_AST_H
 #define DECOMPRESSOR_SRC_SEXP_AST_H
 
+#include "interp/IntFormats.h"
 #include "sexp/Ast.def"
 #include "sexp/NodeType.h"
 #include "sexp/Strings.def"
@@ -87,6 +88,9 @@ struct AstTraitsType {
 };
 
 extern AstTraitsType AstTraits[NumNodeTypes];
+
+extern bool definesIntTypeFormat(const filt::Node* Nd);
+extern interp::IntTypeFormat getIntTypeFormat(const filt::Node* Nd);
 
 // Models integer values (as used in AST nodes).
 class IntegerValue {

--- a/src/sexp/FlattenAst.cpp
+++ b/src/sexp/FlattenAst.cpp
@@ -1,0 +1,202 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a converter of an Ast algorithm, to the corresponding
+// (integer) CASM stream.
+
+#include "sexp/FlattenAst.h"
+#include "sexp/TextWriter.h"
+
+namespace wasm {
+
+using namespace decode;
+using namespace interp;
+
+namespace filt {
+
+FlattenAst::FlattenAst(std::shared_ptr<IntWriter> Writer,
+                       std::shared_ptr<SymbolTable> Symtab)
+    : Writer(Writer),
+      Symtab(Symtab),
+      SectionSymtab(Symtab),
+      FreezeEofOnDestruct(true),
+      HasErrors(false) {
+}
+
+FlattenAst::~FlattenAst() {
+  if (FreezeEofOnDestruct)
+    Writer->writeFreezeEof();
+}
+
+void FlattenAst::setTrace(std::shared_ptr<TraceClassSexp> NewTrace) {
+  Trace = NewTrace;
+  if (!Trace)
+    return;
+  Trace->addContext(Writer->getTraceContext());
+}
+
+std::shared_ptr<TraceClassSexp> FlattenAst::getTracePtr() {
+  return std::make_shared<TraceClassSexp>("FlattenAst");
+}
+
+void FlattenAst::reportError(const char* Message) {
+  fprintf(stderr, "Error: %s\n", Message);
+  HasErrors = true;
+}
+
+void FlattenAst::reportError(const char* Label, const Node* Nd) {
+  fprintf(stderr, "%s: ", Label);
+  TextWriter Writer;
+  Writer.writeAbbrev(stderr, Nd);
+  HasErrors = true;
+}
+
+void FlattenAst::writeNode(const Node* Nd) {
+  if (HasErrors)
+    return;
+  TRACE_METHOD("writeNode");
+  TRACE_SEXP(nullptr, Nd);
+  switch (NodeType Opcode = Nd->getType()) {
+    case NO_SUCH_NODETYPE:
+    case OpUnknownSection: {
+      reportError("Unexpected s-expression, can't write!");
+      reportError("s-expression: ", Nd);
+      break;
+    }
+#define X(tag, format, defval, mergable, NODE_DECLS) \
+  case Op##tag: {                                    \
+    Writer->write(Opcode);                           \
+    auto* Int = cast<tag##Node>(Nd);                 \
+    if (Int->isDefaultValue()) {                     \
+      Writer->write(0);                              \
+    } else {                                         \
+      Writer->write(int(Int->getFormat()) + 1);      \
+      Writer->write(Int->getValue());                \
+    }                                                \
+    break;                                           \
+  }
+      AST_INTEGERNODE_TABLE
+#undef X
+    case OpAnd:
+    case OpBlock:
+    case OpBitwiseAnd:
+    case OpBitwiseNegate:
+    case OpBitwiseOr:
+    case OpBitwiseXor:
+    case OpCallback:
+    case OpCase:
+    case OpConvert:
+    case OpOr:
+    case OpNot:
+    case OpError:
+    case OpIfThen:
+    case OpIfThenElse:
+    case OpLastSymbolIs:
+    case OpLoop:
+    case OpLoopUnbounded:
+    case OpPeek:
+    case OpRead:
+    case OpUndefine:
+    case OpLastRead:
+    case OpRename:
+    case OpSet:
+    case OpLiteralDef:
+    case OpLiteralUse:
+    case OpVoid: {
+      // Operations that are written out in postorder, with a fixed number of
+      // arguments.
+      for (const auto* Kid : *Nd)
+        writeNode(Kid);
+      Writer->write(Opcode);
+      break;
+    }
+    case OpFile:
+    case OpHeader: {
+      // Note: The header appears at the beginning of the file, and hence,
+      // isn't labeled.
+      for (int i = 0; i < Nd->getNumKids(); ++i)
+        writeNode(Nd->getKid(i));
+      break;
+    }
+    case OpFileHeader: {
+      for (const auto* Kid : *Nd) {
+        TRACE_SEXP("Const", Kid);
+        const auto* Const = dyn_cast<IntegerNode>(Kid);
+        if (Const == nullptr) {
+          reportError("Unrecognized literal constant", Nd);
+          return;
+        }
+        if (!definesIntTypeFormat(Const)) {
+          reportError("Bad literal constant", Const);
+          return;
+        }
+        Writer->writeHeaderValue(Const->getType(), getIntTypeFormat(Const));
+      }
+      break;
+    }
+    case OpStream: {
+      const auto* Stream = cast<StreamNode>(Nd);
+      Writer->write(Opcode);
+      Writer->write(Stream->getEncoding());
+      break;
+    }
+    case OpSection: {
+      Writer->writeAction(Symtab->getBlockEnterCallback());
+      const auto* Section = cast<SectionNode>(Nd);
+      SectionSymtab.installSection(Section);
+      const SectionSymbolTable::IndexLookupType& Vector =
+          SectionSymtab.getVector();
+      Writer->write(Vector.size());
+      for (const SymbolNode* Symbol : Vector) {
+        const std::string& SymName = Symbol->getName();
+        Writer->write(SymName.size());
+        for (size_t i = 0, len = SymName.size(); i < len; ++i)
+          Writer->write(SymName[i]);
+      }
+      for (int i = 0, len = Nd->getNumKids(); i < len; ++i)
+        writeNode(Nd->getKid(i));
+      Writer->writeAction(Symtab->getBlockExitCallback());
+      SectionSymtab.clear();
+      break;
+    }
+    case OpDefine:
+    case OpEval:
+    case OpFilter:
+    case OpOpcode:
+    case OpMap:
+    case OpSwitch:
+    case OpSequence:
+    case OpWrite: {
+      // Operations that are written out in postorder, and have a variable
+      // number of arguments.
+      for (const auto* Kid : *Nd)
+        writeNode(Kid);
+      Writer->write(Opcode);
+      Writer->write(Nd->getNumKids());
+      break;
+    }
+    case OpSymbol: {
+      Writer->write(Opcode);
+      SymbolNode* Sym = cast<SymbolNode>(const_cast<Node*>(Nd));
+      Writer->write(SectionSymtab.getSymbolIndex(Sym));
+      break;
+    }
+  }
+}
+
+}  // end of namespace filt
+
+}  // end of namespace wasm

--- a/src/sexp/FlattenAst.h
+++ b/src/sexp/FlattenAst.h
@@ -1,0 +1,69 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a converter of an Ast algorithm, to the corresponding
+// (integer) CASM stream.
+
+#ifndef DECOMPRESSOR_SRC_SEXP_FLATTENAST_H
+#define DECOMPRESSOR_SRC_SEXP_FLATTENAST_H
+
+#include "binary/SectionSymbolTable.h"
+#include "interp/IntWriter.h"
+
+namespace wasm {
+
+namespace filt {
+
+class FlattenAst {
+  FlattenAst() = delete;
+  FlattenAst(const FlattenAst&) = delete;
+  FlattenAst& operator=(const FlattenAst&) = delete;
+
+ public:
+  FlattenAst(std::shared_ptr<interp::IntWriter> Writer,
+             std::shared_ptr<SymbolTable> Symtab);
+
+  ~FlattenAst();
+
+  bool write(const FileNode* File) {
+    writeNode(File);
+    return HasErrors;
+  }
+
+  void setFreezeEofOnDestruct(bool Value) { FreezeEofOnDestruct = Value; }
+
+  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace);
+  std::shared_ptr<filt::TraceClassSexp> getTracePtr();
+  filt::TraceClassSexp& getTrace() { return *getTracePtr(); }
+
+ private:
+  std::shared_ptr<interp::IntWriter> Writer;
+  std::shared_ptr<SymbolTable> Symtab;
+  SectionSymbolTable SectionSymtab;
+  bool FreezeEofOnDestruct;
+  bool HasErrors;
+  std::shared_ptr<filt::TraceClassSexp> Trace;
+
+  void writeNode(const Node* Nd);
+  void reportError(const char* Message);
+  void reportError(const char* Message, const Node* Nd);
+};
+
+}  // end of namespace filt
+
+}  // end of namespace wasm
+
+#endif  // DECOMPRESSOR_SRC_SEXP_FLATTENAST_H


### PR DESCRIPTION
In particular, it converts file binary/BinaryWriter.{h,cpp} into a simpler class AstToCasm that only does the flattening portion of the code in BinaryWriter. Once the flattened integer stream is generated, it can be written to a byte stream using the existing byte stream writer, and sexp/casm.df, to handle the byte formatting issues.