### PR TITLE
Force cast2casm to maintain the compressed header.

### DIFF
--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -359,7 +359,10 @@ int main(int Argc, const char* Argv[]) {
     Reader->setTrace(Trace);
     Writer->setTrace(Trace);
   }
-  Reader->useFileHeader(InputSymtab->getInstalledHeader());
+  // Note: By default, the reader uses the installed header, which corresponds
+  // to the target header (not the header for compressed algorithms). Fix
+  // by overriding to use the root header.
+  Reader->useFileHeader(InputSymtab->getRootHeader());
   Reader->algorithmStart();
   Reader->algorithmReadBackFilled();
   if (Reader->errorsFound()) {

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -398,6 +398,12 @@ void SymbolTable::installSubtreeCaches(Node* Nd,
     AdditionalNodes.push_back(Kid);
 }
 
+const FileHeaderNode* SymbolTable::getRootHeader() const {
+  if (Root == nullptr)
+    return nullptr;
+  return dyn_cast<FileHeaderNode>(Root->getKid(0));
+}
+
 void SymbolTable::installDefinitions(Node* Root) {
   TRACE_METHOD("installDefinitions");
   TRACE(node_ptr, nullptr, Root);
@@ -410,7 +416,7 @@ void SymbolTable::installDefinitions(Node* Root) {
       if (InstalledHeader == nullptr) {
         InstalledHeader = dyn_cast<FileHeaderNode>(Root->getKid(1));
         if (InstalledHeader == nullptr)
-          InstalledHeader = dyn_cast<FileHeaderNode>(Root->getKid(0));
+          InstalledHeader = getRootHeader();
       }
     // intentionally fall to next case.
     case OpSection:

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -181,6 +181,7 @@ class SymbolTable : public std::enable_shared_from_this<SymbolTable> {
   // Install definitions in tree defined by root.
   void install(Node* Root);
   const Node* getInstalledRoot() const { return Root; }
+  const FileHeaderNode* getRootHeader() const;
   const FileHeaderNode* getInstalledHeader() const { return InstalledHeader; }
   void clear() { SymbolMap.clear(); }
   int getNextCreationIndex() { return ++NextCreationIndex; }
@@ -204,7 +205,7 @@ class SymbolTable : public std::enable_shared_from_this<SymbolTable> {
   std::vector<Node*>* Allocated;
   std::shared_ptr<utils::TraceClass> Trace;
   Node* Root;
-  FileHeaderNode* InstalledHeader;
+  const FileHeaderNode* InstalledHeader;
   Node* Error;
   int NextCreationIndex;
   std::map<std::string, SymbolNode*> SymbolMap;

--- a/src/sexp/InflateAst.cpp
+++ b/src/sexp/InflateAst.cpp
@@ -251,7 +251,7 @@ bool InflateAst::applyOp(IntType Op) {
     case OpSection:
       // Note: Bottom element is for file.
       TRACE(size_t, "Tree stack size", Asts.size());
-      if (Asts.size() < 1)
+      if (Asts.size() < 2)
         return failWriteActionMalformed();
       Values.push(Asts.size() - 2);
       if (!buildNary<SectionNode>())

--- a/src/sexp/casm.df
+++ b/src/sexp/casm.df
@@ -135,6 +135,7 @@
     (case 'error'               (=> 'postorder.inst'))
     (case 'eval'                (eval 'nary.node'))
     #    (case 'file'                (=> 'postorder.inst'))
+    (case 'file.header'         (eval 'nary.node'))
     (case 'filter'              (eval 'nary.node'))
     (case 'if.then'             (=> 'postorder.inst'))
     (case 'if.then.else'        (=> 'postorder.inst'))


### PR DESCRIPTION
By default, the reader uses the installed header (second header line in the default algorithms file) since that header defines what the input should have to apply the algorithms. However, in cast2casm, we are generating the compressed file rather than the corresponding input it will parse. As a result, we override the header file to match the header for the compressed algorithms file (i.e. the primary header of the algorithms file that defines the correct header).