### PR TITLE
Define a Tee writer and use in cast2casm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ INTERP_SRCS = \
 	ReadStream.cpp \
 	StreamReader.cpp \
 	StreamWriter.cpp \
+	TeeWriter.cpp \
 	Writer.cpp \
 	WriteStream.cpp \
 	TraceSexpReader.cpp \

--- a/src/interp/TeeWriter.cpp
+++ b/src/interp/TeeWriter.cpp
@@ -25,25 +25,24 @@ using namespace utils;
 
 namespace interp {
 
-TeeWriter::TeeWriter()
-    : Writer() {
+TeeWriter::TeeWriter() : Writer() {
 }
 
-TeeWriter::~TeeWriter() {}
+TeeWriter::~TeeWriter() {
+}
 
 void TeeWriter::add(std::shared_ptr<Writer> NodeWriter,
                     bool DefinesStreamType,
                     bool TraceNode) {
-  Writers.push_back(
-      Node(NodeWriter, DefinesStreamType, TraceNode));
+  Writers.push_back(Node(NodeWriter, DefinesStreamType, TraceNode));
 }
 
 TeeWriter::Node::Node(std::shared_ptr<Writer> NodeWriter,
                       bool DefinesStreamType,
                       bool TraceNode)
-    :NodeWriter(NodeWriter),
-     TraceNode(TraceNode),
-     DefinesStreamType(DefinesStreamType) {
+    : NodeWriter(NodeWriter),
+      TraceNode(TraceNode),
+      DefinesStreamType(DefinesStreamType) {
 }
 
 void TeeWriter::reset() {

--- a/src/interp/TeeWriter.cpp
+++ b/src/interp/TeeWriter.cpp
@@ -1,0 +1,200 @@
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements a tee that broadcasts write actions to a set of writers.
+
+#include "interp/TeeWriter.h"
+
+namespace wasm {
+
+using namespace decode;
+using namespace utils;
+
+namespace interp {
+
+TeeWriter::TeeWriter() : Writer(), MyContext(nullptr) {
+}
+
+TeeWriter::~TeeWriter() {
+  if (MyContext)
+    MyContext->MyWriter = nullptr;
+}
+
+void TeeWriter::add(std::shared_ptr<Writer> NodeWriter,
+                    bool DefinesStreamType,
+                    bool TraceNode,
+                    bool DefinesTraceContext) {
+  Writers.push_back(
+      Node(NodeWriter, DefinesStreamType, TraceNode, DefinesTraceContext));
+}
+
+TeeWriter::Node::Node(std::shared_ptr<Writer> NodeWriter,
+                      bool TraceNode,
+                      bool DefinesTraceContext,
+                      bool DefinesStreamType)
+    : NodeWriter(NodeWriter),
+      TraceNode(TraceNode),
+      DefinesTraceContext(DefinesTraceContext),
+      DefinesStreamType(DefinesStreamType) {
+}
+
+TraceClass::ContextPtr TeeWriter::Node::getTraceContext() {
+  if (!TraceContext && DefinesTraceContext)
+    TraceContext = NodeWriter->getTraceContext();
+  return TraceContext;
+}
+
+void TeeWriter::reset() {
+  for (Node& Nd : Writers)
+    Nd.getWriter().reset();
+}
+
+StreamType TeeWriter::getStreamType() const {
+  bool IsDefined = false;
+  StreamType Type = StreamType::Other;
+  for (const Node& Nd : Writers) {
+    if (Nd.getDefinesStreamType()) {
+      if (!IsDefined) {
+        IsDefined = true;
+        Type = Nd.getWriter()->getStreamType();
+        continue;
+      }
+      if (Type != Nd.getWriter()->getStreamType())
+        Type = StreamType::Other;
+    }
+  }
+  return Type;
+}
+
+bool TeeWriter::writeUint8(uint8_t Value) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeUint8(Value))
+      return false;
+  return true;
+}
+
+bool TeeWriter::writeUint32(uint32_t Value) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeUint32(Value))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeUint64(uint64_t Value) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeUint64(Value))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeVarint32(int32_t Value) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeVarint32(Value))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeVarint64(int64_t Value) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeVarint64(Value))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeVaruint32(uint32_t Value) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeVaruint32(Value))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeVaruint64(uint64_t Value) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeVaruint64(Value))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeFreezeEof() {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeFreezeEof())
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeValue(decode::IntType Value, const filt::Node* Format) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeValue(Value, Format))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeTypedValue(decode::IntType Value,
+                                interp::IntTypeFormat Format) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeTypedValue(Value, Format))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeHeaderValue(decode::IntType Value,
+                                 interp::IntTypeFormat Format) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeHeaderValue(Value, Format))
+      return false;
+  return false;
+}
+
+bool TeeWriter::writeAction(const filt::CallbackNode* Action) {
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeAction(Action))
+      return false;
+  return false;
+}
+
+void TeeWriter::setMinimizeBlockSize(bool NewValue) {
+  for (Node& Nd : Writers)
+    Nd.getWriter()->setMinimizeBlockSize(NewValue);
+}
+
+void TeeWriter::describeState(FILE* File) {
+  for (Node& Nd : Writers)
+    Nd.getWriter()->describeState(File);
+}
+
+TraceClass::ContextPtr TeeWriter::getTraceContext() {
+  if (!MyContext)
+    MyContext = std::make_shared<Context>(this);
+  return MyContext;
+}
+
+TeeWriter::Context::~Context() {
+}
+
+void TeeWriter::Context::describe(FILE* File) {
+  if (MyWriter)
+    MyWriter->describeContexts(File);
+}
+
+void TeeWriter::describeContexts(FILE* File) {
+  for (Node& Nd : Writers)
+    if (TraceClass::ContextPtr Ptr = Nd.getTraceContext())
+      Ptr->describe(File);
+}
+
+}  // end of namespace interp
+
+}  // end of namespace wasm

