### PR TITLE
Fix decompress to use the new APIs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,12 +365,6 @@ TEST_WASM_WS_GEN_FILES = $(patsubst %.wast, $(TEST_0XD_GENDIR)/%.wasm-ws, \
 TEST_WASM_SW_GEN_FILES = $(patsubst %.wast, $(TEST_0XD_GENDIR)/%.wasm-sw, \
                        $(TEST_WASM_SRCS))
 
-TEST_WASM_PD_GEN_FILES = $(patsubst %.wast, $(TEST_0XD_GENDIR)/%.wasm-pd, \
-                       $(TEST_WASM_SRCS))
-
-TEST_WASM_WPD_GEN_FILES = $(patsubst %.wast, $(TEST_0XD_GENDIR)/%.wasm-wpd, \
-                        $(TEST_WASM_SRCS))
-
 TEST_WASM_CAPI_GEN_FILES = $(patsubst %.wast, $(TEST_0XD_GENDIR)/%.wasm-capi, \
                         $(TEST_WASM_SRCS))
 
@@ -406,7 +400,8 @@ TEST_CASM_DF_GEN_FILES = $(patsubst %.df, $(TEST_0XD_GENDIR)/%.df-out, \
 
 LIBS = $(BINARY_LIB) $(INTERP_LIB) $(SEXP_LIB) $(PARSER_LIB) \
        $(STRM_LIB) $(INTCOMP_LIB) $(INTERP_LIB) $(BINARY_LIB) \
-       $(ALG_LIB) $(SEXP_LIB) $(ALG_LIB) $(STRM_LIB) $(UTILS_LIB) 
+       $(ALG_LIB) $(SEXP_LIB) $(ALG_LIB) $(STRM_LIB) $(UTILS_LIB) \
+       $(PARSER_LIB)
 
 LIBS_BOOT = $(BINARY_LIB_BOOT) $(INTERP_LIB_BOOT) \
 	$(SEXP_LIB_BOOT) $(PARSER_LIB_BOOT) \
@@ -914,8 +909,6 @@ presubmit:
 test-decompress: \
 	$(TEST_WASM_GEN_FILES) \
 	$(TEST_WASM_W_GEN_FILES) \
-	$(TEST_WASM_PD_GEN_FILES) \
-	$(TEST_WASM_WPD_GEN_FILES) \
 	$(TEST_WASM_CAPI_GEN_FILES) \
 	$(TEST_WASM_WS_GEN_FILES) \
 	$(TEST_WASM_SW_GEN_FILES)
@@ -961,49 +954,42 @@ $(TEST_WASM_COMP_FILES): $(TEST_0XD_GENDIR)/%.wasm-comp: $(TEST_0XD_SRCDIR)/%.wa
 
 $(TEST_WASM_GEN_FILES): $(TEST_0XD_GENDIR)/%.wasm: $(TEST_0XD_SRCDIR)/%.wasm \
 		$(BUILD_EXECDIR)/decompress
-	$(BUILD_EXECDIR)/decompress -m -i $< | cmp - $<
+	$(BUILD_EXECDIR)/decompress $< | cmp - $<
 
 .PHONY: $(TEST_WASM_GEN_FILES)
 
 $(TEST_WASM_W_GEN_FILES): $(TEST_0XD_GENDIR)/%.wasm-w: \
 		$(TEST_0XD_SRCDIR)/%.wasm-w $(BUILD_EXECDIR)/decompress
-	$(BUILD_EXECDIR)/decompress -i $< | cmp - $<
+	$(BUILD_EXECDIR)/decompress -m $< | cmp - $<
 
 .PHONY: $(TEST_WASM_W_GEN_FILES)
 
 
 $(TEST_WASM_WS_GEN_FILES): $(TEST_0XD_GENDIR)/%.wasm-ws: \
 		$(TEST_0XD_SRCDIR)/%.wasm $(BUILD_EXECDIR)/decompress
-	$(BUILD_EXECDIR)/decompress -m -i $<-w | cmp - $<
+	$(BUILD_EXECDIR)/decompress $<-w | cmp - $<
 
 .PHONY: $(TEST_WASM_WS_GEN_FILES)
 
 
 $(TEST_WASM_SW_GEN_FILES): $(TEST_0XD_GENDIR)/%.wasm-sw: \
 		$(TEST_0XD_SRCDIR)/%.wasm $(BUILD_EXECDIR)/decompress
-	$(BUILD_EXECDIR)/decompress -i $< | cmp - $<-w
+	$(BUILD_EXECDIR)/decompress -m $< | cmp - $<-w
 
 .PHONY: $(TEST_WASM_WS_GEN_FILES)
-
-$(TEST_WASM_PD_GEN_FILES): $(TEST_0XD_GENDIR)/%.wasm-pd: $(TEST_0XD_SRCDIR)/%.wasm \
-		$(BUILD_EXECDIR)/decompress $(SEXP_DEFAULT_GENSRCS)
-	$(BUILD_EXECDIR)/decompress -m -p -d $(SEXP_GENDIR)/defaults-0xd.df \
-		 -i $< | cmp - $<
-
-.PHOHY: $(TEST_WASM_PD_GEN_FILES)
 
 $(TEST_WASM_WPD_GEN_FILES): $(TEST_0XD_GENDIR)/%.wasm-wpd: \
 		$(TEST_0XD_SRCDIR)/%.wasm-w \
 		$(BUILD_EXECDIR)/decompress $(SEXP_DEFAULT_GENSRCS)
 	$(BUILD_EXECDIR)/decompress -p -d $(SEXP_GENDIR)/defaults-0xd.df \
-		 -i $< | cmp - $<
+		 $< | cmp - $<
 
 .PHOHY: $(TEST_WASM_WPD_GEN_FILES)
 
 
 $(TEST_WASM_CAPI_GEN_FILES): $(TEST_0XD_GENDIR)/%.wasm-capi: \
 		$(TEST_0XD_SRCDIR)/%.wasm-w $(BUILD_EXECDIR)/decompress
-	$(BUILD_EXECDIR)/decompress --c-api -i $< | cmp - $<
+	$(BUILD_EXECDIR)/decompress --c-api $< | cmp - $<
 
 .PHOHY: $(TEST_WASM_WPD_GEN_FILES)
 

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -63,9 +63,7 @@ class CodeGenerator {
   void generateDeclFile();
   void generateImplFile(bool UseArrayImpl);
   bool foundErrors() const { return ErrorsFound; }
-  void setStartPos(std::shared_ptr<ReadCursor> StartPos) {
-    ReadPos = StartPos;
-  }
+  void setStartPos(std::shared_ptr<ReadCursor> StartPos) { ReadPos = StartPos; }
 
  private:
   charstring Filename;
@@ -494,23 +492,26 @@ void CodeGenerator::generateArrayImplFile() {
     if (!ReadPos->atEof())
       Output->putc(',');
   }
-  Output->puts("};\n"
-               "\n"
-               "}  // end of anonymous namespace\n"
-               "\n");
+  Output->puts(
+      "};\n"
+      "\n"
+      "}  // end of anonymous namespace\n"
+      "\n");
   generateAlgorithmHeader();
-  Output->puts(" {\n"
-               "  auto ArrayInput = std::make_shared<ArrayReader>(\n"
-               "    ");
+  Output->puts(
+      " {\n"
+      "  auto ArrayInput = std::make_shared<ArrayReader>(\n"
+      "    ");
   generateArrayName();
   Output->puts(", size(");
   generateArrayName();
-  Output->puts("));\n"
-               "  auto Input = std::make_shared<ReadBackedQueue>(ArrayInput);\n"
-               "  CasmReader Reader;\n"
-               "  Reader.readBinary(Input);\n"
-               "  assert(!Reader.hasErrors());\n"
-               "  return Reader.getReadSymtab();\n");
+  Output->puts(
+      "));\n"
+      "  auto Input = std::make_shared<ReadBackedQueue>(ArrayInput);\n"
+      "  CasmReader Reader;\n"
+      "  Reader.readBinary(Input);\n"
+      "  assert(!Reader.hasErrors());\n"
+      "  return Reader.getReadSymtab();\n");
   generateFunctionFooter();
 }
 
@@ -526,20 +527,22 @@ void CodeGenerator::generateFunctionImplFile() {
       "  SymbolTable* Symtab = Symtable.get();\n"
       "  Symtab->install(");
   generateFunctionCall(Index);
-  Output->puts(");\n"
-               "  return Symtable;\n");
+  Output->puts(
+      ");\n"
+      "  return Symtable;\n");
   generateFunctionFooter();
 }
 
 void CodeGenerator::generateImplFile(bool UseArrayImpl) {
   generateHeader();
   if (UseArrayImpl)
-    Output->puts("#include \"sexp/CasmReader.h\"\n"
-                 "#include \"stream/ArrayReader.h\"\n"
-                 "#include \"stream/ReadBackedQueue.h\"\n"
-                 "\n"
-                 "#include <cassert>\n"
-                 "\n");
+    Output->puts(
+        "#include \"sexp/CasmReader.h\"\n"
+        "#include \"stream/ArrayReader.h\"\n"
+        "#include \"stream/ReadBackedQueue.h\"\n"
+        "\n"
+        "#include <cassert>\n"
+        "\n");
   generateEnterNamespaces();
   Output->puts(
       "using namespace wasm::filt;\n"
@@ -648,11 +651,10 @@ int main(int Argc, charstring Argv[]) {
                      "the INPUT cast algorithm"));
 
     ArgsParser::Optional<bool> UseArrayImplFlag(UseArrayImpl);
-    Args.add(UseArrayImplFlag.setLongName("array")
-             .setDescription(
-                 "Internally implement function NAME() using an "
-                 "array implementation, rather than the default that "
-                 "uses direct code"));
+    Args.add(UseArrayImplFlag.setLongName("array").setDescription(
+        "Internally implement function NAME() using an "
+        "array implementation, rather than the default that "
+        "uses direct code"));
 
     ArgsParser::Optional<bool> HeaderFileFlag(HeaderFile);
     Args.add(HeaderFileFlag.setLongName("header").setDescription(
@@ -742,11 +744,11 @@ int main(int Argc, charstring Argv[]) {
   if (FunctionName != nullptr) {
     if (UseArrayImpl) {
       OutputStream = std::make_shared<Queue>();
-      OutputStartPos
-          = std::make_shared<ReadCursor>(StreamType::Byte, OutputStream);
+      OutputStartPos =
+          std::make_shared<ReadCursor>(StreamType::Byte, OutputStream);
     }
   } else {
-   OutputStream = std::make_shared<WriteBackedQueue>(Output);
+    OutputStream = std::make_shared<WriteBackedQueue>(Output);
   }
 
   if (OutputStream) {


### PR DESCRIPTION
This completes the transition to the new form for casm/cast files. Once this is in, we can start deleting deprecated code.

Note: We still need to fix the decopressor to allow multiple default algorithms.