### PR TITLE
Add in array implementation of casm files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@
 
 # Note: If using -jN, be sure to run "make gen" first.
 
+# helper eq comparison function.
+eq = $(and $(findstring $(1),$(2)),$(findstring $(2),$(1)))
+
 include Makefile.common
 
 GENSRCS =
@@ -532,7 +535,9 @@ $(ALG_GEN_CPP_SRCS): $(ALG_GENDIR)/%.cpp: $(ALG_GENDIR)/%.cast \
 		$(BUILD_EXECDIR_BOOT)/cast2casm $(ALG_GENDIR_ALG)
 	$(BUILD_EXECDIR_BOOT)/cast2casm -a $(ALG_GENDIR_ALG) \
 		$< -o $@ --function \
-		$(patsubst $(ALG_GENDIR)/%.cast, install_Alg%, $<)
+		$(patsubst $(ALG_GENDIR)/%.cast, install_Alg%, $<) \
+		$(if $(call eq, "$(ALG_GENDIR)/casm0x0.cast", "$<") ,  , --array)
+
 -include $(foreach dep,$(ALG_GEN_CPP_SRCS:.cpp=.d),$(ALG_OBJDIR)/$(dep))
 
 $(ALG_OBJS): $(ALG_OBJDIR)/%.o: $(ALG_GENDIR)/%.cpp $(GENSRCS)

--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ TEST_CASM_DF_GEN_FILES = $(patsubst %.df, $(TEST_0XD_GENDIR)/%.df-out, \
 
 LIBS = $(BINARY_LIB) $(INTERP_LIB) $(SEXP_LIB) $(PARSER_LIB) \
        $(STRM_LIB) $(INTCOMP_LIB) $(INTERP_LIB) $(BINARY_LIB) \
-       $(ALG_LIB) $(STRM_LIB) $(UTILS_LIB) 
+       $(ALG_LIB) $(SEXP_LIB) $(ALG_LIB) $(STRM_LIB) $(UTILS_LIB) 
 
 LIBS_BOOT = $(BINARY_LIB_BOOT) $(INTERP_LIB_BOOT) \
 	$(SEXP_LIB_BOOT) $(PARSER_LIB_BOOT) \
@@ -535,8 +535,10 @@ $(ALG_GEN_CPP_SRCS): $(ALG_GENDIR)/%.cpp: $(ALG_GENDIR)/%.cast \
 		$(BUILD_EXECDIR_BOOT)/cast2casm $(ALG_GENDIR_ALG)
 	$(BUILD_EXECDIR_BOOT)/cast2casm -a $(ALG_GENDIR_ALG) \
 		$< -o $@ --function \
-		$(patsubst $(ALG_GENDIR)/%.cast, install_Alg%, $<) \
-		$(if $(call eq, "$(ALG_GENDIR)/casm0x0.cast", "$<") ,  , --array)
+		$(patsubst $(ALG_GENDIR)/%.cast, install_Alg%, $<)
+
+
+#		$(if $(call eq, "$(ALG_GENDIR)/casm0x0.cast", "$<") ,  , --array)
 
 -include $(foreach dep,$(ALG_GEN_CPP_SRCS:.cpp=.d),$(ALG_OBJDIR)/$(dep))
 

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -508,9 +508,15 @@ void CodeGenerator::generateArrayImplFile() {
   Output->puts("));\n"
                "  auto Input = std::make_shared<ReadBackedQueue>(ArrayInput);\n"
                "  CasmReader Reader;\n"
-               "  Reader.readBinary(Input, Symtable);\n"
-               "  assert(!Reader.hasErrors());\n");
+#if 1
+               " Reader.setTraceRead(true).setTraceTree(true);\n"
+#endif
+               "  Reader.readBinary(Input);\n"
+               "  assert(!Reader.hasErrors());\n"
+               "  assert(false && \"Need to rewrite code\");\n");
   generateFunctionFooter();
+  fprintf(stderr, "Error: --array option not functional!\n");
+  ErrorsFound = true;
 }
 
 void CodeGenerator::generateFunctionImplFile() {


### PR DESCRIPTION
Hard coded C++ casm files are much too large. The goal is only to keep casm0x0.cast hard coded, since it is the only  one needed to bootstrap the system.

The remaining should be implementable using an array implementation, which is considerably smaller.

Unfortunately, only after completing the bootstrap was an issue discovered that doesn't allow the array solution. A change in the API is necessary first. Rather than loosing changes, the code was left in, but turned off in the make file. This will allow an easier port to the new API.