--- a/src/interp/TeeWriter.h
+++ b/src/interp/TeeWriter.h
@@ -40,32 +40,26 @@ class TeeWriter : public Writer {
 
    public:
     Node(std::shared_ptr<Writer> NodeWriter,
-         bool TraceNode,
-         bool DefinesTraceContext,
-         bool DefinesStreamType);
+         bool DefinesStreamType,
+         bool TraceNode);
 
     std::shared_ptr<Writer> getWriter() { return NodeWriter; }
     const std::shared_ptr<Writer> getWriter() const { return NodeWriter; }
     bool getTraceNode() const { return TraceNode; }
-    bool getDefinesTraceContext() const { return DefinesTraceContext; }
     bool getDefinesStreamType() const { return DefinesStreamType; }
-    utils::TraceClass::ContextPtr getTraceContext();
 
    private:
     std::shared_ptr<Writer> NodeWriter;
     const bool TraceNode;
-    const bool DefinesTraceContext;
     const bool DefinesStreamType;
-    utils::TraceClass::ContextPtr TraceContext;
   };
 
   TeeWriter();
   ~TeeWriter() OVERRIDE;
 
   void add(std::shared_ptr<Writer> NodeWriter,
-           bool DefinesStreamType = false,
-           bool TraceNode = false,
-           bool DefinesTraceContext = false);
+           bool DefinesStreamType,
+           bool TraceNode);
 
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
@@ -89,26 +83,10 @@ class TeeWriter : public Writer {
   void setMinimizeBlockSize(bool NewValue) OVERRIDE;
   void describeState(FILE* File) OVERRIDE;
 
-  utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
+  void setTrace(std::shared_ptr<filt::TraceClassSexp> Trace) OVERRIDE;
 
  private:
-  class Context : public utils::TraceClass::Context {
-    Context() = delete;
-    Context(const Context&) = delete;
-    Context& operator=(const Context&) = delete;
-
-   public:
-    TeeWriter* MyWriter;
-
-    Context(TeeWriter* MyWriter) : MyWriter(MyWriter) {}
-    ~Context() OVERRIDE;
-    void describe(FILE* File) OVERRIDE;
-  };
-
   std::vector<Node> Writers;
-  std::shared_ptr<Context> MyContext;
-
-  void describeContexts(FILE* File);
 };
 
 }  // end of namespace interp

