### PR TITLE
Fix tools to include default algorithms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 WebAssembly Community Group participants
+	# Copyright 2016 WebAssembly Community Group participants
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 include Makefile.common
 
 GENSRCS =
+GENSRCS_BOOT =
 
 ###### Utilities ######
 
@@ -73,14 +74,21 @@ PARSER_GENSRCS = \
 PARSER_SRCS = \
 	Driver.cpp
 
-GENSRCS += $(patsubst %, $(PARSER_GENDIR)/%, $(PARSER_GENSRCS))
+PARSER_CPP_GENSRCS = \
+	Lexer.cpp \
+	Parser.tab.cpp
+
+PARSER_GEN_SRCS = $(patsubst %, $(PARSER_GENDIR)/%, $(PARSER_GENSRCS))
+
+GENSRCS += $(PARSER_GEN_SRCS)
+GENSRCS_BOOT += $(PARSER_GEN_SRCS)
 
 PARSER_STD_OBJS=$(patsubst %.cpp, $(PARSER_OBJDIR)/%.o, $(PARSER_SRCS))
-PARSER_GEN_OBJS=$(patsubst %.cpp, $(PARSER_OBJDIR)/%.o, $(PARSER_GENSRCS))
+PARSER_GEN_OBJS=$(patsubst %.cpp, $(PARSER_OBJDIR)/%.o, $(PARSER_CPP_GENSRCS))
 PARSER_OBJS=$(PARSER_STD_OBJS) $(PARSER_GEN_OBJS)
 
 PARSER_STD_OBJS_BOOT=$(patsubst %.cpp, $(PARSER_OBJDIR_BOOT)/%.o, $(PARSER_SRCS))
-PARSER_GEN_OBJS_BOOT=$(patsubst %.cpp, $(PARSER_OBJDIR_BOOT)/%.o, $(PARSER_GENSRCS))
+PARSER_GEN_OBJS_BOOT=$(patsubst %.cpp, $(PARSER_OBJDIR_BOOT)/%.o, $(PARSER_CPP_GENSRCS))
 PARSER_OBJS_BOOT=$(PARSER_STD_OBJS_BOOT) $(PARSER_GEN_OBJS_BOOT)
 
 PARSER_LIB = $(LIBDIR)/$(LIBPREFIX)parser.a
@@ -144,13 +152,6 @@ ALG_LIB = $(LIBDIR)/$(LIBPREFIX)alg.a
 
 ALG_GENDIR_ALG = $(ALG_GENDIR)/casm0x0.cast
 
-$(info Using ALG_SRCS = $(ALG_SRCS))
-$(info Using ALG_GEN_SRCS = $(ALG_GEN_SRCS))
-$(info Using ALG_GEN_CPP_SRCS = $(ALG_GEN_CPP_SRCS))
-$(info Using ALG_GEN_H_SRCS = $(ALG_GEN_H_SRCS))
-$(info Using ALG_OBJS = $(ALG_OBJS))
-$(info Using ALG_LIB = $(ALG_LIB))
-
 ###### Stream handlers ######
 
 STRM_SRCDIR = $(SRCDIR)/stream
@@ -189,10 +190,9 @@ INTERP_SRCDIR = $(SRCDIR)/interp
 INTERP_OBJDIR = $(OBJDIR)/interp
 INTERP_OBJDIR_BOOT = $(OBJDIR_BOOT)/interp
 
-INTERP_SRCS = \
+INTERP_SRCS_BASE = \
 	ByteReadStream.cpp \
 	ByteWriteStream.cpp \
-	Decompress.cpp \
 	Interpreter.cpp \
 	IntFormats.cpp \
 	IntReader.cpp \
@@ -206,8 +206,10 @@ INTERP_SRCS = \
 	Writer.cpp \
 	WriteStream.cpp
 
+INTERP_SRCS = $(INTERP_SRCS_BASE) Decompress.cpp
+
 INTERP_OBJS = $(patsubst %.cpp, $(INTERP_OBJDIR)/%.o, $(INTERP_SRCS))
-INTERP_OBJS_BOOT = $(patsubst %.cpp, $(INTERP_OBJDIR_BOOT)/%.o, $(INTERP_SRCS))
+INTERP_OBJS_BOOT = $(patsubst %.cpp, $(INTERP_OBJDIR_BOOT)/%.o, $(INTERP_SRCS_BASE))
 
 INTERP_LIB = $(LIBDIR)/$(LIBPREFIX)interp.a
 INTERP_LIB_BOOT = $(LIBDIR_BOOT)/$(LIBPREFIX)interp.a
@@ -258,9 +260,6 @@ EXECS = $(patsubst %.cpp, $(BUILD_EXECDIR)/%$(EXE), $(EXEC_SRCS))
 
 
 EXECS_BOOT = $(patsubst %.cpp, $(BUILD_EXECDIR_BOOT)/%$(EXE_BOOT), $(EXEC_SRCS_BOOT))
-
-$(info Using EXECS = $(EXECS))
-$(info Using EXECS_BOOT = $(EXECS_BOOT))
 
 ###### Test executables and locations ######
 
