### PR TITLE
Use array versions of default files except for casm0x0.cast.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -535,10 +535,8 @@ $(ALG_GEN_CPP_SRCS): $(ALG_GENDIR)/%.cpp: $(ALG_GENDIR)/%.cast \
 		$(BUILD_EXECDIR_BOOT)/cast2casm $(ALG_GENDIR_ALG)
 	$(BUILD_EXECDIR_BOOT)/cast2casm -a $(ALG_GENDIR_ALG) \
 		$< -o $@ --function \
-		$(patsubst $(ALG_GENDIR)/%.cast, getAlg%Symtab, $<)
-
-
-#		$(if $(call eq, "$(ALG_GENDIR)/casm0x0.cast", "$<") ,  , --array)
+		$(patsubst $(ALG_GENDIR)/%.cast, getAlg%Symtab, $<) \
+		$(if $(call eq, "$(ALG_GENDIR)/casm0x0.cast", "$<") ,  , --array)
 
 -include $(foreach dep,$(ALG_GEN_CPP_SRCS:.cpp=.d),$(ALG_OBJDIR)/$(dep))
 

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -508,15 +508,10 @@ void CodeGenerator::generateArrayImplFile() {
   Output->puts("));\n"
                "  auto Input = std::make_shared<ReadBackedQueue>(ArrayInput);\n"
                "  CasmReader Reader;\n"
-#if 1
-               " Reader.setTraceRead(true).setTraceTree(true);\n"
-#endif
                "  Reader.readBinary(Input);\n"
                "  assert(!Reader.hasErrors());\n"
-               "  assert(false && \"Need to rewrite code\");\n");
+               "  return Reader.getReadSymtab();\n");
   generateFunctionFooter();
-  fprintf(stderr, "Error: --array option not functional!\n");
-  ErrorsFound = true;
 }
 
 void CodeGenerator::generateFunctionImplFile() {


### PR DESCRIPTION
Now uses an array/CasmReader to build all default implementations except that for casm0x0.cast (which must exist in order to use CasmReader). This cuts out over 2.7 Mbs from most executables, which is substantial (the executables are all under 5mbs now).

This is because the binary array form is already a highly compressed form of the algorithm build in that it takes advantage of existing code in class InflateAst to does the actual construction.