### PR TITLE
Add a bunch of fixes to fix compress-int (more still needed).

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "algorithms/wasm0xd.h"
 #include "intcomp/IntCompress.h"
 #include "stream/FileReader.h"
 #include "stream/FileWriter.h"
@@ -164,14 +165,13 @@ int main(int Argc, const char* Argv[]) {
     }
   }
 
-  auto Symtab = std::make_shared<SymbolTable>();
-
   // TODO(karlschimpf) Fill in code here to get default algorithm if not
   // explicitly defined.
 
   IntCompressor Compressor(std::make_shared<ReadBackedQueue>(getInput()),
                            std::make_shared<WriteBackedQueue>(getOutput()),
-                           Symtab, CompressionFlags);
+                           getAlgwasm0xdSymtab(),
+                           CompressionFlags);
   Compressor.compress(Verbose ? IntCompressor::DetailLevel::SomeDetail
                               : IntCompressor::DetailLevel::NoDetail);
   if (Compressor.errorsFound()) {

--- a/src/intcomp/CountWriter.cpp
+++ b/src/intcomp/CountWriter.cpp
@@ -111,6 +111,11 @@ bool CountWriter::writeAction(const filt::CallbackNode* Action) {
   }
 }
 
+bool CountWriter::writeHeaderValue(decode::IntType Value,
+                                   interp::IntTypeFormat Format) {
+  return true;
+}
+
 }  // end of namespace intcomp
 
 }  // end of namespace wasm

