### PR TITLE
Show path (value) encodings on accept nodes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -998,6 +998,8 @@ test-parser: $(TEST_EXECDIR)/TestParser
 		diff - $(TEST_SRCS_DIR)/MismatchedParens.df-out
 	$< -w $(TEST_SRCS_DIR)/ExprRedirects.df | \
 		diff - $(TEST_SRCS_DIR)/ExprRedirects.df-out
+	$< -w $(TEST_SRCS_DIR)/BinaryFormat.cast | \
+		diff - $(TEST_SRCS_DIR)/BinaryFormat.cast-out
 	@echo "*** parser tests passed ***"
 
 .PHONY: test-parser

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -150,7 +150,6 @@ struct IntValue {
 %type <wasm::filt::Node *> file_header_args
 %type <wasm::filt::Node *> fixed_format_directive
 %type <wasm::filt::Node *> format_binary
-%type <wasm::filt::Node *> format_binary_tree
 %type <wasm::filt::Node *> format_directive
 %type <wasm::filt::Node *> literal_expression
 %type <wasm::filt::Node *> locals_decl
@@ -434,18 +433,14 @@ format_directive
         | "(" "varuint64" ")" {
             $$ = Driver.create<Varuint64Node>();
           }
-        | format_binary_tree { $$ = $1; }
+        | format_binary { $$ = $1; }
         ;
 
 format_binary
-        : format_binary_tree { $$ = $1; }
-        | "(" "accept" ")" {
-            $$ = Driver.create<BinaryAcceptNode>();
+        : "(" "accept" ")" {
+            $$ = Driver.getBinaryAcceptDefinition();
           }
-        ;
-
-format_binary_tree
-        : "(" "binary" format_binary format_binary {
+        | "(" "binary" format_binary format_binary ")" {
             $$ = Driver.create<BinarySelectNode>($3, $4);
           }
         ;

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -104,7 +104,6 @@
 
 //#define X(tag, NODE_DECLS)
 #define AST_NULLARYNODE_TABLE                                                  \
-  X(BinaryAccept,)                                                             \
   X(Error,)                                                                    \
   X(LastRead,)                                                                 \
   X(Uint32,)                                                                   \
@@ -124,6 +123,7 @@
 //   mergable: True if instances can be merged.
 //   NODE_DECLS: Other declarations for the node.
 #define AST_INTEGERNODE_TABLE                                                  \
+  X(BinaryAccept, Varuint32, 0, false, BINARYACCEPT_DECLS)                     \
   X(I32Const, Varint32, 0, true,)                                              \
   X(I64Const, Varint64, 0, true,)                                              \
   X(Local, Varuint32, 0, true,)                                                \
@@ -133,6 +133,9 @@
   X(U8Const, Uint8, 0, true,)                                                  \
   X(U32Const, Varuint32, 0, true,)                                             \
   X(U64Const, Varuint64, 0, true,)                                             \
+
+#define BINARYACCEPT_DECLS                                                     \
+  bool validateNode(NodeVectorType &Parents) OVERRIDE;                         \
 
 #define PARAM_DECLS                                                            \
   public:                                                                      \

--- a/src/sexp/FlattenAst.cpp
+++ b/src/sexp/FlattenAst.cpp
@@ -96,7 +96,6 @@ void FlattenAst::flattenNode(const Node* Nd) {
   TRACE(node_ptr, nullptr, Nd);
   switch (NodeType Opcode = Nd->getType()) {
     case NO_SUCH_NODETYPE:
-    case OpBinaryAccept:
     case OpBinarySelect:
     case OpUnknownSection: {
       reportError("Unexpected s-expression, can't write!");

--- a/test/test-sources/BinaryFormat.cast
+++ b/test/test-sources/BinaryFormat.cast
@@ -1,0 +1,24 @@
+(header (u32.const 0x6d736163) (u32.const 0x0))
+(void)
+
+(define 'file' (params)
+  (switch
+    (binary
+      (binary
+        (accept)
+        (binary
+          (accept)
+          (accept)
+        )
+      )
+      (accept)
+    )
+    (void)
+    # NOTE: Paths are parsed right-to-left, but use left-to-right encoding to make
+    # values unique.
+    (case (u32.const 0x0) (void)) # 00
+    (case (u32.const 0x2) (void)) # 010
+    (case (u32.const 0x6) (void)) # 110
+    (case (u32.const 0x1) (void)) # 1
+  )
+)

--- a/test/test-sources/BinaryFormat.cast-out
+++ b/test/test-sources/BinaryFormat.cast-out
@@ -1,0 +1,20 @@
+(header (u32.const 0x6d736163) (u32.const 0x0))
+(void)
+(define 'file' (params)
+  (switch (binary
+      (binary
+        (accept 0x0)
+        (binary
+          (accept 0x2)
+          (accept 0x6)
+        )
+      )
+      (accept 0x1)
+    )
+    (void)
+    (case (u32.const 0x0) (void))
+    (case (u32.const 0x2) (void))
+    (case (u32.const 0x6) (void))
+    (case (u32.const 0x1) (void))
+  )
+)


### PR DESCRIPTION
Encodes paths (from leaf to root) as the value of an accept node. This allows unique values to be associated with each accept, and can be used for case labels.

This also limits all binary format paths to not exceed 64 bits.