--- a/src/interp/TeeWriter.h
+++ b/src/interp/TeeWriter.h
@@ -1,0 +1,118 @@
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a tee that broadcasts write actions to a set of writers.
+// Note: Write contexts and tracing is controllable for each
+// individual writer in the tee.
+
+#ifndef DECOMPRESSOR_SRC_INTERP_TEEWRITER_H
+#define DECOMPRESSOR_SRC_INTERP_TEEWRITER_H
+
+#include "interp/Writer.h"
+
+#include <memory>
+#include <vector>
+
+namespace wasm {
+
+namespace interp {
+
+class TeeWriter : public Writer {
+  TeeWriter(const TeeWriter&) = delete;
+  TeeWriter& operator=(const TeeWriter&) = delete;
+
+ public:
+  class Node {
+    Node() = delete;
+
+   public:
+    Node(std::shared_ptr<Writer> NodeWriter,
+         bool TraceNode,
+         bool DefinesTraceContext,
+         bool DefinesStreamType);
+
+    std::shared_ptr<Writer> getWriter() { return NodeWriter; }
+    const std::shared_ptr<Writer> getWriter() const { return NodeWriter; }
+    bool getTraceNode() const { return TraceNode; }
+    bool getDefinesTraceContext() const { return DefinesTraceContext; }
+    bool getDefinesStreamType() const { return DefinesStreamType; }
+    utils::TraceClass::ContextPtr getTraceContext();
+
+   private:
+    std::shared_ptr<Writer> NodeWriter;
+    const bool TraceNode;
+    const bool DefinesTraceContext;
+    const bool DefinesStreamType;
+    utils::TraceClass::ContextPtr TraceContext;
+  };
+
+  TeeWriter();
+  ~TeeWriter() OVERRIDE;
+
+  void add(std::shared_ptr<Writer> NodeWriter,
+           bool DefinesStreamType = false,
+           bool TraceNode = false,
+           bool DefinesTraceContext = false);
+
+  void reset() OVERRIDE;
+  decode::StreamType getStreamType() const OVERRIDE;
+  // Override the following as needed. These methods return false if the writes
+  // failed. Default actions are to do nothing and return true.
+  bool writeUint8(uint8_t Value) OVERRIDE;
+  bool writeUint32(uint32_t Value) OVERRIDE;
+  bool writeUint64(uint64_t Value) OVERRIDE;
+  bool writeVarint32(int32_t Value) OVERRIDE;
+  bool writeVarint64(int64_t Value) OVERRIDE;
+  bool writeVaruint32(uint32_t Value) OVERRIDE;
+  bool writeVaruint64(uint64_t Value) OVERRIDE;
+  bool writeFreezeEof() OVERRIDE;
+  bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
+  bool writeTypedValue(decode::IntType Value,
+                       interp::IntTypeFormat Format) OVERRIDE;
+  bool writeHeaderValue(decode::IntType Value,
+                        interp::IntTypeFormat Format) OVERRIDE;
+  bool writeAction(const filt::CallbackNode* Action) OVERRIDE;
+
+  void setMinimizeBlockSize(bool NewValue) OVERRIDE;
+  void describeState(FILE* File) OVERRIDE;
+
+  utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
+
+ private:
+  class Context : public utils::TraceClass::Context {
+    Context() = delete;
+    Context(const Context&) = delete;
+    Context& operator=(const Context&) = delete;
+
+   public:
+    TeeWriter* MyWriter;
+
+    Context(TeeWriter* MyWriter) : MyWriter(MyWriter) {}
+    ~Context() OVERRIDE;
+    void describe(FILE* File) OVERRIDE;
+  };
+
+  std::vector<Node> Writers;
+  std::shared_ptr<Context> MyContext;
+
+  void describeContexts(FILE* File);
+};
+
+}  // end of namespace interp
+
+}  // end of namespace wasm
+
+#endif  //  DECOMPRESSOR_SRC_INTERP_TEEWRITER_H