--- a/src/intcomp/CountWriter.h
+++ b/src/intcomp/CountWriter.h
@@ -67,6 +67,8 @@ class CountWriter : public interp::Writer {
   bool writeVaruint32(uint32_t Value) OVERRIDE;
   bool writeVaruint64(uint64_t Value) OVERRIDE;
   bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
+  bool writeHeaderValue(decode::IntType Value,
+                        interp::IntTypeFormat Format) OVERRIDE;
   bool writeAction(const filt::CallbackNode* Action) OVERRIDE;
 
  private:

--- a/src/interp/IntReader.cpp
+++ b/src/interp/IntReader.cpp
@@ -68,8 +68,12 @@ void IntReader::fastResume() {
       case Method::GetFile:
         switch (Frame.CallState) {
           case State::Enter:
-            for (auto Pair : Input->getHeader())
+            for (auto Pair : Input->getHeader()) {
+              IntType Value = readHeaderValue(Pair.second);
+              if (Value != Pair.first)
+                return failBadHeaderValue(Pair.first, Value, ValueFormat::Hexidecimal);
               Output.writeHeaderValue(Pair.first, Pair.second);
+            }
             LocalValues.push_back(Input->size());
             Frame.CallState = State::Exit;
             call(Method::ReadIntBlock, Frame.CallModifier, nullptr);
@@ -232,6 +236,8 @@ StreamType IntReader::getStreamType() {
 }
 
 bool IntReader::processedInputCorrectly() {
+  TRACE_METHOD("processedInputCurrectly");
+  TRACE(bool, "Return", Pos.atEnd());
   return Pos.atEnd();
 }
 
@@ -325,6 +331,7 @@ IntType IntReader::readHeaderValue(IntTypeFormat Format) {
          interp::getName(Format) + " but found " +
          interp::getName(Pair.second));
   }
+  TRACE(hex_IntType, "Value", Pair.first);
   return Pair.first;
 }
 

--- a/src/interp/IntStream.cpp
+++ b/src/interp/IntStream.cpp
@@ -183,6 +183,14 @@ IntStream::ReadCursorWithTraceContext::getTraceContext() {
   return TraceContext;
 }
 
+void IntStream::reset() {
+  Header.clear();
+  Values.clear();
+  TopBlock = std::make_shared<Block>();
+  isFrozenFlag = false;
+  Blocks.clear();
+}
+
 void IntStream::describe(FILE* File, const char* Name) {
   if (Name == nullptr)
     Name = "IntStream";

--- a/src/interp/IntStream.h
+++ b/src/interp/IntStream.h
@@ -181,8 +181,8 @@ class IntStream : public std::enable_shared_from_this<IntStream> {
   };
 
   // WARNING: Don't call constructor directly. Call std::make_shared().
-  IntStream() : TopBlock(std::make_shared<Block>()), isFrozenFlag(false) {}
-  void reset() { TopBlock.reset(); }
+  IntStream() { reset(); }
+  void reset();
   ~IntStream() {}
 
   size_t size() const { return Values.size(); }
@@ -206,7 +206,7 @@ class IntStream : public std::enable_shared_from_this<IntStream> {
   BlockPtr TopBlock;
   bool isFrozenFlag;
 
-  // The following fields is defined by openWriteBlock(), and defines the
+  // The following fields is defined by openBlock(), and defines the
   // sequence of written blocks.
   BlockVector Blocks;
 };

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -26,8 +26,13 @@ using namespace utils;
 
 namespace interp {
 
+IntWriter::IntWriter(std::shared_ptr<IntStream> Output)
+    : Output(Output), Pos(Output) {}
+
 void IntWriter::reset() {
-  Output.reset();
+  Output->reset();
+  IntStream::WriteCursorWithTraceContext StartPos(Output);
+  Pos = StartPos;
 }
 
 TraceClass::ContextPtr IntWriter::getTraceContext() {
@@ -89,8 +94,16 @@ bool IntWriter::writeAction(const filt::CallbackNode* Action) {
     case PredefinedSymbol::Block_exit:
       return Pos.closeBlock();
     default:
-      return false;
+      // Ignore all other actions, since they do not involve
+      // changing the integer sequence.
+      return true;
   }
+}
+
+void IntWriter::describeState(FILE* File) {
+  fprintf(stderr, "Pos = ");
+  Pos.describe(File);
+  fputc('\n', File);
 }
 
 }  // end of namespace interp

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -35,7 +35,7 @@ class IntWriter : public Writer {
   IntWriter& operator=(const IntWriter&) = delete;
 
  public:
-  IntWriter(std::shared_ptr<IntStream> Output) : Output(Output), Pos(Output) {}
+  IntWriter(std::shared_ptr<IntStream> Output);
   ~IntWriter() OVERRIDE {}
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
@@ -53,6 +53,8 @@ class IntWriter : public Writer {
   bool writeAction(const filt::CallbackNode* Action) OVERRIDE;
 
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
+
+  virtual void describeState(FILE* File);
 
  private:
   std::shared_ptr<IntStream> Output;

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -265,6 +265,9 @@ class Reader {
   void failFreezingEof();
   void failInWriteOnlyMode();
   void failNotImplemented();
+  void failBadHeaderValue(decode::IntType WantedValue,
+                          decode::IntType FoundValue,
+                          decode::ValueFormat Format);
 
   // For debugging only.
 

--- a/src/utils/Trace.cpp
+++ b/src/utils/Trace.cpp
@@ -159,6 +159,12 @@ void TraceClass::traceIntTypeInternal(const char* Name, IntType Value) {
   fputc('\n', File);
 }
 
+void TraceClass::traceHexIntTypeInternal(const char* Name, IntType Value) {
+  indent();
+  trace_value_label(Name);
+  fprintf(File, "%" PRIxMAX "\n", uintmax_t(Value));
+}
+
 void TraceClass::traceHexInternal(const char* Name, uintmax_t Value) {
   indent();
   trace_value_label(Name);

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -227,6 +227,9 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
   void trace_IntType(const char* Name, decode::IntType Value) {
     traceIntTypeInternal(Name, Value);
   }
+  void trace_hex_IntType(const char* Name, decode::IntType Value) {
+    traceHexIntTypeInternal(Name, Value);
+  }
   void trace_size_t(const char* Name, size_t Value) {
     traceUintInternal(Name, Value);
   }
@@ -259,6 +262,7 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
   void traceIntTypeInternal(const char* Name, decode::IntType Value);
   void traceHexInternal(const char* Name, uintmax_t Value);
   void tracePointerInternal(const char* Name, void* Value);
+  void traceHexIntTypeInternal(const char* Name, decode::IntType Value);
 
  private:
   inline void init();


### PR DESCRIPTION
Committing fixes since the number of changes are large.

Current fixes move compress-int much further along in the process of compression. Currently dies when late pass is not defining the correct header to the reader.