### PR TITLE
Clean up readers to get a shared_ptr of the writer, extending lifetimes

### DIFF
--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -199,12 +199,12 @@ int main(const int Argc, const char* Argv[]) {
       fprintf(stderr, "Decompressing...\n");
     std::shared_ptr<Queue> BackedOutput =
         std::make_shared<WriteBackedQueue>(Output);
-    interp::StreamWriter Writer(BackedOutput);
+    auto Writer = std::make_shared<interp::StreamWriter>(BackedOutput);
     interp::StreamReader Decompressor(std::make_shared<ReadBackedQueue>(Input),
                                       Writer);
     Decompressor.addSelector(
         std::make_shared<SymbolTableSelector>(getAlgwasm0xdSymtab()));
-    Writer.setMinimizeBlockSize(MinimizeBlockSize);
+    Writer->setMinimizeBlockSize(MinimizeBlockSize);
     if (VerboseTrace) {
       auto Trace = std::make_shared<TraceClass>("Decompress");
       Trace->setTraceProgress(true);

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -102,7 +102,7 @@ CountNode::RootPtr IntCompressor::getRoot() {
 
 void IntCompressor::readInput() {
   Contents = std::make_shared<IntStream>();
-  IntWriter MyWriter(Contents);
+  auto MyWriter = std::make_shared<IntWriter>(Contents);
   StreamReader MyReader(Input, MyWriter, Symtab);
   if (MyFlags.TraceReadingInput)
     MyReader.getTrace().setTraceProgress(true);
@@ -126,8 +126,8 @@ const WriteCursor IntCompressor::writeCodeOutput(
 
 void IntCompressor::writeDataOutput(const WriteCursor& StartPos,
                                     std::shared_ptr<SymbolTable> Symtab) {
-  StreamWriter Writer(Output);
-  Writer.setPos(StartPos);
+  auto Writer = std::make_shared<StreamWriter>(Output);
+  Writer->setPos(StartPos);
   IntReader Reader(IntOutput, Writer, Symtab);
   if (MyFlags.TraceWritingDataOutput)
     Reader.getTrace().setTraceProgress(true);
@@ -151,9 +151,9 @@ bool IntCompressor::compressUpToSize(size_t Size) {
       TRACE_MESSAGE("Collecting integer sequences of (up to) length: " +
                     std::to_string(Size));
   });
-  CountWriter Writer(getRoot());
-  Writer.setCountCutoff(MyFlags.CountCutoff);
-  Writer.setUpToSize(Size);
+  auto Writer = std::make_shared<CountWriter>(getRoot());
+  Writer->setCountCutoff(MyFlags.CountCutoff);
+  Writer->setUpToSize(Size);
 
   IntReader Reader(Contents, Writer, Symtab);
   if (MyFlags.TraceReadingIntStream)
@@ -235,8 +235,8 @@ void IntCompressor::assignInitialAbbreviations(
 }
 
 bool IntCompressor::generateIntOutput() {
-  AbbrevAssignWriter Writer(Root, IntOutput, MyFlags.LengthLimit,
-                            MyFlags.AbbrevFormat);
+  auto Writer = std::make_shared<AbbrevAssignWriter>(
+      Root, IntOutput, MyFlags.LengthLimit, MyFlags.AbbrevFormat);
   IntReader Reader(Contents, Writer, Symtab);
   if (MyFlags.TraceIntStreamGeneration)
     Reader.getTrace().setTraceProgress(true);

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -172,7 +172,7 @@ void* create_decompressor() {
   Decomp->Writer =
       std::make_shared<StreamWriter>(Decomp->OutputPipe.getInput());
   Decomp->Reader =
-      std::make_shared<StreamReader>(Decomp->Input, *Decomp->Writer);
+      std::make_shared<StreamReader>(Decomp->Input, Decomp->Writer);
   Decomp->Reader->addSelector(
       std::make_shared<SymbolTableSelector>(getAlgwasm0xdSymtab()));
   Decomp->Reader->algorithmStart();

--- a/src/interp/IntReader.h
+++ b/src/interp/IntReader.h
@@ -37,7 +37,7 @@ class IntReader : public Reader {
 
  public:
   IntReader(std::shared_ptr<IntStream> Input,
-            Writer& Output,
+            std::shared_ptr<Writer> Output,
             std::shared_ptr<filt::SymbolTable> Symtab);
   ~IntReader() OVERRIDE;
 

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -79,7 +79,8 @@ class Reader {
   Reader& operator=(const Reader&) = delete;
 
  public:
-  Reader(Writer& Output, std::shared_ptr<filt::SymbolTable> Symtab);
+  Reader(std::shared_ptr<Writer> Output,
+         std::shared_ptr<filt::SymbolTable> Symtab);
   virtual ~Reader();
 
   // Can be called immediately before algorithmStart() to insert file version
@@ -229,7 +230,7 @@ class Reader {
     size_t CallingEvalIndex;
   };
 
-  Writer& Output;
+  std::shared_ptr<Writer> Output;
   std::shared_ptr<filt::SymbolTable> Symtab;
   std::vector<std::shared_ptr<AlgorithmSelector>> Selectors;
   // True if magic number/file header should be read.

--- a/src/interp/StreamReader.cpp
+++ b/src/interp/StreamReader.cpp
@@ -29,7 +29,7 @@ using namespace utils;
 namespace interp {
 
 StreamReader::StreamReader(std::shared_ptr<decode::Queue> StrmInput,
-                           Writer& Output,
+                           std::shared_ptr<Writer> Output,
                            std::shared_ptr<filt::SymbolTable> Symtab)
     : Reader(Output, Symtab),
       ReadPos(StreamType::Byte, StrmInput),

--- a/src/interp/StreamReader.h
+++ b/src/interp/StreamReader.h
@@ -34,7 +34,7 @@ class StreamReader : public Reader {
 
  public:
   StreamReader(std::shared_ptr<decode::Queue> Input,
-               Writer& Output,
+               std::shared_ptr<Writer> Output,
                std::shared_ptr<filt::SymbolTable> Symtab =
                    std::shared_ptr<filt::SymbolTable>());
   ~StreamReader() OVERRIDE;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -345,14 +345,14 @@ bool SymbolTable::installPredefinedDefaults(std::shared_ptr<SymbolTable> Symtab,
       std::make_shared<ArrayReader>(AlgArray, AlgArraySize);
   if (!Stream)
     return false;
-  InflateAst Inflator;
+  auto Inflator = std::make_shared<InflateAst>();
   StreamReader Reader(std::make_shared<ReadBackedQueue>(std::move(Stream)),
                       Inflator, Symtab);
   std::shared_ptr<TraceClass> Trace;
   if (TraceInstallation) {
     Trace = std::make_shared<TraceClass>("predefined");
     Reader.setTrace(Trace);
-    Inflator.setTrace(Trace);
+    Inflator->setTrace(Trace);
     Trace->setTraceProgress(true);
   }
   Reader.algorithmStart();

--- a/src/sexp/CasmReader.cpp
+++ b/src/sexp/CasmReader.cpp
@@ -75,14 +75,14 @@ void CasmReader::readText(charstring Filename) {
 
 void CasmReader::readBinary(std::shared_ptr<Queue> Binary,
                             std::shared_ptr<SymbolTable> AlgSymtab) {
-  InflateAst Inflator;
+  auto Inflator = std::make_shared<InflateAst>();
   auto Reader = std::make_shared<StreamReader>(Binary, Inflator, AlgSymtab);
   if (TraceRead || TraceTree) {
     auto Trace = std::make_shared<TraceClass>("CasmReader");
     Trace->setTraceProgress(true);
     Reader->setTrace(Trace);
     if (TraceTree)
-      Inflator.setTrace(Trace);
+      Inflator->setTrace(Trace);
   }
   Reader->algorithmStart();
   Reader->algorithmReadBackFilled();
@@ -90,7 +90,7 @@ void CasmReader::readBinary(std::shared_ptr<Queue> Binary,
     foundErrors();
     return;
   }
-  Symtab = Inflator.getSymtab();
+  Symtab = Inflator->getSymtab();
 }
 
 void CasmReader::readBinary(charstring Filename,

--- a/src/sexp/CasmWriter.cpp
+++ b/src/sexp/CasmWriter.cpp
@@ -74,7 +74,7 @@ const WriteCursor& CasmWriter::writeBinary(
     Tee->add(Writer, true, false, true);
     Writer = Tee;
   }
-  auto Reader = std::make_shared<IntReader>(IntSeq, *Writer, AlgSymtab);
+  auto Reader = std::make_shared<IntReader>(IntSeq, Writer, AlgSymtab);
   Reader->setFreezeEofAtExit(FreezeEofAtExit);
   if (TraceWriter || TraceTree) {
     auto Trace = std::make_shared<TraceClass>("CasmWriter");


### PR DESCRIPTION
Deals with the fact that in some contexts, the writer is created in a local scope, but the corresponding reader that uses the writer may have a longer lifetime.  Does this by using shared pointers, so that the dynamic scope cleans up when all uses are gone.