### PR TITLE
Fix header value insertion into integer streams for compress-int

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -47,7 +47,6 @@ std::shared_ptr<RawStream> getOutput() {
 
 int main(int Argc, const char* Argv[]) {
   charstring AlgorithmFilename = nullptr;
-  bool Verbose = false;
   IntCompressor::Flags CompressionFlags;
 
   {
@@ -101,11 +100,6 @@ int main(int Argc, const char* Argv[]) {
                      "execution time grows non-linearly when this value "
                      " is increased)"));
 
-    ArgsParser::Toggle VerboseFlag(Verbose);
-    Args.add(VerboseFlag.setShortName('v')
-                 .setLongName("verbose")
-                 .setDescription("Show progress of compression"));
-
     ArgsParser::Optional<bool> TraceReadingInputFlag(
         CompressionFlags.TraceReadingInput);
     Args.add(
@@ -149,10 +143,36 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Optional<bool> TraceCompressionFlag(
         CompressionFlags.TraceCompression);
-    Args.add(TraceCompressionFlag.setLongName("verbose=compress")
+    Args.add(TraceCompressionFlag.setShortName('v').setLongName("verbose")
                  .setDescription(
-                     "Show details on how patterns are detected for "
-                     "compressing the (input) integer sequence"));
+                     "Show basic details on how the input is comverted to "
+                     "the corresponding compressed output"));
+
+    ArgsParser::Optional<bool>
+        TraceInputIntStreamFlag(CompressionFlags.TraceInputIntStream);
+    Args.add(TraceInputIntStreamFlag.setLongName("verbose=int-input")
+             .setDescription("Show initial parsed integer stream"));
+
+    ArgsParser::Optional<bool>
+        TraceIntCountsFlag(CompressionFlags.TraceIntCounts);
+    Args.add(TraceIntCountsFlag.setLongName("verbose=int-counts")
+             .setDescription("Show frequency of integers in the input stream"));
+
+    ArgsParser::Optional<bool>
+        TraceSequenceCountsFlag(CompressionFlags.TraceSequenceCounts);
+    Args.add(TraceSequenceCountsFlag.setLongName("verbose=seq-counts")
+             .setDescription("Show frequency of integer sequences in the "
+                             "input stream"));
+
+    ArgsParser::Optional<bool> TraceAbbreviationAssignmentsFlag(
+        CompressionFlags.TraceAbbreviationAssignments);
+    Args.add(TraceAbbreviationAssignmentsFlag.setLongName("verbose=abbrev")
+             .setDescription("Show (initial) abbreviation assignments"));
+
+    ArgsParser::Optional<bool> TraceCompressedIntOutputFlag(
+        CompressionFlags.TraceCompressedIntOutput);
+    Args.add(TraceCompressedIntOutputFlag.setLongName("verbose=int-output")
+             .setDescription("Show generated compressed integer stream"));
 
     switch (Args.parse(Argc, Argv)) {
       case ArgsParser::State::Good:
@@ -172,8 +192,8 @@ int main(int Argc, const char* Argv[]) {
                            std::make_shared<WriteBackedQueue>(getOutput()),
                            getAlgwasm0xdSymtab(),
                            CompressionFlags);
-  Compressor.compress(Verbose ? IntCompressor::DetailLevel::SomeDetail
-                              : IntCompressor::DetailLevel::NoDetail);
+  Compressor.compress();
+
   if (Compressor.errorsFound()) {
     fatal("Failed to compress due to errors!");
     exit_status(EXIT_FAILURE);

--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -99,6 +99,11 @@ bool AbbrevAssignWriter::writeValue(decode::IntType Value, const filt::Node*) {
   return true;
 }
 
+bool AbbrevAssignWriter::writeHeaderValue(decode::IntType Value,
+                                          interp::IntTypeFormat Format) {
+  return Writer.writeHeaderValue(Value, Format);
+}
+
 bool AbbrevAssignWriter::writeAction(const filt::CallbackNode* Action) {
   const auto* Sym = dyn_cast<SymbolNode>(Action->getKid(0));
   if (Sym == nullptr)

--- a/src/intcomp/AbbrevAssignWriter.h
+++ b/src/intcomp/AbbrevAssignWriter.h
@@ -60,6 +60,8 @@ class AbbrevAssignWriter : public interp::Writer {
   bool writeVaruint64(uint64_t Value) OVERRIDE;
   bool writeFreezeEof() OVERRIDE;
   bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
+  bool writeHeaderValue(decode::IntType Value,
+                        interp::IntTypeFormat Format) OVERRIDE;
   bool writeAction(const filt::CallbackNode* Action) OVERRIDE;
 
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;

--- a/src/intcomp/AbbreviationCodegen.h
+++ b/src/intcomp/AbbreviationCodegen.h
@@ -45,7 +45,11 @@ class AbbreviationCodegen {
   interp::IntTypeFormat AbbrevFormat;
   CountNode::PtrVector& Assignments;
   bool ToRead;
-  void generateFile();
+  filt::Node* generateCasmFileHeader();
+  filt::Node* generateWasmFileHeader();
+  filt::Node* generateVoidFileHeader();
+  void generateFile(filt::Node* SourceHeader,
+                    filt::Node* TargetHeader);
   filt::Node* generateFileBody();
   filt::Node* generateFileFcn();
   filt::Node* generateAbbreviationRead();

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -121,6 +121,12 @@ void IntCompressor::readInput() {
 
 const WriteCursor IntCompressor::writeCodeOutput(
     std::shared_ptr<SymbolTable> Symtab) {
+#if 0
+  {
+    TextWriter Writer;
+    Writer.write(stderr, Symtab.get());
+  }
+#endif
   BinaryWriter Writer(Output, Symtab);
   Writer.setFreezeEofOnDestruct(false);
   bool OldTraceProgress = false;
@@ -139,12 +145,18 @@ const WriteCursor IntCompressor::writeCodeOutput(
 
 void IntCompressor::writeDataOutput(const WriteCursor& StartPos,
                                     std::shared_ptr<SymbolTable> Symtab) {
+#if 0
+  {
+    TextWriter Writer;
+    Writer.write(stderr, Symtab.get());
+  }
+#endif
   StreamWriter Writer(Output);
   Writer.setPos(StartPos);
   IntReader Reader(IntOutput, Writer, Symtab);
   if (MyFlags.TraceWritingDataOutput)
     Reader.getTrace().setTraceProgress(true);
-  Reader.insertFileVersion(WasmBinaryMagic, WasmBinaryVersionD);
+  Reader.useFileHeader(Symtab->getInstalledHeader());
   Reader.algorithmStart();
   Reader.algorithmReadBackFilled();
   bool Successful = Reader.isFinished() && Reader.isSuccessful();
@@ -223,7 +235,7 @@ void IntCompressor::compress() {
   TRACE(size_t, "Number of integers in compressed output",
         IntOutput->getNumIntegers());
   if (MyFlags.TraceCompressedIntOutput)
-    IntOutput->describe(stderr, "Input int stream");
+    IntOutput->describe(stderr, "Output int stream");
   TRACE_MESSAGE("Appending compression algorithm to output");
   const WriteCursor Pos =
       writeCodeOutput(generateCodeForReading(AbbrevAssignments));

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -38,6 +38,7 @@ class IntCompressor FINAL {
   IntCompressor& operator=(const IntCompressor&) = delete;
 
  public:
+
   struct Flags {
     uint64_t CountCutoff;
     uint64_t WeightCutoff;
@@ -52,6 +53,11 @@ class IntCompressor FINAL {
     bool TraceIntStreamGeneration;
     bool TraceCodeGenerationForReading;
     bool TraceCodeGenerationForWriting;
+    bool TraceInputIntStream;
+    bool TraceIntCounts;
+    bool TraceSequenceCounts;
+    bool TraceAbbreviationAssignments;
+    bool TraceCompressedIntOutput;
     std::shared_ptr<utils::TraceClass> Trace;
     Flags();
   };
@@ -65,11 +71,9 @@ class IntCompressor FINAL {
 
   bool errorsFound() const { return ErrorsFound; }
 
-  enum DetailLevel { NoDetail, SomeDetail, MoreDetail, AllDetail };
-
   std::shared_ptr<RootCountNode> getRoot();
 
-  void compress(DetailLevel Level = NoDetail);
+  void compress();
 
   void setTraceProgress(bool NewValue) {
     // TODO: Don't force creation of trace object if not needed.

--- a/src/utils/ArgsParse.h
+++ b/src/utils/ArgsParse.h
@@ -98,6 +98,42 @@ class ArgsParser {
     virtual void describeOptionName(FILE* Out,
                                     size_t TabSize,
                                     size_t& Indent) const;
+
+    // The following are support writing routines for parser arguments.
+    static void endLineIfOver(FILE* Out, const size_t TabSize, size_t& Indent) {
+      ArgsParser::endLineIfOver(Out, TabSize, Indent);
+    }
+    static void indentTo(FILE* Out, const size_t TabSize, size_t& Indent) {
+      ArgsParser::indentTo(Out, TabSize, Indent);
+    }
+    static void writeNewline(FILE* Out, size_t& Indent) {
+      ArgsParser::writeNewline(Out, Indent);
+    }
+    static void writeChar(FILE* Out, const size_t TabSize,
+                          size_t& Indent, char Ch) {
+      ArgsParser::writeChar(Out, TabSize, Indent, Ch);
+    }
+    static void writeChunk(FILE* Out, const size_t TabSize, size_t& Indent,
+                           charstring String, size_t Chunk) {
+      ArgsParser::writeChunk(Out, TabSize, Indent, String, Chunk);
+    }
+    static void writeCharstring(FILE* Out, const size_t TabSize, size_t& Indent,
+                                charstring String) {
+      ArgsParser::writeCharstring(Out, TabSize, Indent, String);
+    }
+    static void writeSize_t(FILE* Out, const size_t TabSize, size_t& Indent,
+                            size_t Value) {
+      ArgsParser::writeSize_t(Out, TabSize, Indent, Value);
+    }
+    static void printDescriptionContinue(FILE* Out,
+                                         const size_t TabSize, size_t& Indent,
+                                         charstring Description) {
+      ArgsParser::printDescriptionContinue(Out, TabSize, Indent, Description);
+    }
+    static void printDescription(FILE* Out, size_t TabSize, size_t& Indent,
+                                 charstring Description) {
+      ArgsParser::printDescription(Out, TabSize, Indent, Description);
+    }
   };
 
   class RequiredArg;
@@ -157,6 +193,27 @@ class ArgsParser {
                          size_t& Indent) const OVERRIDE;
 
     ~Toggle() OVERRIDE {}
+  };
+
+  template <class T>
+  class SetValue : public Optional<T> {
+    SetValue() = delete;
+    SetValue(const SetValue&) = delete;
+    SetValue& operator=(const SetValue&) = delete;
+
+   public:
+    SetValue(T& Value, T SelectValue, charstring Description = nullptr)
+        : Optional<T>(Value, Description) {}
+
+    bool select(charstring OptionValue) OVERRIDE;
+    void describeDefault(FILE* Out,
+                         size_t TabSize,
+                         size_t& Indent) const OVERRIDE;
+
+    ~SetValue() OVERRIDE {}
+
+   protected:
+    T SelectValue;
   };
 
   class RequiredArg : public Arg {
@@ -227,6 +284,28 @@ class ArgsParser {
   Arg* parseNextShort(charstring Argument, charstring& Leftover);
   Arg* parseNextLong(charstring Argument, charstring& Leftover);
   void showUsage();
+
+  friend class Arg;
+
+  // The following are support writing routines for parser arguments.
+  static const size_t TabWidth;
+  static const size_t MaxLine;
+
+  static void endLineIfOver(FILE* Out, const size_t TabSize, size_t& Indent);
+  static void indentTo(FILE* Out, const size_t TabSize, size_t& Indent);
+  static void writeNewline(FILE* Out, size_t& Indent);
+  static void writeChar(FILE* Out, const size_t TabSize, size_t& Indent, char Ch);
+  static void writeChunk(FILE* Out, const size_t TabSize, size_t& Indent,
+                         charstring String, size_t Chunk);
+  static void writeCharstring(FILE* Out, const size_t TabSize, size_t& Indent,
+                              charstring String);
+  static void writeSize_t(FILE* Out, const size_t TabSize, size_t& Indent,
+                          size_t Value);
+  static void printDescriptionContinue(FILE* Out,
+                                       const size_t TabSize, size_t& Indent,
+                                       charstring Description);
+  static void printDescription(FILE* Out, size_t TabSize, size_t& Indent,
+                               charstring Description);
 };
 
 }  // end of namespace utils


### PR DESCRIPTION
Fixes the integer streams, resulting in compress-int generating output.  However, it is still using the explicit binary writer for code, which is deprecated. That will be fixed in a later CL.