### PR TITLE
Change decompressor to use a selector table.

### DIFF
--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -180,7 +180,6 @@ int main(const int Argc, const char* Argv[]) {
     return exit_status(runUsingCApi(Verbose >= 1));
   }
 
-  std::shared_ptr<SymbolTable> Symtab = getAlgwasm0xdSymtab();
   bool Succeeded = true;  // until proven otherwise.
   for (size_t i = 0; i < NumTries; ++i) {
     if (Verbose)
@@ -200,8 +199,8 @@ int main(const int Argc, const char* Argv[]) {
     if (Verbose)
       fprintf(stderr, "Decompressing...\n");
     Interpreter Decompressor(std::make_shared<ReadBackedQueue>(Input),
-                             std::make_shared<WriteBackedQueue>(Output),
-                             Symtab);
+                             std::make_shared<WriteBackedQueue>(Output));
+    Decompressor.addSelector(std::make_shared<SymbolTableSelector>(getAlgwasm0xdSymtab()));
     Decompressor.setMinimizeBlockSize(MinimizeBlockSize);
     if (VerboseTrace) {
       auto Trace = std::make_shared<TraceClass>("Decompress");

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -167,10 +167,9 @@ extern "C" {
 
 void* create_decompressor() {
   auto* Decomp = new Decompressor();
-  Decomp->Symtab = getAlgwasm0xdSymtab();
   Decomp->Interp = std::make_shared<Interpreter>(
-      Decomp->Input, Decomp->OutputPipe.getInput(), Decomp->Symtab);
-  // Decomp->Interp->setTraceProgress(true);
+      Decomp->Input, Decomp->OutputPipe.getInput());
+  Decomp->Interp->addSelector(std::make_shared<SymbolTableSelector>(getAlgwasm0xdSymtab()));
   Decomp->Interp->start();
   return Decomp;
 }

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -18,12 +18,40 @@
 
 #include "interp/Interpreter.h"
 
+#include <cassert>
+
 namespace wasm {
 
 using namespace filt;
 using namespace utils;
 
 namespace interp {
+
+SymbolTableSelector::SymbolTableSelector(std::shared_ptr<SymbolTable> Symtab,
+                                         bool DataSelector)
+    : AlgorithmSelector(Symtab->getTargetHeader(), DataSelector),
+      Symtab(Symtab),
+      StillGood(true)
+{}
+
+SymbolTableSelector::~SymbolTableSelector() {}
+
+std::shared_ptr<SymbolTable> SymbolTableSelector::getAlgorithm() {
+  assert(StillGood && "SymbolTableSelector getAlgorithm called more than once!");
+  StillGood = false;
+  return Symtab;
+}
+
+void Interpreter::addSelector(std::shared_ptr<AlgorithmSelector> Selector) {
+  Selectors.push_back(Selector);
+}
+
+void Interpreter::start() {
+  assert(!Selectors.empty());
+  // TODO(karlschimpf) Find correct symbol table to use.
+  Input.setSymbolTable(Selectors.front()->getAlgorithm());
+  Input.algorithmStart();
+}
 
 void Interpreter::setTraceProgress(bool NewValue) {
   if (!NewValue && !Trace)

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -23,13 +23,56 @@
 #include "interp/StreamWriter.h"
 #include "utils/Trace.h"
 
+#include <memory>
+
 namespace wasm {
 
 namespace filt {
 class TextWriter;
+class FileHeaderNode;
+class SymbolTable;
 }
 
 namespace interp {
+
+class AlgorithmSelector
+    : public std::enable_shared_from_this<AlgorithmSelector> {
+  AlgorithmSelector() = delete;
+  AlgorithmSelector(const AlgorithmSelector&) = delete;
+  AlgorithmSelector& operator=(const AlgorithmSelector&) = delete;
+
+ public:
+  explicit AlgorithmSelector(const filt::FileHeaderNode* TargetHeader,
+                             bool DataSelector = false)
+      : TargetHeader(TargetHeader), DataSelector(DataSelector) {}
+  virtual ~AlgorithmSelector() {}
+
+  const filt::FileHeaderNode* getTargetHeader() { return TargetHeader; }
+  virtual std::shared_ptr<filt::SymbolTable> getAlgorithm() = 0;
+  bool IsDataSelector() const { return DataSelector; }
+
+ protected:
+  const filt::FileHeaderNode* TargetHeader;
+  bool DataSelector;
+};
+
+// TODO(karlschimpf): Replace this  with a better solution,  since This selector
+// can only be used once, since there is no symbol table copy.
+class SymbolTableSelector : public AlgorithmSelector {
+  SymbolTableSelector() = delete;
+  SymbolTableSelector(const SymbolTableSelector&) = delete;
+  SymbolTableSelector& operator=(const SymbolTableSelector&) = delete;
+
+ public:
+  explicit SymbolTableSelector(std::shared_ptr<filt::SymbolTable> Symtab,
+                               bool DataSelector = false);
+  ~SymbolTableSelector() OVERRIDE;
+  std::shared_ptr<filt::SymbolTable> getAlgorithm() OVERRIDE;
+
+ private:
+  std::shared_ptr<filt::SymbolTable> Symtab;
+  bool StillGood;
+};
 
 // Defines the algorithm interpreter for filter sections, and the
 // corresponding state associated with the interpreter.
@@ -42,20 +85,21 @@ class Interpreter FINAL {
 
  public:
   Interpreter(std::shared_ptr<decode::Queue> InputStream,
-              std::shared_ptr<decode::Queue> OutputStream,
-              std::shared_ptr<filt::SymbolTable> Symtab)
-      : Symtab(Symtab),
+              std::shared_ptr<decode::Queue> OutputStream)
+      : Symtab(),
         Input(InputStream, Output, Symtab),
         Output(OutputStream) {}
 
   ~Interpreter() {}
 
-  void start() { Input.algorithmStart(); }
+  void start();
   void resume() { Input.algorithmResume(); }
   void fail(const std::string& Message) { Input.fail(Message); }
   bool isFinished() const { return Input.isFinished(); }
   bool isSuccessful() const { return Input.isSuccessful(); }
   bool errorsFound() const { return Input.errorsFound(); }
+
+  void addSelector(std::shared_ptr<AlgorithmSelector> Selector);
 
   // Processes each section in input, and decompresses it (if applicable)
   // to the corresponding output.
@@ -78,6 +122,7 @@ class Interpreter FINAL {
   StreamReader Input;
   StreamWriter Output;
   std::shared_ptr<utils::TraceClass> Trace;
+  std::vector<std::shared_ptr<AlgorithmSelector>> Selectors;
 };
 
 }  // end of namespace interp.

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -52,6 +52,10 @@ class Reader {
     HeaderOverride = Header;
   }
 
+  void setSymbolTable(std::shared_ptr<filt::SymbolTable> NewSymtab) {
+    Symtab = NewSymtab;
+  }
+
   void setFreezeEofAtExit(bool NewValue) { FreezeEofAtExit = NewValue; }
 
   // Starts up decompression using a (file) algorithm.


### PR DESCRIPTION
At the moment, only the selector for the wasm algorithm is defined. However, this PR modifies all caller to now use a selector form, rather than hard coding that only the wasm algorithm can be applied.