@@ -401,8 +400,8 @@ TEST_CASM_DF_GEN_FILES = $(patsubst %.df, $(TEST_0XD_GENDIR)/%.df-out, \
 ###### General compilation definitions ######
 
 LIBS = $(PARSER_LIB) $(BINARY_LIB) $(INTERP_LIB) $(SEXP_LIB) \
-       $(STRM_LIB) $(UTILS_LIB) $(INTCOMP_LIB) $(INTERP_LIB) $(BINARY_LIB) \
-       $(ALG_LIB)
+       $(STRM_LIB) $(INTCOMP_LIB) $(INTERP_LIB) $(BINARY_LIB) \
+       $(ALG_LIB) $(STRM_LIB) $(UTILS_LIB) 
 
 LIBS_BOOT = $(PARSER_LIB_BOOT) $(BINARY_LIB_BOOT) $(INTERP_LIB_BOOT) \
        $(SEXP_LIB_BOOT) $(STRM_LIB_BOOT) $(UTILS_LIB_BOOT) $(INTERP_LIB_BOOT) \
@@ -431,9 +430,6 @@ endif
 ifdef MAKE_PAGE_SIZE
   CXXFLAGS += -DWASM_DECODE_PAGE_SIZE=$(PAGE_SIZE)
 endif
-
-
-$(info GENSRCS = $(GENSRCS))
 
 ###### Default Rule ######
 
@@ -515,7 +511,7 @@ $(ALG_OBJDIR):
 $(ALG_GENDIR):
 	mkdir -p $@
 
-$(ALG_LIB): $(ALG_OBJS)>
+$(ALG_LIB): $(ALG_OBJS)
 	ar -rs $@ $(ALG_OBJS)
 	ranlib $@
 
@@ -528,14 +524,13 @@ $(ALG_GEN_H_SRCS): $(ALG_GENDIR)/%.h: $(ALG_GENDIR)/%.cast \
 		$(BUILD_EXECDIR_BOOT)/cast2casm
 	$(BUILD_EXECDIR_BOOT)/cast2casm -a $(ALG_GENDIR_ALG) -m \
 		$< -o $@ --header --function \
-		$(patsubst $(ALG_GENDIR)/%.cast, Alg%, $<)
+		$(patsubst $(ALG_GENDIR)/%.cast, install_Alg%, $<)
 
 $(ALG_GEN_CPP_SRCS): $(ALG_GENDIR)/%.cpp: $(ALG_GENDIR)/%.cast \
 		$(BUILD_EXECDIR_BOOT)/cast2casm $(ALG_GENDIR_ALG)
 	$(BUILD_EXECDIR_BOOT)/cast2casm -a $(ALG_GENDIR_ALG) -m \
 		$< -o $@ --function \
-		$(patsubst $(ALG_GENDIR)/%.cast, Alg%, $<)
-
+		$(patsubst $(ALG_GENDIR)/%.cast, install_Alg%, $<)
 -include $(foreach dep,$(ALG_GEN_CPP_SRCS:.cpp=.d),$(ALG_OBJDIR)/$(dep))
 
 $(ALG_OBJS): $(ALG_OBJDIR)/%.o: $(ALG_GENDIR)/%.cpp $(GENSRCS)
@@ -558,7 +553,7 @@ $(BINARY_OBJS): $(BINARY_OBJDIR)/%.o: $(BINARY_DIR)/%.cpp $(GENSRCS)
 
 -include $(foreach dep,$(BINARY_SRCS:.cpp=.d),$(BINARY_OBJDIR_BOOT)/$(dep))
 
-$(BINARY_OBJS_BOOT): $(BINARY_OBJDIR_BOOT)/%.o: $(BINARY_DIR)/%.cpp
+$(BINARY_OBJS_BOOT): $(BINARY_OBJDIR_BOOT)/%.o: $(BINARY_DIR)/%.cpp $(GENSRCS_BOOT)
 	$(CPP_COMPILER_BOOT) -c $(CXXFLAGS_BOOT) $< -o $@
 
 $(BINARY_LIB): $(BINARY_OBJS)
@@ -588,7 +583,7 @@ $(UTILS_OBJS): $(OBJDIR)/%.o: $(SRCDIR)/%.cpp $(GENSRCS)
 
 -include $(foreach dep,$(UTILS_SRCS:.cpp=.d),$(OBJDIR_BOOT)/$(dep))
 
-$(UTILS_OBJS_BOOT): $(OBJDIR_BOOT)/%.o: $(SRCDIR)/%.cpp
+$(UTILS_OBJS_BOOT): $(OBJDIR_BOOT)/%.o: $(SRCDIR)/%.cpp $(GENSRCS_BOOT)
 	$(CPP_COMPILER_BOOT) -c $(CXXFLAGS_BOOT) $< -o $@
 
 $(UTILS_LIB): $(UTILS_OBJS)
@@ -618,7 +613,7 @@ $(INTERP_OBJS): $(INTERP_OBJDIR)/%.o: $(INTERP_SRCDIR)/%.cpp $(GENSRCS)
 
 -include $(foreach dep,$(INTERP_SRCS:.cpp=.d),$(INTERP_OBJDIR_BOOT)/$(dep))
 
-$(INTERP_OBJS_BOOT): $(INTERP_OBJDIR_BOOT)/%.o: $(INTERP_SRCDIR)/%.cpp
+$(INTERP_OBJS_BOOT): $(INTERP_OBJDIR_BOOT)/%.o: $(INTERP_SRCDIR)/%.cpp $(GENSRCS_BOOT)
 	$(CPP_COMPILER_BOOT) -c $(CXXFLAGS_BOOT) $< -o $@
 
 $(INTERP_LIB): $(INTERP_OBJS)
@@ -665,7 +660,7 @@ $(SEXP_OBJS): $(SEXP_OBJDIR)/%.o: $(SEXP_SRCDIR)/%.cpp $(GENSRCS)
 
 -include $(foreach dep,$(SEXP_SRCS:.cpp=.d),$(SEXP_OBJDIR_BOOT)/$(dep))
 
-$(SEXP_OBJS_BOOT): $(SEXP_OBJDIR_BOOT)/%.o: $(SEXP_SRCDIR)/%.cpp
+$(SEXP_OBJS_BOOT): $(SEXP_OBJDIR_BOOT)/%.o: $(SEXP_SRCDIR)/%.cpp $(GENSRCS_BOOT)
 	$(CPP_COMPILER_BOOT) -c $(CXXFLAGS_BOOT) $< -o $@
 
 -include $(foreach dep,$(SEXP_DEFAULT_SRCS:.cpp=.d),$(SEXP_OBJDIR)/$(dep))
@@ -701,7 +696,7 @@ $(STRM_OBJS): $(STRM_OBJDIR)/%.o: $(STRM_SRCDIR)/%.cpp $(GENSRCS)
 
 -include $(foreach dep,$(STRM_SRCS:.cpp=.d),$(STRM_OBJDIR_BOOT)/$(dep))
 
-$(STRM_OBJS_BOOT): $(STRM_OBJDIR_BOOT)/%.o: $(STRM_SRCDIR)/%.cpp
+$(STRM_OBJS_BOOT): $(STRM_OBJDIR_BOOT)/%.o: $(STRM_SRCDIR)/%.cpp $(GENSRCS_BOOT)
 	$(CPP_COMPILER_BOOT) -c $(CXXFLAGS_BOOT) $< -o $@
 
 $(STRM_LIB): $(STRM_OBJS)
@@ -733,6 +728,22 @@ $(PARSER_GENDIR)/Parser.ypp: $(PARSER_DIR)/Parser.ypp $(PARSER_GENDIR)
 $(PARSER_GENDIR)/Parser.tab.cpp: $(PARSER_GENDIR)/Parser.ypp
 	cd $(PARSER_GENDIR); bison -d -r all Parser.ypp
 
+$(PARSER_GENDIR)/location.hh: $(PARSER_GENDIR)/Parser.tab.cpp
+	touch $@
+
+$(PARSER_GENDIR)/Parser.output: $(PARSER_GENDIR)/Parser.tab.cpp
+	touch $@
+
+$(PARSER_GENDIR)/Parser.tab.hpp: $(PARSER_GENDIR)/Parser.tab.cpp
+	touch $@
+
+
+$(PARSER_GENDIR)/position.hh: $(PARSER_GENDIR)/Parser.tab.cpp
+	touch $@
+
+$(PARSER_GENDIR)/stack.hh: $(PARSER_GENDIR)/Parser.tab.cpp
+	touch $@
+
 $(PARSER_OBJS): | $(PARSER_OBJDIR)
 
 $(PARSER_OBJDIR):
@@ -748,21 +759,22 @@ $(PARSER_OBJDIR_BOOT):
 $(PARSER_STD_OBJS): $(PARSER_OBJDIR)/%.o: $(PARSER_DIR)/%.cpp $(GENSRCS)
 	$(CPP_COMPILER) -c $(CXXFLAGS) $< -o $@
 
--include $(foreach dep,$(PARSER_GENSRCS:.cpp=.d),$(PARSER_OBJDIR)/$(dep))
+-include $(foreach dep,$(PARSER_CPP_GENSRCS:.cpp=.d),$(PARSER_OBJDIR)/$(dep))
 
-$(PARSER_GEN_OBJS): $(PARSER_OBJDIR)/%.o: $(PARSER_GENDIR)/%.cpp $(GENSRCS)
+$(PARSER_GEN_OBJS): $(PARSER_OBJDIR)/%.o: $(PARSER_GENDIR)/%.cpp \
+		$(GENSRCS)
 	$(CPP_COMPILER) -c $(CXXFLAGS) $< -o $@
 
 -include $(foreach dep,$(PARSER_SRCS:.cpp=.d),$(PARSER_OBJDIR_BOOT)/$(dep))
 
 $(PARSER_STD_OBJS_BOOT): $(PARSER_OBJDIR_BOOT)/%.o: $(PARSER_DIR)/%.cpp \
-	        $(PARSER_GENDIR)/Lexer.cpp $(PARSER_GENDIR)/Parser.tab.cpp
+		$(GENSRCS_BOOT)
 	$(CPP_COMPILER_BOOT) -c $(CXXFLAGS_BOOT) $< -o $@
 
--include $(foreach dep,$(PARSER_GENSRCS:.cpp=.d),$(PARSER_OBJDIR_BOOT)/$(dep))
+-include $(foreach dep,$(PARSER_CPP_GENSRCS:.cpp=.d),$(PARSER_OBJDIR_BOOT)/$(dep))
 
 $(PARSER_GEN_OBJS_BOOT): $(PARSER_OBJDIR_BOOT)/%.o: $(PARSER_GENDIR)/%.cpp \
-	        $(PARSER_GENDIR)/Lexer.cpp $(PARSER_GENDIR)/Parser.tab.cpp
+		$(GENSRCS_BOOT)
 	$(CPP_COMPILER_BOOT) -c $(CXXFLAGS_BOOT) $< -o $@
 
 $(PARSER_LIB): $(PARSER_OBJS)
@@ -813,7 +825,7 @@ $(EXEC_OBJS): $(EXEC_OBJDIR)/%.o: $(EXEC_DIR)/%.cpp $(GENSRCS)
 -include $(foreach dep,$(EXEC_SRCS:.cpp=.d),$(EXEC_OBJDIR_BOOT)/$(dep))
 
 $(EXEC_OBJS_BOOT): $(EXEC_OBJDIR_BOOT)/%.o: $(EXEC_DIR)/%.cpp \
-		$(PARSER_GENDIR)/Parser.tab.cpp
+		$(GENSRCS_BOOT)
 	$(CPP_COMPILER_BOOT) -c $(CXXFLAGS_BOOT) $< -o $@
 
 $(BUILD_EXECDIR):
@@ -859,9 +871,12 @@ $(TEST_EXECS): $(TEST_EXECDIR)/%$(EXE): $(TEST_OBJDIR)/%.o $(LIBS)
 ###### Testing ######
 
 test: build-all test-parser test-raw-streams test-byte-queues \
-	test-decompsexp-wasm test-decompwasm-sexp test-decompress
+	test-decompress
 	@echo "*** all tests passed ***"
 
+# TODO: FInish removing the following since cast2casm and casm2cast replace
+# the following deprecated tests (now broken).
+#	test-decompsexp-wasm test-decompwasm-sexp
 # TODO: Add this back to the set of tests.
 #	test-compress
 

--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ CXXFLAGS_BASE := -Wall -Wextra -O2 -g -pedantic -MP -MD \
 	    -Werror -Wno-unused-parameter -fno-omit-frame-pointer -fPIC \
 	    -Isrc -I$(SRC_GENDIR)
 CXXFLAGS := $(TARGET_CXXFLAGS) $(PLATFORM_CXXFLAGS) \
-	    $(CXXFLAGS_BASE) -DWASM_BOOT=0
+	    $(CXXFLAGS_BASE)
 
 CXXFLAGS_BOOT := $(PLATFORM_CXXFLAGS_DEFAULT) $(CXXFLAGS_BASE) -DWASM_BOOT=1
 

--- a/src/binary/BinaryReader.cpp
+++ b/src/binary/BinaryReader.cpp
@@ -382,7 +382,7 @@ void BinaryReader::resume() {
                 StreamKind StrmKind;
                 StreamType StrmType;
                 StreamNode::decode(Encoding, StrmKind, StrmType);
-                auto* Node = Symtab->create<StreamNode>(StrmKind, StrmType);
+                auto* Node = Symtab->getStreamDefinition(StrmKind, StrmType);
                 TRACE(node_ptr, nullptr, Node);
                 NodeStack.push_back(Node);
                 break;

--- a/src/exec/casm2cast.cpp
+++ b/src/exec/casm2cast.cpp
@@ -16,6 +16,12 @@
 
 // Converts binary algorithm file back to textual form.
 
+#include "utils/Defs.h"
+
+#if WASM_BOOT == 0
+#include "algorithms/casm0x0.h"
+#endif
+
 #include "interp/StreamReader.h"
 #include "sexp/InflateAst.h"
 #include "sexp/TextWriter.h"
@@ -39,7 +45,7 @@ namespace {
 
 const char* InputFilename = "-";
 const char* OutputFilename = "-";
-const char* AlgorithmFilename = "/dev/null";
+const char* AlgorithmFilename = nullptr;
 
 bool TraceParser = false;
 bool TraceLexer = false;
@@ -99,10 +105,16 @@ int main(int Argc, const char* Argv[]) {
   {
     ArgsParser Args("Converts compression algorithm from binary fto text");
 
-    ArgsParser::Required<charstring> AlgorithmFlag(AlgorithmFilename);
-    Args.add(AlgorithmFlag.setShortName('a')
-                 .setOptionName("ALG")
-                 .setDescription("Usage algorithm to parse binary file"));
+#if WASM_BOOT
+    ArgsParser::Required<charstring>
+#else
+    ArgsParser::Optional<charstring>
+#endif
+        AlgorithmFlag(AlgorithmFilename);
+    Args.add(
+        AlgorithmFlag.setShortName('a').setOptionName("ALG").setDescription(
+            "File containing algorithm defining binary "
+            "format"));
 
     ArgsParser::Optional<bool> ExpectFailFlag(ExpectExitFail);
     Args.add(ExpectFailFlag.setDefault(false)
@@ -158,11 +170,19 @@ int main(int Argc, const char* Argv[]) {
       TraceRead = true;
   }
 
-  if (Verbose)
-    fprintf(stderr, "Reading algorithm file: %s\n", AlgorithmFilename);
-  std::shared_ptr<SymbolTable> AlgSymtab = parseFile(AlgorithmFilename);
-  if (!AlgSymtab)
-    return exit_status(EXIT_FAILURE);
+  assert(!(WASM_BOOT && AlgorithmFilename == nullptr));
+
+  std::shared_ptr<SymbolTable> AlgSymtab;
+  if (AlgorithmFilename) {
+    if (Verbose)
+      fprintf(stderr, "Reading algorithm file: %s\n", AlgorithmFilename);
+    AlgSymtab = parseFile(AlgorithmFilename);
+    if (!AlgSymtab)
+      return exit_status(EXIT_FAILURE);
+  } else {
+    AlgSymtab = std::make_shared<SymbolTable>();
+    install_Algcasm0x0(AlgSymtab);
+  }
 
   if (Verbose)
     fprintf(stderr, "Reading input: %s\n", InputFilename);

--- a/src/exec/casm2cast.cpp
+++ b/src/exec/casm2cast.cpp
@@ -46,7 +46,7 @@ bool TraceLexer = false;
 
 std::shared_ptr<RawStream> getInput() {
   if (InputFilename == std::string("-")) {
-    return std::make_shared<FdReader>(STDIN_FILENO, false);
+    return std::make_shared<FileReader>(stdin, false);
   }
   return std::make_shared<FileReader>(InputFilename);
 }

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -89,8 +89,7 @@ class CodeGenerator {
         Namespaces(Namespaces),
         FunctionName(FunctionName),
         FoundErrors(false),
-        NextIndex(1)
-  {}
+        NextIndex(1) {}
   ~CodeGenerator() {}
   bool generateDeclFile();
   bool generateImplFile();
@@ -193,8 +192,8 @@ void CodeGenerator::generateEnterNamespaces() {
 }
 
 void CodeGenerator::generateExitNamespaces() {
-  for (std::vector<charstring>::reverse_iterator
-           Iter = Namespaces.rbegin(), IterEnd = Namespaces.rend();
+  for (std::vector<charstring>::reverse_iterator Iter = Namespaces.rbegin(),
+                                                 IterEnd = Namespaces.rend();
        Iter != IterEnd; ++Iter) {
     Output->puts("}  // end of namespace ");
     Output->puts(*Iter);
@@ -249,10 +248,10 @@ void CodeGenerator::generateFunctionHeader(std::string NodeType, size_t Index) {
 }
 
 void CodeGenerator::generateFunctionFooter() {
-  Output->puts("}\n"
-               "\n");
+  Output->puts(
+      "}\n"
+      "\n");
 }
-
 
 void CodeGenerator::generateCloseFunctionFooter() {
   Output->puts(");\n");
@@ -448,7 +447,7 @@ size_t CodeGenerator::generateNode(const Node* Nd) {
     case OpRead:
       return generateUnaryNode("ReadNode", Nd);
     case OpRename:
-      return  generateBinaryNode("RenameNode", Nd);
+      return generateBinaryNode("RenameNode", Nd);
     case OpSection:
       return generateNaryNode("SectionNode", Nd);
     case OpSequence:
@@ -503,17 +502,20 @@ bool CodeGenerator::generateDeclFile() {
 bool CodeGenerator::generateImplFile() {
   generateHeader();
   generateEnterNamespaces();
-  Output->puts("using namespace wasm::filt;\n"
-               "\n"
-               "namespace {\n"
-               "\n");
+  Output->puts(
+      "using namespace wasm::filt;\n"
+      "\n"
+      "namespace {\n"
+      "\n");
   size_t Index = generateNode(Symtab->getInstalledRoot());
-  Output->puts("}  // end of anonymous namespace\n"
-               "\n");
+  Output->puts(
+      "}  // end of anonymous namespace\n"
+      "\n");
   generateAlgorithmHeader();
-  Output->puts(" {\n"
-               "  SymbolTable* Symtab = Symtable.get();\n"
-               "  Symtab->install(");
+  Output->puts(
+      " {\n"
+      "  SymbolTable* Symtab = Symtable.get();\n"
+      "  Symtab->install(");
   generateFunctionCall(Index);
   generateCloseFunctionFooter();
   generateExitNamespaces();
@@ -692,7 +694,8 @@ int main(int Argc, charstring Argv[]) {
     Namespaces.push_back("decode");
     CodeGenerator Generator(InputFilename, Output, InputSymtab, Namespaces,
                             FunctionName);
-    if (HeaderFile ? Generator.generateDeclFile() : Generator.generateImplFile()) {
+    if (HeaderFile ? Generator.generateDeclFile()
+                   : Generator.generateImplFile()) {
       fprintf(stderr, "Unable to generate valid C++ source!");
       return exit_status(EXIT_FAILURE);
     }

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -27,6 +27,7 @@
 #include "stream/WriteBackedQueue.h"
 #include "utils/ArgsParse.h"
 
+#include <cstdio>
 #include <memory>
 #include <unistd.h>
 
@@ -38,21 +39,21 @@ using namespace wasm::utils;
 
 namespace {
 
-const char* InputFilename = "-";
-const char* OutputFilename = "-";
-const char* AlgorithmFilename = "/dev/null";
+charstring InputFilename = "-";
+charstring OutputFilename = "-";
+charstring AlgorithmFilename = "/dev/null";
 
 bool TraceParser = false;
 bool TraceLexer = false;
 
 std::shared_ptr<RawStream> getOutput() {
   if (OutputFilename == std::string("-")) {
-    return std::make_shared<FdWriter>(STDOUT_FILENO, false);
+    return std::make_shared<FileWriter>(stdout, false);
   }
   return std::make_shared<FileWriter>(OutputFilename);
 }
 
-std::shared_ptr<SymbolTable> parseFile(const char* Filename) {
+std::shared_ptr<SymbolTable> parseFile(charstring Filename) {
   auto Symtab = std::make_shared<SymbolTable>();
   Driver Parser(Symtab);
   if (TraceParser)
@@ -68,7 +69,88 @@ std::shared_ptr<SymbolTable> parseFile(const char* Filename) {
 
 #define BYTES_PER_LINE_IN_WASM_DEFAULTS 16
 
-void generateHeader(const char* Filename, std::shared_ptr<RawStream> Output) {
+static charstring LocalName = "Local_";
+static charstring FuncName = "Func_";
+
+class CodeGenerator {
+  CodeGenerator() = delete;
+  CodeGenerator(const CodeGenerator&) = delete;
+  CodeGenerator& operator=(const CodeGenerator&) = delete;
+
+ public:
+  CodeGenerator(charstring Filename,
+                std::shared_ptr<RawStream> Output,
+                std::shared_ptr<SymbolTable> Symtab,
+                std::vector<charstring>& Namespaces,
+                charstring FunctionName)
+      : Filename(Filename),
+        Output(Output),
+        Symtab(Symtab),
+        Namespaces(Namespaces),
+        FunctionName(FunctionName),
+        FoundErrors(false),
+        NextIndex(1)
+  {}
+  ~CodeGenerator() {}
+  bool generateDeclFile();
+  bool generateImplFile();
+
+ private:
+  charstring Filename;
+  std::shared_ptr<RawStream> Output;
+  std::shared_ptr<SymbolTable> Symtab;
+  std::vector<charstring>& Namespaces;
+  charstring FunctionName;
+  bool FoundErrors;
+  size_t NextIndex;
+
+  void generateHeader();
+  void generateEnterNamespaces();
+  void generateExitNamespaces();
+  void generateAlgorithmHeader();
+  size_t generateNode(const Node* Nd);
+  size_t generateSymbol(const SymbolNode* Sym);
+  size_t generateIntegerNode(charstring NodeType, const IntegerNode* Nd);
+  size_t generateNullaryNode(charstring NodeType, const Node* Nd);
+  size_t generateUnaryNode(charstring NodeType, const Node* Nd);
+  size_t generateBinaryNode(charstring NodeType, const Node* Nd);
+  size_t generateTernaryNode(charstring NodeType, const Node* Nd);
+  size_t generateNaryNode(charstring NodeName, const Node* Nd);
+  void generateInt(IntType Value);
+  void generateFormat(ValueFormat Format);
+  void generateLocal(size_t Index);
+  void generateLocalVar(std::string NodeType, size_t Index);
+  void generateFunctionName(size_t Index);
+  void generateFunctionCall(size_t Index);
+  void generateFunctionHeader(std::string NodeType, size_t Index);
+  void generateCloseFunctionFooter();
+  void generateFunctionFooter();
+  void generateCreate(charstring NodeType);
+  void generateReturnCreate(charstring NodeType);
+  size_t generateBadLocal();
+};
+
+void CodeGenerator::generateInt(IntType Value) {
+  char Buffer[40];
+  sprintf(Buffer, "%" PRIuMAX "", uintmax_t(Value));
+  Output->puts(Buffer);
+}
+
+void CodeGenerator::generateFormat(ValueFormat Format) {
+  switch (Format) {
+    case ValueFormat::Decimal:
+      Output->puts("ValueFormat::Decimal");
+      break;
+    case ValueFormat::SignedDecimal:
+      Output->puts("ValueFormat::SignedDecimal");
+      break;
+    case ValueFormat::Hexidecimal:
+      Output->puts("ValueFormat::Hexidecimal");
+      break;
+  }
+}
+
+void CodeGenerator::generateHeader() {
   Output->puts(
       "// -*- C++ -*- \n"
       "\n"
@@ -89,16 +171,19 @@ void generateHeader(const char* Filename, std::shared_ptr<RawStream> Output) {
       "// See the License for the specific language governing permissions and\n"
       "// limitations under the License.\n"
       "\n"
-      "// Geneated from: \"");
-  Output->puts(InputFilename);
+      "// Generated from: \"");
+  Output->puts(Filename);
   Output->puts(
       "\"\n"
+      "\n"
+      "#include \"sexp/Ast.h\"\n"
+      "\n"
+      "#include <memory>\n"
       "\n");
 }
 
-void generateEnterNamespaces(std::vector<const char*>& Namespaces,
-                             std::shared_ptr<RawStream> Output) {
-  for (const char* Name : Namespaces) {
+void CodeGenerator::generateEnterNamespaces() {
+  for (charstring Name : Namespaces) {
     Output->puts("namespace ");
     Output->puts(Name);
     Output->puts(
@@ -107,106 +192,343 @@ void generateEnterNamespaces(std::vector<const char*>& Namespaces,
   }
 }
 
-void generateExitNamespaces(std::vector<const char*>& Namespaces,
-                            std::shared_ptr<RawStream> Output) {
-  for (const char* Name : Namespaces) {
+void CodeGenerator::generateExitNamespaces() {
+  for (std::vector<charstring>::reverse_iterator
+           Iter = Namespaces.rbegin(), IterEnd = Namespaces.rend();
+       Iter != IterEnd; ++Iter) {
     Output->puts("}  // end of namespace ");
-    Output->puts(Name);
+    Output->puts(*Iter);
     Output->puts(
         "\n"
         "\n");
   }
 }
 
-void generateArrayAccessorHeader(const char* FunctionName,
-                                 std::shared_ptr<RawStream> Output) {
-  Output->puts("const uint8_t* ");
+void CodeGenerator::generateAlgorithmHeader() {
+  Output->puts("void ");
   Output->puts(FunctionName);
-  Output->puts("()");
+  Output->puts("(std::shared_ptr<filt::SymbolTable> Symtable)");
 }
 
-void generateArraySizeAccessorHeader(const char* FunctionName,
-                                     std::shared_ptr<RawStream> Output) {
-  Output->puts("size_t ");
-  Output->puts(FunctionName);
-  Output->puts("Size()");
+size_t CodeGenerator::generateBadLocal() {
+  size_t Index = NextIndex++;
+  FoundErrors = true;
+  generateLocalVar("Node", Index);
+  Output->puts("nullptr;\n");
+  return Index;
 }
 
-void generateArrayDecl(const char* InputFilename,
-                       std::vector<const char*>& Namespaces,
-                       const char* FunctionName,
-                       std::shared_ptr<ReadCursor> ReadPos,
-                       std::shared_ptr<RawStream> Output) {
-  generateHeader(InputFilename, Output);
-  generateEnterNamespaces(Namespaces, Output);
-  generateArrayAccessorHeader(FunctionName, Output);
-  Output->puts(
-      ";\n"
-      "\n");
-  generateArraySizeAccessorHeader(FunctionName, Output);
-  Output->puts(
-      ";\n"
-      "\n");
-  generateExitNamespaces(Namespaces, Output);
-  Output->freeze();
+void CodeGenerator::generateLocal(size_t Index) {
+  Output->puts(LocalName);
+  generateInt(Index);
 }
 
-void generateArrayImpl(const char* InputFilename,
-                       std::vector<const char*>& Namespaces,
-                       const char* FunctionName,
-                       std::shared_ptr<ReadCursor> ReadPos,
-                       std::shared_ptr<RawStream> Output) {
-  generateHeader(InputFilename, Output);
-  Output->puts(
-      "#include \"utils/Defs.h\"\n"
-      "\n"
-      "namespace {\n"
-      "\n"
-      "const uint8_t ");
-  Output->puts(FunctionName);
-  Output->puts("Array[] = {\n");
-  char Buffer[256];
-  while (!ReadPos->atEof()) {
-    uint8_t Byte = ReadPos->readByte();
-    size_t Address = ReadPos->getCurByteAddress();
-    if (Address > 0 && Address % BYTES_PER_LINE_IN_WASM_DEFAULTS == 0)
-      Output->putc('\n');
-    sprintf(Buffer, " %u", Byte);
-    Output->puts(Buffer);
-    if (!ReadPos->atEof())
-      Output->putc(',');
+void CodeGenerator::generateLocalVar(std::string NodeType, size_t Index) {
+  Output->puts("  ");
+  Output->puts(NodeType.c_str());
+  Output->puts("* ");
+  generateLocal(Index);
+  Output->puts(" = ");
+}
+
+void CodeGenerator::generateFunctionName(size_t Index) {
+  Output->puts(FuncName);
+  generateInt(Index);
+}
+
+void CodeGenerator::generateFunctionCall(size_t Index) {
+  generateFunctionName(Index);
+  Output->puts("(Symtab)");
+}
+
+void CodeGenerator::generateFunctionHeader(std::string NodeType, size_t Index) {
+  Output->puts(NodeType.c_str());
+  Output->puts("* ");
+  generateFunctionName(Index);
+  Output->puts("(SymbolTable* Symtab) {\n");
+}
+
+void CodeGenerator::generateFunctionFooter() {
+  Output->puts("}\n"
+               "\n");
+}
+
+
+void CodeGenerator::generateCloseFunctionFooter() {
+  Output->puts(");\n");
+  generateFunctionFooter();
+}
+
+void CodeGenerator::generateCreate(charstring NodeType) {
+  Output->puts("Symtab->create<");
+  Output->puts(NodeType);
+  Output->puts(">(");
+}
+
+void CodeGenerator::generateReturnCreate(charstring NodeType) {
+  Output->puts("  return ");
+  generateCreate(NodeType);
+}
+
+size_t CodeGenerator::generateSymbol(const SymbolNode* Sym) {
+  size_t Index = NextIndex++;
+  generateFunctionHeader("SymbolNode", Index);
+  Output->puts("  return Symtab->getSymbolDefinition(\"");
+  for (auto& Ch : Sym->getName())
+    Output->putc(Ch);
+  Output->putc('"');
+  generateCloseFunctionFooter();
+  return Index;
+}
+
+size_t CodeGenerator::generateIntegerNode(charstring NodeName,
+                                          const IntegerNode* Nd) {
+  size_t Index = NextIndex++;
+  std::string NodeType(NodeName);
+  NodeType.append("Node");
+  generateFunctionHeader(NodeType, Index);
+  Output->puts("  return Symtab->get");
+  Output->puts(NodeName);
+  Output->puts("Definition(");
+  generateInt(Nd->getValue());
+  Output->puts(", ");
+  generateFormat(Nd->getFormat());
+  generateCloseFunctionFooter();
+  return Index;
+}
+
+size_t CodeGenerator::generateNullaryNode(charstring NodeType, const Node* Nd) {
+  size_t Index = NextIndex++;
+  generateFunctionHeader(NodeType, Index);
+  generateReturnCreate(NodeType);
+  generateCloseFunctionFooter();
+  return Index;
+}
+
+size_t CodeGenerator::generateUnaryNode(charstring NodeType, const Node* Nd) {
+  size_t Index = NextIndex++;
+  assert(Nd->getNumKids() == 1);
+  size_t Kid1 = generateNode(Nd->getKid(0));
+  generateFunctionHeader(NodeType, Index);
+  generateReturnCreate(NodeType);
+  generateFunctionCall(Kid1);
+  generateCloseFunctionFooter();
+  return Index;
+}
+
+size_t CodeGenerator::generateBinaryNode(charstring NodeType, const Node* Nd) {
+  assert(Nd->getNumKids() == 2);
+  size_t Kid1 = generateNode(Nd->getKid(0));
+  size_t Kid2 = generateNode(Nd->getKid(1));
+  size_t Index = NextIndex++;
+  generateFunctionHeader(NodeType, Index);
+  generateReturnCreate(NodeType);
+  generateFunctionCall(Kid1);
+  Output->puts(", ");
+  generateFunctionCall(Kid2);
+  generateCloseFunctionFooter();
+  return Index;
+}
+
+size_t CodeGenerator::generateTernaryNode(charstring NodeType, const Node* Nd) {
+  assert(Nd->getNumKids() == 3);
+  size_t Kid1 = generateNode(Nd->getKid(0));
+  size_t Kid2 = generateNode(Nd->getKid(1));
+  size_t Kid3 = generateNode(Nd->getKid(2));
+  size_t Index = NextIndex++;
+  generateFunctionHeader(NodeType, Index);
+  generateReturnCreate(NodeType);
+  generateFunctionCall(Kid1);
+  Output->puts(", ");
+  generateFunctionCall(Kid2);
+  Output->puts(", ");
+  generateFunctionCall(Kid3);
+  generateCloseFunctionFooter();
+  return Index;
+}
+
+size_t CodeGenerator::generateNaryNode(charstring NodeType, const Node* Nd) {
+  std::vector<size_t> Kids;
+  for (int i = 0; i < Nd->getNumKids(); ++i)
+    Kids.push_back(generateNode(Nd->getKid(i)));
+  size_t Index = NextIndex++;
+  generateFunctionHeader(NodeType, Index);
+  generateLocalVar(NodeType, Index);
+  generateCreate(NodeType);
+  Output->puts(");\n");
+  for (size_t KidIndex : Kids) {
+    Output->puts("  ");
+    generateLocal(Index);
+    Output->puts("->append(");
+    generateFunctionCall(KidIndex);
+    Output->puts(");\n");
   }
-  Output->puts(
-      "};\n"
-      "\n"
-      "}  // end of anonymous namespace\n"
-      "\n");
-  generateEnterNamespaces(Namespaces, Output);
-  generateArrayAccessorHeader(FunctionName, Output);
-  Output->puts(" { return ");
-  Output->puts(FunctionName);
-  Output->puts(
-      "Array; }\n"
-      "\n");
-  generateArraySizeAccessorHeader(FunctionName, Output);
-  Output->puts(" { return size(");
-  Output->puts(FunctionName);
-  Output->puts(
-      "Array); }\n"
-      "\n");
-  generateExitNamespaces(Namespaces, Output);
-  Output->freeze();
+  Output->puts("  return ");
+  generateLocal(Index);
+  Output->puts(";\n");
+  generateFunctionFooter();
+  return Index;
+}
+
+size_t CodeGenerator::generateNode(const Node* Nd) {
+  if (Nd == nullptr)
+    return generateBadLocal();
+
+  switch (Nd->getType()) {
+    default:
+      return generateBadLocal();
+    case OpAnd:
+      return generateBinaryNode("AndNode", Nd);
+    case OpBitwiseAnd:
+      return generateBinaryNode("BitwiseAndNode", Nd);
+    case OpBitwiseNegate:
+      return generateUnaryNode("BitwiseNegateNode", Nd);
+    case OpBitwiseOr:
+      return generateBinaryNode("BitwiseOrNode", Nd);
+    case OpBitwiseXor:
+      return generateBinaryNode("BitwiseXorNode", Nd);
+    case OpBlock:
+      return generateUnaryNode("BlockNode", Nd);
+    case OpCallback:
+      return generateUnaryNode("CallbackNode", Nd);
+    case OpCase:
+      return generateBinaryNode("CaseNode", Nd);
+    case OpConvert:
+      return generateTernaryNode("ConvertNode", Nd);
+    case OpDefine:
+      return generateNaryNode("DefineNode", Nd);
+    case OpError:
+      return generateNullaryNode("ErrorNode", Nd);
+    case OpEval:
+      return generateNaryNode("EvalNode", Nd);
+    case OpFile:
+      return generateTernaryNode("FileNode", Nd);
+    case OpFileHeader:
+      return generateNaryNode("FileHeaderNode", Nd);
+    case OpFilter:
+      return generateNaryNode("FilterNode", Nd);
+    case OpIfThen:
+      return generateBinaryNode("IfThenNode", Nd);
+    case OpIfThenElse:
+      return generateTernaryNode("IfThenElseNode", Nd);
+    case OpI32Const:
+      return generateIntegerNode("I32Const", cast<I32ConstNode>(Nd));
+    case OpI64Const:
+      return generateIntegerNode("I64Const", cast<I64ConstNode>(Nd));
+    case OpLastRead:
+      return generateNullaryNode("LastReadNode", Nd);
+    case OpLastSymbolIs:
+      return generateUnaryNode("LastSymbolIsNode", Nd);
+    case OpLiteralDef:
+      return generateBinaryNode("LiteralDefNode", Nd);
+    case OpLiteralUse:
+      return generateUnaryNode("LiteralUseNode", Nd);
+    case OpLocal:
+      return generateIntegerNode("Local", cast<LocalNode>(Nd));
+    case OpLocals:
+      return generateIntegerNode("Locals", cast<LocalNode>(Nd));
+    case OpLoop:
+      return generateBinaryNode("LoopNode", Nd);
+    case OpLoopUnbounded:
+      return generateUnaryNode("LoopUnboundedNode", Nd);
+    case OpMap:
+      return generateNaryNode("MapNode", Nd);
+    case OpNot:
+      return generateUnaryNode("NotNode", Nd);
+    case OpOpcode:
+      return generateNaryNode("OpcodeNode", Nd);
+    case OpOr:
+      return generateBinaryNode("OrNode", Nd);
+    case OpParam:
+      return generateIntegerNode("Param", cast<ParamsNode>(Nd));
+    case OpParams:
+      return generateIntegerNode("Params", cast<ParamsNode>(Nd));
+    case OpPeek:
+      return generateUnaryNode("PeekNode", Nd);
+    case OpRead:
+      return generateUnaryNode("ReadNode", Nd);
+    case OpRename:
+      return  generateBinaryNode("RenameNode", Nd);
+    case OpSection:
+      return generateNaryNode("SectionNode", Nd);
+    case OpSequence:
+      return generateNaryNode("SequenceNode", Nd);
+    case OpSet:
+      return generateBinaryNode("SetNode", Nd);
+    case OpStream:
+      return generateBinaryNode("StreamNode", Nd);
+    case OpSymbol:
+      return generateSymbol(cast<SymbolNode>(Nd));
+    case OpSwitch:
+      return generateNaryNode("SwitchNode", Nd);
+    case OpUint8:
+      return generateIntegerNode("Uint8", cast<Uint8Node>(Nd));
+    case OpUint32:
+      return generateIntegerNode("Uint32", cast<Uint32Node>(Nd));
+    case OpUint64:
+      return generateIntegerNode("Uint64", cast<Uint64Node>(Nd));
+    case OpUndefine:
+      return generateUnaryNode("UndefineNode", Nd);
+    case OpU8Const:
+      return generateIntegerNode("U8Const", cast<U8ConstNode>(Nd));
+    case OpU32Const:
+      return generateIntegerNode("U32Const", cast<U32ConstNode>(Nd));
+    case OpU64Const:
+      return generateIntegerNode("U64Const", cast<U64ConstNode>(Nd));
+    case OpVarint32:
+      return generateIntegerNode("Varint32", cast<Varint32Node>(Nd));
+    case OpVarint64:
+      return generateIntegerNode("Varint64", cast<Varint64Node>(Nd));
+    case OpVaruint32:
+      return generateIntegerNode("Varuint32", cast<Varuint32Node>(Nd));
+    case OpVaruint64:
+      return generateIntegerNode("Varuint64", cast<Varuint64Node>(Nd));
+    case OpVoid:
+      return generateNullaryNode("VoidNode", Nd);
+    case OpWrite:
+      return generateNaryNode("WriteNode", Nd);
+  }
+  WASM_RETURN_UNREACHABLE(0);
+}
+
+bool CodeGenerator::generateDeclFile() {
+  generateHeader();
+  generateEnterNamespaces();
+  generateAlgorithmHeader();
+  Output->puts(";\n\n");
+  generateExitNamespaces();
+  return FoundErrors;
+}
+
+bool CodeGenerator::generateImplFile() {
+  generateHeader();
+  generateEnterNamespaces();
+  Output->puts("using namespace wasm::filt;\n"
+               "\n"
+               "namespace {\n"
+               "\n");
+  size_t Index = generateNode(Symtab->getInstalledRoot());
+  Output->puts("}  // end of anonymous namespace\n"
+               "\n");
+  generateAlgorithmHeader();
+  Output->puts(" {\n"
+               "  SymbolTable* Symtab = Symtable.get();\n"
+               "  Symtab->install(");
+  generateFunctionCall(Index);
+  generateCloseFunctionFooter();
+  generateExitNamespaces();
+  return FoundErrors;
 }
 
 }  // end of anonymous namespace
 
-int main(int Argc, const char* Argv[]) {
+int main(int Argc, charstring Argv[]) {
   bool MinimizeBlockSize = false;
   bool Verbose = false;
   bool TraceFlatten = false;
   bool TraceWrite = false;
   bool TraceTree = false;
-  const char* FunctionName = nullptr;
+  charstring FunctionName = nullptr;
   bool HeaderFile;
   {
     ArgsParser Args("Converts compression algorithm from text to binary");
@@ -335,13 +657,10 @@ int main(int Argc, const char* Argv[]) {
   if (Verbose)
     fprintf(stderr, "Writing file: %s\n", OutputFilename);
   std::shared_ptr<decode::Queue> OutputStream;
-  std::shared_ptr<ReadCursor> ReadPos;
   if (FunctionName == nullptr)
     OutputStream = std::make_shared<WriteBackedQueue>(Output);
-  else {
+  else
     OutputStream = std::make_shared<Queue>();
-    ReadPos = std::make_shared<ReadCursor>(StreamType::Byte, OutputStream);
-  }
   std::shared_ptr<Writer> Writer = std::make_shared<StreamWriter>(OutputStream);
   if (TraceTree) {
     auto Tee = std::make_shared<TeeWriter>();
@@ -368,15 +687,15 @@ int main(int Argc, const char* Argv[]) {
     return exit_status(EXIT_FAILURE);
   }
   if (FunctionName != nullptr) {
-    std::vector<const char*> Namespaces;
+    std::vector<charstring> Namespaces;
     Namespaces.push_back("wasm");
     Namespaces.push_back("decode");
-    if (HeaderFile)
-      generateArrayDecl(InputFilename, Namespaces, FunctionName, ReadPos,
-                        Output);
-    else
-      generateArrayImpl(InputFilename, Namespaces, FunctionName, ReadPos,
-                        Output);
+    CodeGenerator Generator(InputFilename, Output, InputSymtab, Namespaces,
+                            FunctionName);
+    if (HeaderFile ? Generator.generateDeclFile() : Generator.generateImplFile()) {
+      fprintf(stderr, "Unable to generate valid C++ source!");
+      return exit_status(EXIT_FAILURE);
+    }
   }
   return exit_status(EXIT_SUCCESS);
 }

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -62,107 +62,104 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser Args("Compress integer sequences in a WASM file");
 
     ArgsParser::Required<charstring> InputFilenameFlag(InputFilename);
-    Args.add(InputFilenameFlag
-             .setOptionName("INPUT")
-             .setDescription("WASM file to compress"));
+    Args.add(InputFilenameFlag.setOptionName("INPUT")
+                 .setDescription("WASM file to compress"));
 
     ArgsParser::Optional<charstring> OutputFilenameFlag(OutputFilename);
-    Args.add(OutputFilenameFlag
-             .setShortName('o')
-             .setLongName("output")
-             .setOptionName("OUTPUT")
-             .setDescription("Place to put resulting compressed WASM binary"));
+    Args.add(
+        OutputFilenameFlag.setShortName('o')
+            .setLongName("output")
+            .setOptionName("OUTPUT")
+            .setDescription("Place to put resulting compressed WASM binary"));
 
     ArgsParser::Optional<charstring> AlgorithmFilenameFlag(AlgorithmFilename);
-    Args.add(AlgorithmFilenameFlag
-             .setShortName('a')
-             .setLongName("algorithm")
-             .setOptionName("ALGORITHM")
-             .setDescription("File containing algorithm to parse WASM file "
-                             "(rather than using builting algorithm)"));
+    Args.add(AlgorithmFilenameFlag.setShortName('a')
+                 .setLongName("algorithm")
+                 .setOptionName("ALGORITHM")
+                 .setDescription(
+                     "File containing algorithm to parse WASM file "
+                     "(rather than using builting algorithm)"));
 
     ArgsParser::Optional<size_t> CountCutoffFlag(CompressionFlags.CountCutoff);
-    Args.add(CountCutoffFlag
-             .setDefault(10)
-             .setLongName("min-int-count")
-             .setOptionName("INTEGER")
-             .setDescription("Minimum number of times an integer must appear "
-                             "to be considered for compression"));
+    Args.add(CountCutoffFlag.setDefault(10)
+                 .setLongName("min-int-count")
+                 .setOptionName("INTEGER")
+                 .setDescription(
+                     "Minimum number of times an integer must appear "
+                     "to be considered for compression"));
 
-    ArgsParser::Optional<size_t>
-        WeightCutoffFlag(CompressionFlags.WeightCutoff);
-    Args.add(WeightCutoffFlag
-             .setDefault(100)
-             .setLongName("min-weight")
-             .setOptionName("INTEGER")
-             .setDescription("Minimum number of integers (single and/or "
-                             "sequences) that are needed to be considered a "
-                             "compression pattern"));
+    ArgsParser::Optional<size_t> WeightCutoffFlag(
+        CompressionFlags.WeightCutoff);
+    Args.add(WeightCutoffFlag.setDefault(100)
+                 .setLongName("min-weight")
+                 .setOptionName("INTEGER")
+                 .setDescription(
+                     "Minimum number of integers (single and/or "
+                     "sequences) that are needed to be considered a "
+                     "compression pattern"));
 
     ArgsParser::Optional<size_t> LengthLimitFlag(CompressionFlags.LengthLimit);
-    Args.add(LengthLimitFlag
-             .setDefault(5)
-             .setLongName("max-length")
-             .setOptionName("INTEGER")
-             .setDescription("Maximum integer sequence length that will be "
-                             "considered for compression patterns ("
-                             "execution time grows non-linearly when this value "
-                             " is increased)"));
+    Args.add(LengthLimitFlag.setDefault(5)
+                 .setLongName("max-length")
+                 .setOptionName("INTEGER")
+                 .setDescription(
+                     "Maximum integer sequence length that will be "
+                     "considered for compression patterns ("
+                     "execution time grows non-linearly when this value "
+                     " is increased)"));
 
     ArgsParser::Toggle VerboseFlag(Verbose);
-    Args.add(VerboseFlag
-             .setShortName('v')
-             .setLongName("verbose")
-             .setDescription("Show progress of compression"));
+    Args.add(VerboseFlag.setShortName('v')
+                 .setLongName("verbose")
+                 .setDescription("Show progress of compression"));
 
-    ArgsParser::Optional<bool>
-        TraceReadingInputFlag(CompressionFlags.TraceReadingInput);
-    Args.add(TraceReadingInputFlag
-             .setLongName("verbose=read")
-             .setDescription("Show trace of initial read of the WASM file"));
+    ArgsParser::Optional<bool> TraceReadingInputFlag(
+        CompressionFlags.TraceReadingInput);
+    Args.add(
+        TraceReadingInputFlag.setLongName("verbose=read")
+            .setDescription("Show trace of initial read of the WASM file"));
 
-    ArgsParser::Optional<bool>
-        TraceReadingIntStreamFlag(CompressionFlags.TraceReadingIntStream);
-    Args.add(TraceReadingIntStreamFlag
-             .setLongName("verbose=reread")
-             .setDescription("Show trace of subsequent reads of the integer "
-                             "stream produced by the intial read"));
+    ArgsParser::Optional<bool> TraceReadingIntStreamFlag(
+        CompressionFlags.TraceReadingIntStream);
+    Args.add(TraceReadingIntStreamFlag.setLongName("verbose=reread")
+                 .setDescription(
+                     "Show trace of subsequent reads of the integer "
+                     "stream produced by the intial read"));
 
-    ArgsParser::Optional<bool>
-        TraceWritingCodeOutputFlag(CompressionFlags.TraceWritingCodeOutput);
-    Args.add(TraceWritingCodeOutputFlag
-             .setLongName("verbose=code")
-             .setDescription("Show trace of generated compression algorithm"));
+    ArgsParser::Optional<bool> TraceWritingCodeOutputFlag(
+        CompressionFlags.TraceWritingCodeOutput);
+    Args.add(
+        TraceWritingCodeOutputFlag.setLongName("verbose=code")
+            .setDescription("Show trace of generated compression algorithm"));
 
-    ArgsParser::Optional<bool>
-        TraceCodeGenerationForReadingFlag(
-            CompressionFlags.TraceCodeGenerationForReading);
-    Args.add(TraceCodeGenerationForReadingFlag
-             .setLongName("verbose=read-code")
-             .setDescription("Show trace of generating code to compress the "
-                             "integer stream produced by the initial read, to "
-                             "the corresponding compressed integer stream"));
+    ArgsParser::Optional<bool> TraceCodeGenerationForReadingFlag(
+        CompressionFlags.TraceCodeGenerationForReading);
+    Args.add(TraceCodeGenerationForReadingFlag.setLongName("verbose=read-code")
+                 .setDescription(
+                     "Show trace of generating code to compress the "
+                     "integer stream produced by the initial read, to "
+                     "the corresponding compressed integer stream"));
 
     ArgsParser::Optional<bool> TraceCodeGenerationForWritingFlag(
         CompressionFlags.TraceCodeGenerationForWriting);
-    Args.add(TraceCodeGenerationForWritingFlag
-             .setLongName("verbose=write-code")
-             .setDescription("Show trace of generating code to write out the "
-                             "generated compressed integer stream"));
+    Args.add(TraceCodeGenerationForWritingFlag.setLongName("verbose=write-code")
+                 .setDescription(
+                     "Show trace of generating code to write out the "
+                     "generated compressed integer stream"));
 
-    ArgsParser::Optional<bool>
-        TraceWritingDataOutputFlag(CompressionFlags.TraceWritingDataOutput);
-    Args.add(TraceWritingDataOutputFlag
-             .setLongName("verbose=data")
-             .setDescription("Show trace of how data is compressed in the "
-                             "output file"));
+    ArgsParser::Optional<bool> TraceWritingDataOutputFlag(
+        CompressionFlags.TraceWritingDataOutput);
+    Args.add(TraceWritingDataOutputFlag.setLongName("verbose=data")
+                 .setDescription(
+                     "Show trace of how data is compressed in the "
+                     "output file"));
 
-    ArgsParser::Optional<bool>
-        TraceCompressionFlag(CompressionFlags.TraceCompression);
-    Args.add(TraceCompressionFlag
-             .setLongName("verbose=compress")
-             .setDescription("Show details on how patterns are detected for "
-                             "compressing the (input) integer sequence"));
+    ArgsParser::Optional<bool> TraceCompressionFlag(
+        CompressionFlags.TraceCompression);
+    Args.add(TraceCompressionFlag.setLongName("verbose=compress")
+                 .setDescription(
+                     "Show details on how patterns are detected for "
+                     "compressing the (input) integer sequence"));
 
     switch (Args.parse(Argc, Argv)) {
       case ArgsParser::State::Good:
@@ -183,9 +180,8 @@ int main(int Argc, const char* Argv[]) {
   IntCompressor Compressor(std::make_shared<ReadBackedQueue>(getInput()),
                            std::make_shared<WriteBackedQueue>(getOutput()),
                            Symtab, CompressionFlags);
-  Compressor.compress(Verbose
-                      ? IntCompressor::DetailLevel::SomeDetail
-                      : IntCompressor::DetailLevel::NoDetail);
+  Compressor.compress(Verbose ? IntCompressor::DetailLevel::SomeDetail
+                              : IntCompressor::DetailLevel::NoDetail);
   if (Compressor.errorsFound()) {
     fatal("Failed to compress due to errors!");
     exit_status(EXIT_FAILURE);

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -41,7 +41,7 @@ charstring OutputFilename = "-";
 
 std::shared_ptr<RawStream> getInput() {
   if (InputFilename == std::string("-")) {
-    return std::make_shared<FdReader>(STDIN_FILENO, false);
+    return std::make_shared<FileReader>(stdin, false);
   }
   return std::make_shared<FileReader>(InputFilename);
 }

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -80,7 +80,8 @@ int main(int Argc, const char* Argv[]) {
                      "File containing algorithm to parse WASM file "
                      "(rather than using builting algorithm)"));
 
-    ArgsParser::Optional<size_t> CountCutoffFlag(CompressionFlags.CountCutoff);
+    ArgsParser::Optional<uint64_t> CountCutoffFlag(
+        CompressionFlags.CountCutoff);
     Args.add(CountCutoffFlag.setDefault(10)
                  .setLongName("min-int-count")
                  .setOptionName("INTEGER")
@@ -88,7 +89,7 @@ int main(int Argc, const char* Argv[]) {
                      "Minimum number of times an integer must appear "
                      "to be considered for compression"));
 
-    ArgsParser::Optional<size_t> WeightCutoffFlag(
+    ArgsParser::Optional<uint64_t> WeightCutoffFlag(
         CompressionFlags.WeightCutoff);
     Args.add(WeightCutoffFlag.setDefault(100)
                  .setLongName("min-weight")

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -24,6 +24,7 @@
 #include "stream/ReadBackedQueue.h"
 #include "stream/WriteBackedQueue.h"
 #include "utils/ArgsParse.h"
+
 #include "utils/Defs.h"
 
 #include <cstring>
@@ -33,6 +34,7 @@ using namespace wasm;
 using namespace wasm::decode;
 using namespace wasm::filt;
 using namespace wasm::intcomp;
+using namespace wasm::utils;
 
 charstring InputFilename = "-";
 charstring OutputFilename = "-";
@@ -46,69 +48,14 @@ std::shared_ptr<RawStream> getInput() {
 
 std::shared_ptr<RawStream> getOutput() {
   if (OutputFilename == std::string("-")) {
-    return std::make_shared<FdWriter>(STDOUT_FILENO, false);
+    return std::make_shared<FileWriter>(stdout, false);
   }
   return std::make_shared<FileWriter>(OutputFilename);
 }
 
-#if 0
-void usage(const char* AppName) {
-  fprintf(stderr, "usage: %s [options]\n", AppName);
-  fprintf(stderr, "\n");
-  fprintf(stderr, "  Compress integer sequences in a WASM binary file.\n");
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Options:\n");
-  fprintf(stderr,
-          "  -c N\t\t\tOnly compress sequences with count usage >= N.\n");
-  fprintf(stderr, "  -d File\t\tFile containing default algorithms.\n");
-  fprintf(stderr, "  --expect-fail\t\tSucceed on failure/fail on success\n");
-  fprintf(stderr, "  -h\t\t\tPrint this usage message.\n");
-  fprintf(stderr, "  -i File\t\tFile to decompress ('-' implies stdin).\n");
-  fprintf(stderr, "  -l N\t\t\tOnly compress integer sequences <= N.\n");
-  fprintf(stderr, "  -m\t\t\tMinimize block sizes in output stream.\n");
-  fprintf(stderr,
-          "  -o File\t\tGenerated Decompressed File ('-' implies stdout).\n");
-  fprintf(stderr, "  -p\t\t\tDon't install predefined decompression rules.\n");
-  fprintf(stderr,
-          "  -w N\t\t\tOnly compress integer with weight usage >= N.\n");
-  if (isDebug()) {
-    fprintf(stderr,
-            "  -v | --verbose\t"
-            "Show progress (can be repeated for more detail).\n");
-    fprintf(stderr,
-            "\t\t\t-v\n"
-            "\t\t\t\tAdd progress of compression.\n");
-    fprintf(stderr,
-            "\t\t\t-v -v\n"
-            "\t\t\t\tAdd detailed progress of compression.\n");
-    fprintf(stderr,
-            "\t\t\t-v -v -v\n"
-            "\t\t\t\tAdd showing internal integer streams.\n");
-    fprintf(stderr,
-            "\t\t\t-v -v -v -v\n"
-            "\t\t\t\tAdd trace of initial parsing of (wasm) input file.\n");
-    fprintf(stderr,
-            "\t\t\t-v -v -v -v -v\n"
-            "\t\t\t\tAdd trace of subsequent parses of (wasm) input file.\n");
-    fprintf(stderr,
-            "\t\t\t-v -v -v -v -v -v\n"
-            "\t\t\t\tAdd progress of parsing default files.\n");
-    fprintf(stderr,
-            "\t\t\t-v -v -v -v -v -v -v\n"
-            "\t\t\t\tAdd progress of lexing default files.\n");
-  }
-}
-#endif
-
-int main(int Argc, char* Argv[]) {
+int main(int Argc, const char* Argv[]) {
   charstring AlgorithmFilename = nullptr;
   bool Verbose = false;
-#if 0
-  unsigned Verbose = 0;
-  bool MinimizeBlockSize = false;
-  bool InstallPredefinedRules = true;
-  std::vector<int> DefaultIndices;
-#endif
   IntCompressor::Flags CompressionFlags;
 
   {
@@ -120,13 +67,13 @@ int main(int Argc, char* Argv[]) {
              .setDescription("WASM file to compress"));
 
     ArgsParser::Optional<charstring> OutputFilenameFlag(OutputFilename);
-    Args.add(OutputFilename
+    Args.add(OutputFilenameFlag
              .setShortName('o')
              .setLongName("output")
              .setOptionName("OUTPUT")
              .setDescription("Place to put resulting compressed WASM binary"));
 
-    ArgsParser::Optional<charstring> AlgorithmFilenameFlag(AlgorithmFile);
+    ArgsParser::Optional<charstring> AlgorithmFilenameFlag(AlgorithmFilename);
     Args.add(AlgorithmFilenameFlag
              .setShortName('a')
              .setLongName("algorithm")
@@ -137,10 +84,10 @@ int main(int Argc, char* Argv[]) {
     ArgsParser::Optional<size_t> CountCutoffFlag(CompressionFlags.CountCutoff);
     Args.add(CountCutoffFlag
              .setDefault(10)
-             .setLongName('min-int-count')
+             .setLongName("min-int-count")
              .setOptionName("INTEGER")
-             .setDescription("Minimum number of times an integer must appear to "
-                             "be considered for compression"));
+             .setDescription("Minimum number of times an integer must appear "
+                             "to be considered for compression"));
 
     ArgsParser::Optional<size_t>
         WeightCutoffFlag(CompressionFlags.WeightCutoff);
@@ -152,7 +99,7 @@ int main(int Argc, char* Argv[]) {
                              "sequences) that are needed to be considered a "
                              "compression pattern"));
 
-    ArgsParser::Optional<size_t> LenghtLimitfFlag(CompressionFlags.LengthLimit);
+    ArgsParser::Optional<size_t> LengthLimitFlag(CompressionFlags.LengthLimit);
     Args.add(LengthLimitFlag
              .setDefault(5)
              .setLongName("max-length")
@@ -165,47 +112,53 @@ int main(int Argc, char* Argv[]) {
     ArgsParser::Toggle VerboseFlag(Verbose);
     Args.add(VerboseFlag
              .setShortName('v')
-             .setLongName("verbose");
+             .setLongName("verbose")
              .setDescription("Show progress of compression"));
 
-    ArgsParser::Optional<bool> TracedReadingInputFlag(MyFlags.TraceReadingInput);
+    ArgsParser::Optional<bool>
+        TraceReadingInputFlag(CompressionFlags.TraceReadingInput);
     Args.add(TraceReadingInputFlag
              .setLongName("verbose=read")
              .setDescription("Show trace of initial read of the WASM file"));
 
-    ArgsParser::Optional<bool> TraceReadingIntStreamFlag(MyFlags.TraceReadingIntStream);
+    ArgsParser::Optional<bool>
+        TraceReadingIntStreamFlag(CompressionFlags.TraceReadingIntStream);
     Args.add(TraceReadingIntStreamFlag
              .setLongName("verbose=reread")
              .setDescription("Show trace of subsequent reads of the integer "
                              "stream produced by the intial read"));
 
-    ArgsParser::Optional<bool> TraceWritingCodeOutputFlag(MyFlags.TracewritingCodeOutput);
+    ArgsParser::Optional<bool>
+        TraceWritingCodeOutputFlag(CompressionFlags.TraceWritingCodeOutput);
     Args.add(TraceWritingCodeOutputFlag
              .setLongName("verbose=code")
              .setDescription("Show trace of generated compression algorithm"));
 
-    ArgsParser::Optional<bool> TraceCodeGenerationForReadingFlag(
-        MyFlags.TraceCodeGenerationForReading);
-    Args.add(TraceCodeGenerationForReading
+    ArgsParser::Optional<bool>
+        TraceCodeGenerationForReadingFlag(
+            CompressionFlags.TraceCodeGenerationForReading);
+    Args.add(TraceCodeGenerationForReadingFlag
              .setLongName("verbose=read-code")
              .setDescription("Show trace of generating code to compress the "
                              "integer stream produced by the initial read, to "
                              "the corresponding compressed integer stream"));
 
     ArgsParser::Optional<bool> TraceCodeGenerationForWritingFlag(
-        MyFlags.TraceCodeGenerationForWriting);
-    Args.add(TraceCodeGenerationForWriting
+        CompressionFlags.TraceCodeGenerationForWriting);
+    Args.add(TraceCodeGenerationForWritingFlag
              .setLongName("verbose=write-code")
              .setDescription("Show trace of generating code to write out the "
                              "generated compressed integer stream"));
 
-    ArgsParser::Optional<bool> TraceWritingDataOutputFlag(MyFlags.TraceWritingDataOutput);
+    ArgsParser::Optional<bool>
+        TraceWritingDataOutputFlag(CompressionFlags.TraceWritingDataOutput);
     Args.add(TraceWritingDataOutputFlag
              .setLongName("verbose=data")
              .setDescription("Show trace of how data is compressed in the "
                              "output file"));
 
-    ArgsParser::Optional<bool> TraceCompressionFlag(MyFlags.TraceCompression);
+    ArgsParser::Optional<bool>
+        TraceCompressionFlag(CompressionFlags.TraceCompression);
     Args.add(TraceCompressionFlag
              .setLongName("verbose=compress")
              .setDescription("Show details on how patterns are detected for "
@@ -221,148 +174,18 @@ int main(int Argc, char* Argv[]) {
         return exit_status(EXIT_FAILURE);
     }
   }
-#if 0
-  size_t CountCutoff = 10;
-  size_t WeightCutoff = 100;
-  size_t LengthLimit = 5;
-  for (int i = 1; i < Argc; ++i) {
-    std::string Arg(Argv[i]);
-    if (Arg == "-c") {
-      if (++i >= Argc) {
-        fprintf(stderr, "No count N specified after -c option\n");
-        usage(Argv[0]);
-        return exit_status(EXIT_FAILURE);
-      }
-      CountCutoff = atol(Argv[i]);
-    } else if (Arg == "-w") {
-      if (++i >= Argc) {
-        fprintf(stderr, "No count N specified after -w option\n");
-        usage(Argv[0]);
-        return exit_status(EXIT_FAILURE);
-      }
-      WeightCutoff = atol(Argv[i]);
-    } else if (Arg == "-l") {
-      if (++i >= Argc) {
-        fprintf(stderr, "No count N specified after -l option\n");
-        usage(Argv[0]);
-        return exit_status(EXIT_FAILURE);
-      }
-      LengthLimit = atol(Argv[i]);
-    } else if (Arg == "-d") {
-      if (++i >= Argc) {
-        fprintf(stderr, "No file specified after -d option\n");
-        usage(Argv[0]);
-        return exit_status(EXIT_FAILURE);
-      }
-      DefaultIndices.push_back(i);
-    } else if (Arg == "--expect-fail") {
-      ExpectExitFail = true;
-    } else if (Arg == "-h" || Arg == "--help") {
-      usage(Argv[0]);
-      return exit_status(EXIT_SUCCESS);
-    } else if (Arg == "-i") {
-      if (++i >= Argc) {
-        fprintf(stderr, "No file specified after -i option\n");
-        usage(Argv[0]);
-        return exit_status(EXIT_FAILURE);
-      }
-      InputFilename = Argv[i];
-    } else if (Arg == "-m") {
-      MinimizeBlockSize = true;
-    } else if (Arg == "-o") {
-      if (++i >= Argc) {
-        fprintf(stderr, "No file specified after -o option\n");
-        usage(Argv[0]);
-        return exit_status(EXIT_FAILURE);
-      }
-      OutputFilename = Argv[i];
-    } else if (Arg == "-p") {
-      InstallPredefinedRules = false;
-    } else if (isDebug() && (Arg == "-v" || Arg == "--verbose")) {
-      ++Verbose;
-    } else {
-      fprintf(stderr, "Unrecognized option: %s\n", Argv[i]);
-      usage(Argv[0]);
-      return exit_status(EXIT_FAILURE);
-    }
-  }
-
-  // Define defaults if only one cutoff provided.
-  if (WeightCutoff == 0)
-    WeightCutoff = CountCutoff;
-  if (CountCutoff == 0)
-    CountCutoff = WeightCutoff;
-
-  // Extract compression detail level from verbose, and adjust, so
-  // that remaining verbose checks need not be changed if detail level
-  // changes.
-  unsigned CompressVerbose = Verbose;
-  constexpr unsigned MaxCompressVerbose = 3;
-  if (Verbose < MaxCompressVerbose)
-    Verbose = 0;
-  else
-    Verbose -= MaxCompressVerbose;
 
   auto Symtab = std::make_shared<SymbolTable>();
-  if (InstallPredefinedRules &&
-      !SymbolTable::installPredefinedDefaults(Symtab, Verbose >= 3)) {
-    fprintf(stderr, "Unable to load compiled in default rules!\n");
-    return exit_status(EXIT_FAILURE);
-  }
-  for (int i : DefaultIndices) {
-    if (Verbose)
-      fprintf(stderr, "Loading default: %s\n", Argv[i]);
-    if (BinaryReader::isBinary(Argv[i])) {
-      std::shared_ptr<RawStream> Stream = std::make_shared<FileReader>(Argv[i]);
-      BinaryReader Reader(std::make_shared<ReadBackedQueue>(std::move(Stream)),
-                          Symtab);
-      Reader.getTrace().setTraceProgress(Verbose >= 3);
-      if (Reader.readFile()) {
-        continue;
-      }
-    }
-    Driver Parser(Symtab);
-    Parser.setTraceParsing(Verbose >= 3);
-    Parser.setTraceLexing(Verbose >= 4);
-    ;
-    if (!Parser.parse(Argv[i])) {
-      fprintf(stderr, "Unable to parse default algorithms: %s\n", Argv[i]);
-      return exit_status(EXIT_FAILURE);
-    }
-  }
 
-  IntCompressor::DetailLevel DetailLevel;
-  switch (CompressVerbose) {
-    case 0:
-      DetailLevel = IntCompressor::NoDetail;
-      break;
-    case 1:
-      DetailLevel = IntCompressor::SomeDetail;
-      break;
-    case 2:
-      DetailLevel = IntCompressor::MoreDetail;
-      break;
-    default:
-      DetailLevel = IntCompressor::AllDetail;
-      break;
-  }
-#endif
-
-  auto Symtab = std::make_shared<SymbolTable>();
-  if (AlgorithmFilename == nullptr) {
-
-  } else {
-  }
+  // TODO(karlschimpf) Fill in code here to get default algorithm if not
+  // explicitly defined.
 
   IntCompressor Compressor(std::make_shared<ReadBackedQueue>(getInput()),
                            std::make_shared<WriteBackedQueue>(getOutput()),
-                           Symtab);
-  Compressor.setLengthLimit(LengthLimit);
-  Compressor.setCountCutoff(CountCutoff);
-  Compressor.setWeightCutoff(WeightCutoff);
-  Compressor.setTraceProgress(CompressVerbose);
-  Compressor.setMinimizeBlockSize(MinimizeBlockSize);
-  Compressor.compress(DetailLevel, Verbose >= 1, Verbose <= 2);
+                           Symtab, CompressionFlags);
+  Compressor.compress(Verbose
+                      ? IntCompressor::DetailLevel::SomeDetail
+                      : IntCompressor::DetailLevel::NoDetail);
   if (Compressor.errorsFound()) {
     fatal("Failed to compress due to errors!");
     exit_status(EXIT_FAILURE);

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -44,7 +44,7 @@ const char* OutputFilename = "-";
 std::shared_ptr<RawStream> getInput() {
   if (InputFilename == std::string("-")) {
     if (UseFileStreams)
-      return std::make_shared<FdReader>(STDIN_FILENO, false);
+      return std::make_shared<FileReader>(stdin, false);
     return std::make_shared<decode::StreamReader>(std::cin);
   }
   if (UseFileStreams)

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "algorithms/wasm0xd.h"
 #include "binary/BinaryReader.h"
 #include "interp/Decompress.h"
 #include "interp/Interpreter.h"
@@ -54,7 +55,7 @@ std::shared_ptr<RawStream> getInput() {
 std::shared_ptr<RawStream> getOutput() {
   if (OutputFilename == std::string("-")) {
     if (UseFileStreams)
-      return std::make_shared<FdWriter>(STDOUT_FILENO, false);
+      return std::make_shared<FileWriter>(stdout, false);
     return std::make_shared<decode::StreamWriter>(std::cout);
   }
   if (UseFileStreams)
@@ -222,11 +223,8 @@ int main(int Argc, char* Argv[]) {
   }
   auto Symtab = std::make_shared<SymbolTable>();
   Symtab->getTrace().setTraceProgress(Verbose >= 4);
-  if (InstallPredefinedRules &&
-      !SymbolTable::installPredefinedDefaults(Symtab, Verbose >= 2)) {
-    fprintf(stderr, "Unable to load compiled in default rules!\n");
-    return exit_status(EXIT_FAILURE);
-  }
+  if (InstallPredefinedRules)
+    install_Algwasm0xd(Symtab);
   for (int i : DefaultIndices) {
     if (Verbose)
       fprintf(stderr, "Loading default: %s\n", Argv[i]);

--- a/src/exec/decompsexp-wasm.cpp
+++ b/src/exec/decompsexp-wasm.cpp
@@ -44,7 +44,7 @@ const char* OutputFilename = "-";
 std::shared_ptr<RawStream> getOutput() {
   if (OutputFilename == std::string("-")) {
     if (UseFileStreams)
-      return std::make_shared<FdWriter>(STDOUT_FILENO, false);
+      return std::make_shared<FileWriter>(stderr, false);
     return std::make_shared<StreamWriter>(std::cout);
   }
   if (UseFileStreams)

--- a/src/exec/decompwasm-sexp.cpp
+++ b/src/exec/decompwasm-sexp.cpp
@@ -43,7 +43,7 @@ const char* OutputFilename = "-";
 std::shared_ptr<RawStream> getInput() {
   if (InputFilename == std::string("-")) {
     if (UseFileStreams)
-      return std::make_shared<FdReader>(STDIN_FILENO, false);
+      return std::make_shared<FileReader>(stdin, false);
     return std::make_shared<StreamReader>(std::cin);
   }
   if (UseFileStreams)

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -49,8 +49,8 @@ IntCompressor::Flags::Flags()
       TraceCompression(false),
       TraceIntStreamGeneration(false),
       TraceCodeGenerationForReading(false),
-      TraceCodeGenerationForWriting(false)
-{}
+      TraceCodeGenerationForWriting(false) {
+}
 
 IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> Input,
                              std::shared_ptr<decode::Queue> Output,
@@ -229,7 +229,8 @@ bool IntCompressor::generateIntOutput() {
 
 std::shared_ptr<SymbolTable> IntCompressor::generateCode(
     CountNode::PtrVector& Assignments,
-    bool ToRead, bool Trace) {
+    bool ToRead,
+    bool Trace) {
   AbbreviationCodegen Codegen(Root, MyFlags.AbbrevFormat, Assignments);
   std::shared_ptr<SymbolTable> Symtab = Codegen.getCodeSymtab(ToRead);
   if (Trace) {

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -36,27 +36,41 @@ using namespace utils;
 
 namespace intcomp {
 
-IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> Input,
-                             std::shared_ptr<decode::Queue> Output,
-                             std::shared_ptr<filt::SymbolTable> Symtab)
-    : Input(Input),
-      Output(Output),
-      Symtab(Symtab),
-      CountCutoff(0),
+IntCompressor::Flags::Flags()
+    : CountCutoff(0),
       WeightCutoff(0),
       LengthLimit(1),
       AbbrevFormat(IntTypeFormat::Varuint64),
+      MinimizeCodeSize(true),
+      TraceReadingInput(false),
+      TraceReadingIntStream(false),
+      TraceWritingCodeOutput(false),
+      TraceWritingDataOutput(false),
+      TraceCompression(false),
+      TraceIntStreamGeneration(false),
+      TraceCodeGenerationForReading(false),
+      TraceCodeGenerationForWriting(false)
+{}
+
+IntCompressor::IntCompressor(std::shared_ptr<decode::Queue> Input,
+                             std::shared_ptr<decode::Queue> Output,
+                             std::shared_ptr<filt::SymbolTable> Symtab,
+                             Flags& MyFlags)
+    : Input(Input),
+      Output(Output),
+      MyFlags(MyFlags),
+      Symtab(Symtab),
       ErrorsFound(false) {
 }
 
 void IntCompressor::setTrace(std::shared_ptr<TraceClass> NewTrace) {
-  Trace = NewTrace;
+  MyFlags.Trace = NewTrace;
 }
 
 std::shared_ptr<TraceClass> IntCompressor::getTracePtr() {
-  if (!Trace)
+  if (!MyFlags.Trace)
     setTrace(std::make_shared<TraceClass>("IntCompress"));
-  return Trace;
+  return MyFlags.Trace;
 }
 
 CountNode::RootPtr IntCompressor::getRoot() {
@@ -65,16 +79,12 @@ CountNode::RootPtr IntCompressor::getRoot() {
   return Root;
 }
 
-void IntCompressor::readInput(bool TraceParsing) {
+void IntCompressor::readInput() {
   Contents = std::make_shared<IntStream>();
   IntWriter MyWriter(Contents);
   StreamReader MyReader(Input, MyWriter, Symtab);
-  if (TraceParsing) {
-    TraceClass& Trace = MyReader.getTrace();
-    Trace.addContext(MyReader.getTraceContext());
-    Trace.addContext(MyWriter.getTraceContext());
-    Trace.setTraceProgress(true);
-  }
+  if (MyFlags.TraceReadingInput)
+    MyReader.getTrace().setTraceProgress(true);
   MyReader.fastStart();
   MyReader.fastReadBackFilled();
   bool Successful = MyReader.isFinished() && MyReader.isSuccessful();
@@ -85,28 +95,23 @@ void IntCompressor::readInput(bool TraceParsing) {
 }
 
 const WriteCursor IntCompressor::writeCodeOutput(
-    std::shared_ptr<SymbolTable> Symtab,
-    bool Trace) {
+    std::shared_ptr<SymbolTable> Symtab) {
   BinaryWriter Writer(Output, Symtab);
   Writer.setFreezeEofOnDestruct(false);
-  Writer.setTraceProgress(Trace);
-  Writer.setMinimizeBlockSize(true);
+  if (MyFlags.TraceWritingCodeOutput)
+    Writer.getTrace().setTraceProgress(true);
+  Writer.setMinimizeBlockSize(MyFlags.MinimizeCodeSize);
   Writer.write(dyn_cast<FileNode>(Symtab->getInstalledRoot()));
   return Writer.getWritePos();
 }
 
 void IntCompressor::writeDataOutput(const WriteCursor& StartPos,
-                                    std::shared_ptr<SymbolTable> Symtab,
-                                    bool Trace) {
+                                    std::shared_ptr<SymbolTable> Symtab) {
   StreamWriter Writer(Output);
   Writer.setPos(StartPos);
   IntReader Reader(IntOutput, Writer, Symtab);
-  if (Trace) {
-    TraceClass& Trace = Reader.getTrace();
-    Trace.addContext(Reader.getTraceContext());
-    Trace.addContext(Writer.getTraceContext());
-    Trace.setTraceProgress(true);
-  }
+  if (MyFlags.TraceWritingDataOutput)
+    Reader.getTrace().setTraceProgress(true);
   Reader.insertFileVersion(WasmBinaryMagic, WasmBinaryVersionD);
   Reader.algorithmStart();
   Reader.algorithmReadBackFilled();
@@ -119,7 +124,7 @@ void IntCompressor::writeDataOutput(const WriteCursor& StartPos,
 IntCompressor::~IntCompressor() {
 }
 
-bool IntCompressor::compressUpToSize(size_t Size, bool TraceParsing) {
+bool IntCompressor::compressUpToSize(size_t Size) {
   TRACE_BLOCK({
     if (Size == 1)
       TRACE_MESSAGE("Collecting integer sequences of length: 1");
@@ -128,10 +133,10 @@ bool IntCompressor::compressUpToSize(size_t Size, bool TraceParsing) {
                     std::to_string(Size));
   });
   CountWriter Writer(getRoot());
-  Writer.setCountCutoff(CountCutoff);
+  Writer.setCountCutoff(MyFlags.CountCutoff);
   Writer.setUpToSize(Size);
   IntReader Reader(Contents, Writer, Symtab);
-  if (TraceParsing)
+  if (MyFlags.TraceReadingIntStream)
     Reader.getTrace().setTraceProgress(true);
   Reader.fastStart();
   Reader.fastReadBackFilled();
@@ -143,15 +148,13 @@ void IntCompressor::removeSmallUsageCounts() {
   // the trie to (a) recover memory and (b) make remaining analysis
   // faster.  It does this by removing int count nodes that are not
   // not useful (See case RemoveFrame::State::Exit for details).
-  RemoveNodesVisitor Visitor(Root, CountCutoff);
+  RemoveNodesVisitor Visitor(Root, MyFlags.CountCutoff);
   Visitor.walk();
 }
 
-void IntCompressor::compress(DetailLevel Level,
-                             bool TraceParsing,
-                             bool TraceFirstPassOnly) {
+void IntCompressor::compress(DetailLevel Level) {
   TRACE_METHOD("compress");
-  readInput(TraceParsing);
+  readInput();
   if (errorsFound()) {
     fprintf(stderr, "Unable to decompress, input malformed");
     return;
@@ -162,13 +165,13 @@ void IntCompressor::compress(DetailLevel Level,
   // Start by collecting number of occurrences of each integer, so
   // that we can use as a filter on integer sequence inclusion into the
   // trie.
-  if (!compressUpToSize(1, TraceParsing && !TraceFirstPassOnly))
+  if (!compressUpToSize(1))
     return;
   if (Level >= DetailLevel::MoreDetail)
     describe(stderr, makeFlags(CollectionFlag::TopLevel));
   removeSmallUsageCounts();
-  if (LengthLimit > 1) {
-    if (!compressUpToSize(LengthLimit, TraceParsing && !TraceFirstPassOnly))
+  if (MyFlags.LengthLimit > 1) {
+    if (!compressUpToSize(MyFlags.LengthLimit))
       return;
     removeSmallUsageCounts();
   }
@@ -179,7 +182,7 @@ void IntCompressor::compress(DetailLevel Level,
   if (Level >= DetailLevel::MoreDetail)
     describe(stderr, makeFlags(CollectionFlag::All));
   IntOutput = std::make_shared<IntStream>();
-  if (!generateIntOutput(TraceParsing && !TraceFirstPassOnly))
+  if (!generateIntOutput())
     return;
   TRACE(size_t, "Number of integers in compressed output",
         IntOutput->getNumIntegers());
@@ -200,16 +203,18 @@ void IntCompressor::compress(DetailLevel Level,
 
 void IntCompressor::assignInitialAbbreviations(
     CountNode::PtrVector& Assignments) {
-  AbbreviationsCollector Collector(getRoot(), AbbrevFormat, Assignments);
-  Collector.CountCutoff = CountCutoff;
-  Collector.WeightCutoff = WeightCutoff;
+  AbbreviationsCollector Collector(getRoot(), MyFlags.AbbrevFormat,
+                                   Assignments);
+  Collector.CountCutoff = MyFlags.CountCutoff;
+  Collector.WeightCutoff = MyFlags.WeightCutoff;
   Collector.assignAbbreviations();
 }
 
-bool IntCompressor::generateIntOutput(bool TraceParsing) {
-  AbbrevAssignWriter Writer(Root, IntOutput, LengthLimit, AbbrevFormat);
+bool IntCompressor::generateIntOutput() {
+  AbbrevAssignWriter Writer(Root, IntOutput, MyFlags.LengthLimit,
+                            MyFlags.AbbrevFormat);
   IntReader Reader(Contents, Writer, Symtab);
-  if (TraceParsing) {
+  if (MyFlags.TraceIntStreamGeneration) {
     std::shared_ptr<TraceClass> Trace = Writer.getTracePtr();
     Reader.setTrace(Trace);
     Writer.setTrace(Trace);
@@ -224,9 +229,8 @@ bool IntCompressor::generateIntOutput(bool TraceParsing) {
 
 std::shared_ptr<SymbolTable> IntCompressor::generateCode(
     CountNode::PtrVector& Assignments,
-    bool ToRead,
-    bool Trace) {
-  AbbreviationCodegen Codegen(Root, AbbrevFormat, Assignments);
+    bool ToRead, bool Trace) {
+  AbbreviationCodegen Codegen(Root, MyFlags.AbbrevFormat, Assignments);
   std::shared_ptr<SymbolTable> Symtab = Codegen.getCodeSymtab(ToRead);
   if (Trace) {
     TextWriter Writer;
@@ -239,8 +243,8 @@ void IntCompressor::describe(FILE* Out, CollectionFlags Flags) {
   CountNodeCollector Collector(getRoot());
   if (hasTrace())
     Collector.setTrace(getTracePtr());
-  Collector.CountCutoff = CountCutoff;
-  Collector.WeightCutoff = WeightCutoff;
+  Collector.CountCutoff = MyFlags.CountCutoff;
+  Collector.WeightCutoff = MyFlags.WeightCutoff;
   Collector.collect(Flags);
   TRACE_BLOCK({ Collector.describe(getTrace().getFile()); });
 }

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -104,16 +104,17 @@ class IntCompressor FINAL {
   void removeSmallUsageCounts();
   void assignInitialAbbreviations(CountNode::PtrVector& Assignments);
   bool generateIntOutput();
-  std::shared_ptr<filt::SymbolTable> generateCode(
-      CountNode::PtrVector& Assignments,
-      bool ToRead, bool Trace);
+  std::shared_ptr<filt::SymbolTable>
+  generateCode(CountNode::PtrVector& Assignments, bool ToRead, bool Trace);
   std::shared_ptr<filt::SymbolTable> generateCodeForReading(
       CountNode::PtrVector& Assignments) {
-    return generateCode(Assignments, true, MyFlags.TraceCodeGenerationForReading);
+    return generateCode(Assignments, true,
+                        MyFlags.TraceCodeGenerationForReading);
   }
   std::shared_ptr<filt::SymbolTable> generateCodeForWriting(
       CountNode::PtrVector& Assignments) {
-    return generateCode(Assignments, false, MyFlags.TraceCodeGenerationForWriting);
+    return generateCode(Assignments, false,
+                        MyFlags.TraceCodeGenerationForWriting);
   }
 };
 

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -84,17 +84,6 @@ class IntCompressor FINAL {
   std::shared_ptr<utils::TraceClass> getTracePtr();
   bool hasTrace() { return bool(MyFlags.Trace); }
 
-#if 0
-  void setCountCutoff(uint64_t NewCutoff) { CountCutoff = NewCutoff; }
-  void setWeightCutoff(uint64_t NewCutoff) { WeightCutoff = NewCutoff; }
-  void setLengthLimit(size_t NewLimit) { LengthLimit = NewLimit; }
-
-  void setMinimizeBlockSize(bool NewValue) { (void)NewValue; }
-
-  interp::IntTypeFormat getAbbrevFormat() const { return AbbrevFormat; }
-  void setAbbrevFormat(interp::IntTypeFormat Fmt) { AbbrevFormat = Fmt; }
-#endif
-
   void describe(FILE* Out, CollectionFlags = makeFlags(CollectionFlag::All));
 
  private:

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -168,14 +168,11 @@ extern "C" {
 
 void* create_decompressor() {
   auto* Decomp = new Decompressor();
-  bool InstalledDefaults = SymbolTable::installPredefinedDefaults(
-      Decomp->Symtab, Algwasm0xd(), Algwasm0xdSize(), false);
+  install_Algwasm0xd(Decomp->Symtab);
   Decomp->Interp = std::make_shared<Interpreter>(
       Decomp->Input, Decomp->OutputPipe.getInput(), Decomp->Symtab);
   // Decomp->Interp->setTraceProgress(true);
   Decomp->Interp->start();
-  if (!InstalledDefaults)
-    Decomp->Interp->fail("Unable to install decompression rules!");
   return Decomp;
 }
 

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -16,6 +16,7 @@
 
 // Implementation of the C API to the decompressor interpreter.
 
+#include "algorithms/wasm0xd.h"
 #include "interp/Decompress.h"
 #include "interp/Interpreter.h"
 #include "stream/Pipe.h"
@@ -167,8 +168,8 @@ extern "C" {
 
 void* create_decompressor() {
   auto* Decomp = new Decompressor();
-  bool InstalledDefaults =
-      SymbolTable::installPredefinedDefaults(Decomp->Symtab, false);
+  bool InstalledDefaults = SymbolTable::installPredefinedDefaults(
+      Decomp->Symtab, Algwasm0xd(), Algwasm0xdSize(), false);
   Decomp->Interp = std::make_shared<Interpreter>(
       Decomp->Input, Decomp->OutputPipe.getInput(), Decomp->Symtab);
   // Decomp->Interp->setTraceProgress(true);

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -45,11 +45,17 @@ class Driver {
   ~Driver() {}
 
   template <typename T>
-  T* create() { return Table->create<T>(); }
+  T* create() {
+    return Table->create<T>();
+  }
   template <typename T>
-  T* create(Node* Nd) { return Table->create<T>(Nd); }
+  T* create(Node* Nd) {
+    return Table->create<T>(Nd);
+  }
   template <typename T>
-  T* create(Node* Nd1, Node* Nd2) { return Table->create<T>(Nd1, Nd2); }
+  T* create(Node* Nd1, Node* Nd2) {
+    return Table->create<T>(Nd1, Nd2);
+  }
   template <typename T>
   T* create(Node* Nd1, Node* Nd2, Node* Nd3) {
     return Table->create<T>(Nd1, Nd2, Nd3);

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -44,9 +44,19 @@ class Driver {
 
   ~Driver() {}
 
-  template <typename T, typename... Args>
-  T* create(Args&&... args) {
-    return Table->create<T>(std::forward<Args>(args)...);
+  template <typename T>
+  T* create() { return Table->create<T>(); }
+  template <typename T>
+  T* create(Node* Nd) { return Table->create<T>(Nd); }
+  template <typename T>
+  T* create(Node* Nd1, Node* Nd2) { return Table->create<T>(Nd1, Nd2); }
+  template <typename T>
+  T* create(Node* Nd1, Node* Nd2, Node* Nd3) {
+    return Table->create<T>(Nd1, Nd2, Nd3);
+  }
+  StreamNode* getStreamDefinition(decode::StreamKind Kind,
+                                  decode::StreamType Type) {
+    return Table->getStreamDefinition(Kind, Type);
   }
 
 #define X(tag, format, defval, mergable, NODE_DECLS)               \

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -606,7 +606,7 @@ control_flow
 
 stream
         : stream_kind "." stream_type {
-            $$ = Driver.create<StreamNode>($1, $3);
+            $$ = Driver.getStreamDefinition($1, $3);
           }
         ;
 

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -265,6 +265,24 @@ SymbolTable::~SymbolTable() {
   deallocateNodes();
 }
 
+bool SymbolTable::installPredefinedDefaults(std::shared_ptr<SymbolTable> Symtab,
+                                            const uint8_t AlgArray,
+                                            size_t AlgArraySize,
+                                            bool Trace) {
+  std::shared_ptr<ArrayReader> Stream =
+      std::make_shared<ArayReader>(AlgArray, AlgArraySize);
+  if (!Stream)
+    return false;
+  BinaryReader Reader(std::make_shared<ReadBackedQueue>(std::move(Stream)),
+                      Symtab);
+  if (Trace) {
+    TraceClass& Trace = Reader.getTrace();
+    Trace.setTraceProgress(true);
+    TRACE_MESSAGE_USING(Trace,  "Loading predefined decompression rules\n");
+  }
+  return Reader.readFile() != nullptr;
+}
+
 void SymbolTable::setTraceProgress(bool NewValue) {
   if (!NewValue && !Trace)
     return;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -20,7 +20,11 @@
 #include "sexp/Ast.h"
 
 #include "interp/IntFormats.h"
+#include "interp/StreamReader.h"
+#include "sexp/InflateAst.h"
 #include "sexp/TextWriter.h"
+#include "stream/ArrayReader.h"
+#include "stream/ReadBackedQueue.h"
 #include "utils/Defs.h"
 
 #include <algorithm>
@@ -46,6 +50,75 @@ void TraceClass::trace_node_ptr(const char* Name, const Node* Nd) {
 }
 
 namespace filt {
+
+#define X(tag, NODE_DECLS)                      \
+  template<>                                    \
+  tag##Node* SymbolTable::create<tag##Node>() { \
+    tag##Node* tag##Nd = new tag##Node(*this);  \
+    Allocated->push_back(tag##Nd);              \
+    return tag##Nd;                             \
+  }
+AST_NULLARYNODE_TABLE
+#undef X
+
+#define X(tag, NODE_DECLS)                              \
+  template<>                                            \
+  tag##Node* SymbolTable::create<tag##Node>(Node* Nd) { \
+    tag##Node* tag##Nd = new tag##Node(*this, Nd);      \
+    Allocated->push_back(tag##Nd);                      \
+    return tag##Nd;                                     \
+  }
+AST_UNARYNODE_TABLE
+#undef X
+
+#define X(tag, NODE_DECLS)                                          \
+  template<>                                                        \
+  tag##Node* SymbolTable::create<tag##Node>(Node* Nd1, Node* Nd2) { \
+    tag##Node* tag##Nd = new tag##Node(*this, Nd1, Nd2);            \
+    Allocated->push_back(tag##Nd);                                  \
+    return tag##Nd;                                                 \
+  }
+AST_BINARYNODE_TABLE
+#undef X
+
+#define X(tag, NODE_DECLS)                                     \
+  template<>                                                   \
+  tag##Node* SymbolTable::create<tag##Node>(Node* Nd1,         \
+                                            Node* Nd2,         \
+                                            Node* Nd3) {       \
+    tag##Node* tag##Nd = new tag##Node(*this, Nd1, Nd2, Nd3);  \
+    Allocated->push_back(tag##Nd);                             \
+    return tag##Nd;                                            \
+  }
+AST_TERNARYNODE_TABLE
+#undef X
+
+#define X(tag, NODE_DECLS)                      \
+  template<>                                    \
+  tag##Node* SymbolTable::create<tag##Node>() { \
+    tag##Node* tag##Nd = new tag##Node(*this);  \
+    Allocated->push_back(tag##Nd);              \
+    return tag##Nd;                             \
+  }
+AST_NARYNODE_TABLE
+#undef X
+
+#define X(tag, NODE_DECLS)                      \
+  template<>                                    \
+  tag##Node* SymbolTable::create<tag##Node>() { \
+    tag##Node* tag##Nd = new tag##Node(*this);  \
+    Allocated->push_back(tag##Nd);              \
+    return tag##Nd;                             \
+  }
+AST_SELECTNODE_TABLE
+#undef X
+
+template<>
+OpcodeNode* SymbolTable::create<OpcodeNode>() {
+  OpcodeNode* Nd = new OpcodeNode(*this);
+  Allocated->push_back(Nd);
+  return Nd;
+}
 
 namespace {
 
@@ -266,21 +339,26 @@ SymbolTable::~SymbolTable() {
 }
 
 bool SymbolTable::installPredefinedDefaults(std::shared_ptr<SymbolTable> Symtab,
-                                            const uint8_t AlgArray,
+                                            const uint8_t* AlgArray,
                                             size_t AlgArraySize,
-                                            bool Trace) {
+                                            bool TraceInstallation) {
   std::shared_ptr<ArrayReader> Stream =
-      std::make_shared<ArayReader>(AlgArray, AlgArraySize);
+      std::make_shared<ArrayReader>(AlgArray, AlgArraySize);
   if (!Stream)
     return false;
-  BinaryReader Reader(std::make_shared<ReadBackedQueue>(std::move(Stream)),
-                      Symtab);
-  if (Trace) {
-    TraceClass& Trace = Reader.getTrace();
-    Trace.setTraceProgress(true);
-    TRACE_MESSAGE_USING(Trace,  "Loading predefined decompression rules\n");
+  InflateAst Inflator;
+  StreamReader Reader(std::make_shared<ReadBackedQueue>(std::move(Stream)),
+                      Inflator, Symtab);
+  std::shared_ptr<TraceClass> Trace;
+  if (TraceInstallation) {
+    Trace = std::make_shared<TraceClass>("predefined");
+    Reader.setTrace(Trace);
+    Inflator.setTrace(Trace);
+    Trace->setTraceProgress(true);
   }
-  return Reader.readFile() != nullptr;
+  Reader.algorithmStart();
+  Reader.algorithmReadBackFilled();
+  return !Reader.errorsFound();
 }
 
 void SymbolTable::setTraceProgress(bool NewValue) {
@@ -320,7 +398,8 @@ void SymbolTable::init() {
 SymbolNode* SymbolTable::getSymbolDefinition(const std::string& Name) {
   SymbolNode* Node = SymbolMap[Name];
   if (Node == nullptr) {
-    Node = create<SymbolNode>(Name);
+    Node = new SymbolNode(*this, Name);
+    Allocated->push_back(Node);
     SymbolMap[Name] = Node;
   }
   return Node;
@@ -333,27 +412,40 @@ SymbolNode* SymbolTable::getSymbolDefinition(const std::string& Name) {
       IntegerValue I(Op##tag, Value, Format, false);                 \
       IntegerNode* Node = IntMap[I];                                 \
       if (Node == nullptr) {                                         \
-        Node = create<tag##Node>(Value, Format);                     \
+        Node = new tag##Node(*this, Value, Format);                  \
+        Allocated->push_back(Node);                                  \
         IntMap[I] = Node;                                            \
       }                                                              \
       return dyn_cast<tag##Node>(Node);                              \
     }                                                                \
-    return create<tag##Node>(Value, Format);                         \
+    tag##Node* Node = new tag##Node(*this, Value, Format);           \
+    Allocated->push_back(Node);                                      \
+    return Node;                                                     \
   }                                                                  \
   tag##Node* SymbolTable::get##tag##Definition() {                   \
     if (mergable) {                                                  \
       IntegerValue I(Op##tag, (defval), ValueFormat::Decimal, true); \
       IntegerNode* Node = IntMap[I];                                 \
       if (Node == nullptr) {                                         \
-        Node = create<tag##Node>();                                  \
+        Node = new tag##Node(*this);                                 \
+        Allocated->push_back(Node);                                  \
         IntMap[I] = Node;                                            \
       }                                                              \
       return dyn_cast<tag##Node>(Node);                              \
     }                                                                \
-    return create<tag##Node>();                                      \
+    tag##Node* Node = new tag##Node(*this);                          \
+    Allocated->push_back(Node);                                      \
+    return Node;                                                     \
   }
 AST_INTEGERNODE_TABLE
 #undef X
+
+StreamNode* SymbolTable::getStreamDefinition(StreamKind Kind,
+                                             StreamType Type) {
+  StreamNode* Nd = new StreamNode(*this, Kind, Type);
+  Allocated->push_back(Nd);
+  return Nd;
+}
 
 void SymbolTable::install(Node* Root) {
   TRACE_METHOD("install");
@@ -530,7 +622,7 @@ bool UnaryNode::implementsClass(NodeType Type) {
   }
 }
 
-#define X(tag, NODE_DECLS) \
+#define X(tag, NODE_DECLS)                    \
   void tag##Node::forceCompilation() {}
 AST_UNARYNODE_TABLE
 #undef X

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -52,7 +52,7 @@ void TraceClass::trace_node_ptr(const char* Name, const Node* Nd) {
 namespace filt {
 
 #define X(tag, NODE_DECLS)                      \
-  template<>                                    \
+  template <>                                   \
   tag##Node* SymbolTable::create<tag##Node>() { \
     tag##Node* tag##Nd = new tag##Node(*this);  \
     Allocated->push_back(tag##Nd);              \
@@ -61,40 +61,39 @@ namespace filt {
 AST_NULLARYNODE_TABLE
 #undef X
 
-#define X(tag, NODE_DECLS)                              \
-  template<>                                            \
-  tag##Node* SymbolTable::create<tag##Node>(Node* Nd) { \
-    tag##Node* tag##Nd = new tag##Node(*this, Nd);      \
-    Allocated->push_back(tag##Nd);                      \
-    return tag##Nd;                                     \
+#define X(tag, NODE_DECLS)                               \
+  template <>                                            \
+  tag##Node* SymbolTable::create<tag##Node>(Node * Nd) { \
+    tag##Node* tag##Nd = new tag##Node(*this, Nd);       \
+    Allocated->push_back(tag##Nd);                       \
+    return tag##Nd;                                      \
   }
 AST_UNARYNODE_TABLE
 #undef X
 
-#define X(tag, NODE_DECLS)                                          \
-  template<>                                                        \
-  tag##Node* SymbolTable::create<tag##Node>(Node* Nd1, Node* Nd2) { \
-    tag##Node* tag##Nd = new tag##Node(*this, Nd1, Nd2);            \
-    Allocated->push_back(tag##Nd);                                  \
-    return tag##Nd;                                                 \
+#define X(tag, NODE_DECLS)                                            \
+  template <>                                                         \
+  tag##Node* SymbolTable::create<tag##Node>(Node * Nd1, Node * Nd2) { \
+    tag##Node* tag##Nd = new tag##Node(*this, Nd1, Nd2);              \
+    Allocated->push_back(tag##Nd);                                    \
+    return tag##Nd;                                                   \
   }
 AST_BINARYNODE_TABLE
 #undef X
 
-#define X(tag, NODE_DECLS)                                     \
-  template<>                                                   \
-  tag##Node* SymbolTable::create<tag##Node>(Node* Nd1,         \
-                                            Node* Nd2,         \
-                                            Node* Nd3) {       \
-    tag##Node* tag##Nd = new tag##Node(*this, Nd1, Nd2, Nd3);  \
-    Allocated->push_back(tag##Nd);                             \
-    return tag##Nd;                                            \
+#define X(tag, NODE_DECLS)                                          \
+  template <>                                                       \
+  tag##Node* SymbolTable::create<tag##Node>(Node * Nd1, Node * Nd2, \
+                                            Node * Nd3) {           \
+    tag##Node* tag##Nd = new tag##Node(*this, Nd1, Nd2, Nd3);       \
+    Allocated->push_back(tag##Nd);                                  \
+    return tag##Nd;                                                 \
   }
 AST_TERNARYNODE_TABLE
 #undef X
 
 #define X(tag, NODE_DECLS)                      \
-  template<>                                    \
+  template <>                                   \
   tag##Node* SymbolTable::create<tag##Node>() { \
     tag##Node* tag##Nd = new tag##Node(*this);  \
     Allocated->push_back(tag##Nd);              \
@@ -104,7 +103,7 @@ AST_NARYNODE_TABLE
 #undef X
 
 #define X(tag, NODE_DECLS)                      \
-  template<>                                    \
+  template <>                                   \
   tag##Node* SymbolTable::create<tag##Node>() { \
     tag##Node* tag##Nd = new tag##Node(*this);  \
     Allocated->push_back(tag##Nd);              \
@@ -113,7 +112,7 @@ AST_NARYNODE_TABLE
 AST_SELECTNODE_TABLE
 #undef X
 
-template<>
+template <>
 OpcodeNode* SymbolTable::create<OpcodeNode>() {
   OpcodeNode* Nd = new OpcodeNode(*this);
   Allocated->push_back(Nd);
@@ -440,8 +439,7 @@ SymbolNode* SymbolTable::getSymbolDefinition(const std::string& Name) {
 AST_INTEGERNODE_TABLE
 #undef X
 
-StreamNode* SymbolTable::getStreamDefinition(StreamKind Kind,
-                                             StreamType Type) {
+StreamNode* SymbolTable::getStreamDefinition(StreamKind Kind, StreamType Type) {
   StreamNode* Nd = new StreamNode(*this, Kind, Type);
   Allocated->push_back(Nd);
   return Nd;
@@ -622,7 +620,7 @@ bool UnaryNode::implementsClass(NodeType Type) {
   }
 }
 
-#define X(tag, NODE_DECLS)                    \
+#define X(tag, NODE_DECLS) \
   void tag##Node::forceCompilation() {}
 AST_UNARYNODE_TABLE
 #undef X

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -55,6 +55,7 @@ namespace filt {
 class FileHeaderNode;
 class IntegerNode;
 class Node;
+class StreamNode;
 class SymbolNode;
 class SymbolTable;
 class CallbackNode;
@@ -186,12 +187,16 @@ class SymbolTable : public std::enable_shared_from_this<SymbolTable> {
   void clear() { SymbolMap.clear(); }
   int getNextCreationIndex() { return ++NextCreationIndex; }
 
-  template <typename T, typename... Args>
-  T* create(Args&&... args) {
-    T* Nd = new T(*this, std::forward<Args>(args)...);
-    Allocated->push_back(Nd);
-    return Nd;
-  }
+  template <typename T>
+  T* create();
+  template <typename T>
+  T* create(Node* Nd);
+  template <typename T>
+  T* create(Node* Nd1, Node* Nd2);
+  template <typename T>
+  T* create(Node* Nd1, Node* Nd2, Node* Nd3);
+  StreamNode* getStreamDefinition(decode::StreamKind Kind,
+                                  decode::StreamType Type);
 
   static bool installPredefinedDefaults(std::shared_ptr<SymbolTable> Symtab,
                                         const uint8_t* AlgArray,

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -194,7 +194,9 @@ class SymbolTable : public std::enable_shared_from_this<SymbolTable> {
   }
 
   static bool installPredefinedDefaults(std::shared_ptr<SymbolTable> Symtab,
-                                        bool Verbose);
+                                        const uint8_t* AlgArray,
+                                        size_t AlgArraySize,
+                                        bool Trace);
 
   void setTraceProgress(bool NewValue);
   virtual void setTrace(std::shared_ptr<utils::TraceClass> Trace);

--- a/src/sexp/InflateAst.cpp
+++ b/src/sexp/InflateAst.cpp
@@ -248,7 +248,7 @@ bool InflateAst::applyOp(IntType Op) {
       return buildUnary<ReadNode>();
     case OpRename:
       return buildBinary<RenameNode>();
-    case OpSection:
+    case OpSection: {
       // Note: Bottom element is for file.
       TRACE(size_t, "Tree stack size", Asts.size());
       if (Asts.size() < 2)
@@ -257,7 +257,14 @@ bool InflateAst::applyOp(IntType Op) {
       if (!buildNary<SectionNode>())
         return false;
       Values.push(OpFile);
-      return buildTernary<FileNode>();
+      if (!buildTernary<FileNode>())
+        return false;
+      FileNode* File = getGeneratedFile();
+      if (File == nullptr)
+        return failBuild("InflateAst", "Did not generate a file node");
+      Symtab->install(File);
+      return true;
+    }
     case OpSequence:
       return buildNary<SequenceNode>();
     case OpSet:

--- a/src/stream/FileReader.h
+++ b/src/stream/FileReader.h
@@ -21,12 +21,14 @@
 
 #include "stream/RawStream.h"
 
+#include <cstdio>
 #include <memory>
 
 namespace wasm {
 
 namespace decode {
 
+#if 0
 class FdReader : public RawStream {
   FdReader() = delete;
   FdReader(const FdReader&) = delete;
@@ -72,6 +74,48 @@ class FileReader FINAL : public FdReader {
   FileReader(const char* Filename);
   ~FileReader() OVERRIDE;
 };
+
+#else
+
+class FileReader : public RawStream {
+  FileReader() = delete;
+  FileReader(const FileReader&) = delete;
+  FileReader& operator=(const FileReader*) = delete;
+
+ public:
+  FileReader(FILE* File, bool CloseOnExit)
+      : File(File),
+        CurSize(0),
+        BytesRemaining(0),
+        FoundErrors(false),
+        AtEof(false),
+        CloseOnExit(CloseOnExit) {}
+
+  FileReader(const char*);
+
+  ~FileReader() OVERRIDE;
+
+  size_t read(uint8_t* Buf, size_t Size = 1) OVERRIDE;
+  bool write(uint8_t* Buf, size_t Size = 1) OVERRIDE;
+  bool freeze() OVERRIDE;
+  bool atEof() OVERRIDE;
+  bool hasErrors() OVERRIDE;
+
+ protected:
+  FILE* File;
+  static constexpr size_t kBufSize = 4096;
+  uint8_t Bytes[kBufSize];
+  size_t CurSize;
+  size_t BytesRemaining;
+  bool FoundErrors;
+  bool AtEof;
+  bool CloseOnExit;
+
+  void closeFile();
+  void fillBuffer();
+};
+
+#endif
 
 }  // end of namespace decode
 

--- a/src/stream/FileWriter.h
+++ b/src/stream/FileWriter.h
@@ -22,25 +22,28 @@
 
 #include "stream/RawStream.h"
 
+#include <cstdio>
 #include <memory>
 
 namespace wasm {
 
 namespace decode {
 
-class FdWriter : public RawStream {
-  FdWriter(const FdWriter&) = delete;
-  FdWriter& operator=(const FdWriter&) = delete;
+class FileWriter : public RawStream {
+  FileWriter(const FileWriter&) = delete;
+  FileWriter& operator=(const FileWriter&) = delete;
 
  public:
-  FdWriter(int Fd, bool CloseOnExit = true)
-      : Fd(Fd),
+  FileWriter(FILE* File, bool CloseOnExit = true)
+      : File(File),
         CurSize(0),
-        FoundErrors(Fd < 0),
+        FoundErrors(false),
         IsFrozen(false),
         CloseOnExit(CloseOnExit) {}
 
-  ~FdWriter() OVERRIDE;
+  explicit FileWriter(const char* Filename);
+
+  ~FileWriter() OVERRIDE;
   size_t read(uint8_t* Buf, size_t Size = 1) OVERRIDE;
   bool write(uint8_t* Buf, size_t Size = 1) OVERRIDE;
   bool freeze() OVERRIDE;
@@ -48,7 +51,7 @@ class FdWriter : public RawStream {
   bool hasErrors() OVERRIDE;
 
  protected:
-  int Fd;
+  FILE* File;
   static constexpr size_t kBufSize = 4096;
   uint8_t Bytes[kBufSize];
   size_t CurSize;
@@ -57,15 +60,6 @@ class FdWriter : public RawStream {
   bool CloseOnExit;
 
   bool saveBuffer();
-};
-
-class FileWriter FINAL : public FdWriter {
-  FileWriter(const FileWriter&) = delete;
-  FileWriter& operator=(const FileWriter&) = delete;
-
- public:
-  FileWriter(const char* Filename);
-  ~FileWriter() OVERRIDE;
 };
 
 }  // end of namespace decode

--- a/src/test/TestByteQueues.cpp
+++ b/src/test/TestByteQueues.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<RawStream> getInput() {
 
 std::shared_ptr<RawStream> getOutput() {
   if (OutputFilename == std::string("-")) {
-    return std::make_shared<FdWriter>(STDOUT_FILENO, false);
+    return std::make_shared<FileWriter>(stdout, false);
   }
   return std::make_shared<FileWriter>(OutputFilename);
 }

--- a/src/test/TestByteQueues.cpp
+++ b/src/test/TestByteQueues.cpp
@@ -38,7 +38,7 @@ const char* OutputFilename = "-";
 
 std::shared_ptr<RawStream> getInput() {
   if (InputFilename == std::string("-"))
-    return std::make_shared<FdReader>(STDIN_FILENO, false);
+    return std::make_shared<FileReader>(stdin, false);
   return std::make_shared<FileReader>(InputFilename);
 }
 

--- a/src/test/TestRawStreams.cpp
+++ b/src/test/TestRawStreams.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<RawStream> getInput() {
 std::shared_ptr<RawStream> getOutput() {
   if (OutputFilename == std::string("-")) {
     if (UseFileStreams)
-      return std::make_shared<FdWriter>(STDOUT_FILENO, false);
+      return std::make_shared<FileWriter>(stdout, false);
     return std::make_shared<StreamWriter>(std::cout);
   }
   if (UseFileStreams)

--- a/src/test/TestRawStreams.cpp
+++ b/src/test/TestRawStreams.cpp
@@ -36,7 +36,7 @@ const char* OutputFilename = "-";
 std::shared_ptr<RawStream> getInput() {
   if (InputFilename == std::string("-")) {
     if (UseFileStreams)
-      return std::make_shared<FdReader>(STDIN_FILENO, false);
+      return std::make_shared<FileReader>(stdin, false);
     return std::make_shared<StreamReader>(std::cin);
   }
   if (UseFileStreams)

--- a/src/utils/ArgsParse.cpp
+++ b/src/utils/ArgsParse.cpp
@@ -311,13 +311,13 @@ void ArgsParser::Optional<charstring>::describeDefault(FILE* Out,
   printDescriptionContinue(Out, TabSize, Indent, "')");
 }
 
-template<>
+template <>
 bool ArgsParser::Optional<size_t>::select(charstring OptionValue) {
   Value = size_t(atoll(OptionValue));
   return true;
 }
 
-template<>
+template <>
 void ArgsParser::Optional<size_t>::describeDefault(FILE* Out,
                                                    size_t TabSize,
                                                    size_t& Indent) const {

--- a/src/utils/ArgsParse.cpp
+++ b/src/utils/ArgsParse.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <cstdlib>
 #include <cstring>
 
 namespace {
@@ -114,6 +115,17 @@ void writeCharstring(FILE* Out,
                      size_t& Indent,
                      const char* string) {
   writeChunk(Out, TabSize, Indent, string, strlen(string));
+}
+
+void writeSize_t(FILE* Out,
+                 const size_t TabSize,
+                 size_t& Indent,
+                 size_t Value) {
+  if (Indent + sizeof(size_t) >= MaxLine) {
+    writeNewline(Out, Indent);
+    indentTo(Out, TabSize, Indent);
+  }
+  fprintf(stderr, "%" PRIuMAX "", uintmax_t(Value));
 }
 
 void printDescriptionContinue(FILE* Out,
@@ -297,6 +309,21 @@ void ArgsParser::Optional<charstring>::describeDefault(FILE* Out,
   printDescriptionContinue(Out, TabSize, Indent, " (default is '");
   printDescriptionContinue(Out, TabSize, Indent, DefaultValue);
   printDescriptionContinue(Out, TabSize, Indent, "')");
+}
+
+template<>
+bool ArgsParser::Optional<size_t>::select(charstring OptionValue) {
+  Value = size_t(atoll(OptionValue));
+  return true;
+}
+
+template<>
+void ArgsParser::Optional<size_t>::describeDefault(FILE* Out,
+                                                   size_t TabSize,
+                                                   size_t& Indent) const {
+  printDescriptionContinue(Out, TabSize, Indent, " (default is ");
+  writeSize_t(Out, TabSize, Indent, DefaultValue);
+  printDescriptionContinue(Out, TabSize, Indent, ")");
 }
 
 int ArgsParser::RequiredArg::compare(const Arg& A) const {

--- a/src/utils/ArgsParse.cpp
+++ b/src/utils/ArgsParse.cpp
@@ -312,15 +312,60 @@ void ArgsParser::Optional<charstring>::describeDefault(FILE* Out,
 }
 
 template <>
-bool ArgsParser::Optional<size_t>::select(charstring OptionValue) {
+bool ArgsParser::Optional<uint32_t>::select(charstring OptionValue) {
   Value = size_t(atoll(OptionValue));
   return true;
 }
 
 template <>
-void ArgsParser::Optional<size_t>::describeDefault(FILE* Out,
-                                                   size_t TabSize,
-                                                   size_t& Indent) const {
+void ArgsParser::Optional<uint32_t>::describeDefault(FILE* Out,
+                                                     size_t TabSize,
+                                                     size_t& Indent) const {
+  printDescriptionContinue(Out, TabSize, Indent, " (default is ");
+  writeSize_t(Out, TabSize, Indent, DefaultValue);
+  printDescriptionContinue(Out, TabSize, Indent, ")");
+}
+
+template <>
+bool ArgsParser::Optional<int32_t>::select(charstring OptionValue) {
+  Value = size_t(atoll(OptionValue));
+  return true;
+}
+
+template <>
+void ArgsParser::Optional<int32_t>::describeDefault(FILE* Out,
+                                                    size_t TabSize,
+                                                    size_t& Indent) const {
+  printDescriptionContinue(Out, TabSize, Indent, " (default is ");
+  writeSize_t(Out, TabSize, Indent, DefaultValue);
+  printDescriptionContinue(Out, TabSize, Indent, ")");
+}
+
+template <>
+bool ArgsParser::Optional<uint64_t>::select(charstring OptionValue) {
+  Value = size_t(atoll(OptionValue));
+  return true;
+}
+
+template <>
+void ArgsParser::Optional<uint64_t>::describeDefault(FILE* Out,
+                                                     size_t TabSize,
+                                                     size_t& Indent) const {
+  printDescriptionContinue(Out, TabSize, Indent, " (default is ");
+  writeSize_t(Out, TabSize, Indent, DefaultValue);
+  printDescriptionContinue(Out, TabSize, Indent, ")");
+}
+
+template <>
+bool ArgsParser::Optional<int64_t>::select(charstring OptionValue) {
+  Value = size_t(atoll(OptionValue));
+  return true;
+}
+
+template <>
+void ArgsParser::Optional<int64_t>::describeDefault(FILE* Out,
+                                                    size_t TabSize,
+                                                    size_t& Indent) const {
   printDescriptionContinue(Out, TabSize, Indent, " (default is ");
   writeSize_t(Out, TabSize, Indent, DefaultValue);
   printDescriptionContinue(Out, TabSize, Indent, ")");

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -39,6 +39,16 @@ namespace wasm {
 #define WASM_RETURN_UNREACHABLE(V)
 #endif
 
+inline bool isBoot() {
+  return
+#ifdef BOOT
+      BOOT
+#else
+      false
+#endif
+      ;
+}
+
 #ifdef NDEBUG
 inline bool isRelease() {
   return true;

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -29,6 +29,10 @@
 #include <memory>
 #include <string>
 
+#ifndef WASM_BOOT
+#define WASM_BOOT 0
+#endif
+
 namespace wasm {
 
 #define WASM_IGNORE(V) (void)(V);
@@ -38,16 +42,6 @@ namespace wasm {
 #else
 #define WASM_RETURN_UNREACHABLE(V)
 #endif
-
-inline bool isBoot() {
-  return
-#ifdef BOOT
-      BOOT
-#else
-      false
-#endif
-      ;
-}
 
 #ifdef NDEBUG
 inline bool isRelease() {


### PR DESCRIPTION
Up till now, been trying to remove the binary reader/writer of casm files, since its form is incompatible with the decompressor reader. This PR moves tools over to using a decompressor compatible form of default algorithms.

a) Generates explicit functions for default algorithms using cast2wasm.

b) Modifies executables (other than decompsexp-wasm and decompwasm-sexp) to use generated explicit default functions.

c) Disabled testing decompexp-wasm and decompwasm-sexp since they are now replaced by cast2casm and casm2cast. Source not removed yet because they include tests that haven't been ported.

d) Removed FdReader and FdWriter after discovering that they were incompatible with other code. Now use FILE* forms (using classes FileReader/FileWriter).