--- a/src/interp/TeeWriter.h
+++ b/src/interp/TeeWriter.h
@@ -36,8 +36,6 @@ class TeeWriter : public Writer {
 
  public:
   class Node {
-    Node() = delete;
-
    public:
     Node(std::shared_ptr<Writer> NodeWriter,
          bool DefinesStreamType,

--- a/src/interp/TeeWriter.h
+++ b/src/interp/TeeWriter.h
@@ -48,8 +48,8 @@ class TeeWriter : public Writer {
 
    private:
     std::shared_ptr<Writer> NodeWriter;
-    const bool TraceNode;
-    const bool DefinesStreamType;
+    bool TraceNode;
+    bool DefinesStreamType;
   };
 
   TeeWriter();

--- a/src/interp/Writer.cpp
+++ b/src/interp/Writer.cpp
@@ -29,6 +29,10 @@ namespace interp {
 Writer::~Writer() {
 }
 
+void Writer::setMinimizeBlockSize(bool NewValue) {
+  MinimizeBlockSize = NewValue;
+}
+
 TraceClass::ContextPtr Writer::getTraceContext() {
   TraceClass::ContextPtr Ptr;
   return Ptr;

--- a/src/interp/Writer.h
+++ b/src/interp/Writer.h
@@ -55,7 +55,7 @@ class Writer {
                                 interp::IntTypeFormat Format);
   virtual bool writeAction(const filt::CallbackNode* Action) = 0;
 
-  void setMinimizeBlockSize(bool NewValue) { MinimizeBlockSize = NewValue; }
+  virtual void setMinimizeBlockSize(bool NewValue);
   virtual void describeState(FILE* File);
 
   virtual utils::TraceClass::ContextPtr getTraceContext();

--- a/src/sexp/InflateAst.cpp
+++ b/src/sexp/InflateAst.cpp
@@ -95,7 +95,7 @@ bool InflateAst::appendArgs(Node* Nd) {
 
 // TODO(karlschimpf) Should we extend StreamType to have other?
 StreamType InflateAst::getStreamType() const {
-  return StreamType::Int;
+  return StreamType::Other;
 }
 
 const char* InflateAst::getDefaultTraceName() const {

--- a/src/sexp/InflateAst.cpp
+++ b/src/sexp/InflateAst.cpp
@@ -44,6 +44,21 @@ InflateAst::InflateAst()
 InflateAst::~InflateAst() {
 }
 
+bool InflateAst::failBuild(const char* Method, std::string Message) {
+  TRACE_METHOD(Method);
+  TRACE_MESSAGE(Message);
+  TRACE_MESSAGE("Can't continue");
+  return false;
+}
+
+bool InflateAst::failWriteActionMalformed() {
+  return failBuild("writeAction", "Input malformed");
+}
+
+bool InflateAst::failWriteHeaderMalformed() {
+  return failBuild("writeHeader", "Input malformed");
+}
+
 FileNode* InflateAst::getGeneratedFile() const {
   if (Asts.size() != 1)
     return nullptr;
@@ -143,7 +158,7 @@ bool InflateAst::writeHeaderValue(decode::IntType Value,
   if (Asts.empty())
     Asts.push(Symtab->create<FileHeaderNode>());
   if (Asts.size() != 1)
-    return false;
+    return failWriteHeaderMalformed();
   Node* Header = AstsTop;
   switch (Format) {
     case IntTypeFormat::Uint8:
@@ -156,15 +171,13 @@ bool InflateAst::writeHeaderValue(decode::IntType Value,
       Asts.push(Symtab->getU64ConstDefinition(Value, ValueFormat::Hexidecimal));
       break;
     default:
-      return false;
+      return failWriteHeaderMalformed();
   }
   Header->append(Asts.popValue());
   return true;
 }
 
 bool InflateAst::applyOp(IntType Op) {
-  TRACE_METHOD("applyOp");
-  TRACE(IntType, "Op", Op);
   switch (NodeType(Op)) {
     case OpBlock:
       return buildUnary<BlockNode>();
@@ -192,9 +205,9 @@ bool InflateAst::applyOp(IntType Op) {
       return buildUnary<ReadNode>();
     case OpSection:
       // Note: Bottom element is for file.
-      TRACE(size_t, "Stack.size", Asts.size());
+      TRACE(size_t, "Ast stack size", Asts.size());
       if (Asts.empty())
-        return false;
+        return failWriteActionMalformed();
       Values.push(Asts.size() - 1);
       if (!buildNary<SectionNode>())
         return false;
@@ -207,17 +220,17 @@ bool InflateAst::applyOp(IntType Op) {
     case OpSymbol: {
       SymbolNode* Sym = SectionSymtab.getIndexSymbol(Values.popValue());
       Values.pop();
+      if (Sym == nullptr) {
+        return failWriteActionMalformed();
+      }
       TRACE_SEXP("Ast", Sym);
-      if (Sym == nullptr)
-        return false;
       Asts.push(Sym);
       return true;
     }
     default:
-      TRACE_MESSAGE("unknonw");
-      break;
+      return failWriteActionMalformed();
   }
-  return false;
+  return failWriteActionMalformed();
 }
 
 bool InflateAst::writeAction(const filt::CallbackNode* Action) {
@@ -245,7 +258,7 @@ bool InflateAst::writeAction(const filt::CallbackNode* Action) {
 #endif
   const auto* Sym = dyn_cast<SymbolNode>(Action->getKid(0));
   if (Sym == nullptr)
-    return false;
+    return failWriteActionMalformed();
   PredefinedSymbol Name = Sym->getPredefinedSymbol();
   switch (Name) {
     case PredefinedSymbol::Block_enter:
@@ -253,7 +266,7 @@ bool InflateAst::writeAction(const filt::CallbackNode* Action) {
       return true;
     case PredefinedSymbol::Instruction_begin:
       AstMarkers.push(Asts.size());
-      return false;
+      return true;
     case PredefinedSymbol::Int_value_begin:
       ValueMarker = Values.size();
       return true;
@@ -262,11 +275,11 @@ bool InflateAst::writeAction(const filt::CallbackNode* Action) {
       ValueFormat Format = ValueFormat::Decimal;
       IntType Value = 0;
       if (Values.size() < ValueMarker)
-        return false;
+        return failWriteActionMalformed();
       switch (Values.size() - ValueMarker) {
         case 1:
           if (Values.popValue() != 0)
-            return false;
+            return failWriteActionMalformed();
           IsDefault = true;
           break;
         case 2:
@@ -275,10 +288,9 @@ bool InflateAst::writeAction(const filt::CallbackNode* Action) {
           Format = ValueFormat(Values.popValue() - 1);
           break;
         default:
-          return false;
+          return failWriteActionMalformed();
       }
       Node* Nd = nullptr;
-      TRACE(IntType, "Op", ValuesTop);
       switch (Values.popValue()) {
         case OpUint8:
           Nd = IsDefault ? Symtab->getUint8Definition()
@@ -313,28 +325,20 @@ bool InflateAst::writeAction(const filt::CallbackNode* Action) {
                          : Symtab->getVaruint64Definition(Value, Format);
           break;
         default:
-          return false;
+          return failWriteActionMalformed();
       }
+      TRACE_SEXP("Ast", Nd);
       Asts.push(Nd);
       return true;
     }
-    case PredefinedSymbol::Literal_define: {
-      if (Asts.size() < 2)
-        return false;
-      Node* Arg2 = Asts.popValue();
-      Node* Arg1 = Asts.popValue();
-      Asts.push(Symtab->create<LiteralDefNode>(Arg1, Arg2));
-      TRACE_SEXP("Define", AstsTop);
-      return false;
-    }
     case PredefinedSymbol::Symbol_name_begin:
       if (Values.empty())
-        return false;
+        return failWriteActionMalformed();
       SymbolNameSize = Values.popValue();
       return true;
     case PredefinedSymbol::Symbol_name_end: {
       if (Values.size() < SymbolNameSize)
-        return false;
+        return failWriteActionMalformed();
       // TODO(karlschimpf) Can we build the string faster than this.
       std::string Name;
       for (size_t i = Values.size() - SymbolNameSize; i < Values.size(); ++i)
@@ -348,18 +352,17 @@ bool InflateAst::writeAction(const filt::CallbackNode* Action) {
     }
     case PredefinedSymbol::Symbol_lookup:
       if (Values.size() < 2)
-        return false;
+        return failWriteActionMalformed();
       return applyOp(Values[Values.size() - 2]);
     case PredefinedSymbol::Postorder_inst:
       if (Values.size() < 1)
-        return false;
+        return failWriteActionMalformed();
       return applyOp(ValuesTop);
     case PredefinedSymbol::Nary_inst:
       if (Values.size() < 2)
-        return false;
-      TRACE(size_t, "Values.size", Values.size());
+        return failWriteActionMalformed();
+      TRACE(size_t, "nary node size", Values.size());
       return applyOp(Values[Values.size() - 2]);
-      return false;
     default:
       break;
   }

--- a/src/sexp/InflateAst.h
+++ b/src/sexp/InflateAst.h
@@ -86,6 +86,9 @@ class InflateAst : public interp::Writer {
   bool buildBinary();
   template <class T>
   bool buildNary();
+  bool failBuild(const char* Method, std::string Message);
+  bool failWriteActionMalformed();
+  bool failWriteHeaderMalformed();
 };
 
 }  // end of namespace filt

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -100,7 +100,7 @@ inline void print_IntType(IntType Value) {
 #define PRI_IntType PRIu64
 static constexpr size_t kBitsInIntType = 64;
 
-enum class StreamType : uint8_t { Byte, Int };
+enum class StreamType : uint8_t { Byte, Int, Other };
 const char* getName(StreamType Type);
 Ordering compare(StreamType S1, StreamType S2);
 


### PR DESCRIPTION
This uses the inflate ast writer with the (algorithm) format writer, so that you can see the ast nodes being written, as they are written, when tracing is turned on.  This makes debugging a lot easier.