### PR TITLE
Add command-line parser to limit number of abbreviations used.

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -100,6 +100,15 @@ int main(int Argc, const char* Argv[]) {
                      "execution time grows non-linearly when this value "
                      " is increased)"));
 
+    ArgsParser::Optional<size_t> MaxAbbreviationsFlag(
+        CompressionFlags.MaxAbbreviations);
+    Args.add(
+        MaxAbbreviationsFlag.setDefault(8192)
+            .setLongName("max-abbreviations")
+            .setOptionName("INTEGER")
+            .setDescription(
+                "Maximum number of abbreviations allowed in compressed file"));
+
     ArgsParser::Optional<bool> TraceReadingInputFlag(
         CompressionFlags.TraceReadingInput);
     Args.add(
@@ -174,8 +183,9 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Optional<bool> TraceAssigningAbbreviationsFlag(
         CompressionFlags.TraceAssigningAbbreviations);
-    Args.add(TraceAssigningAbbreviationsFlag.setLongName("verbose=assign-abbrevs")
-             .setDescription("Show how abbreviations are assigned"));
+    Args.add(
+        TraceAssigningAbbreviationsFlag.setLongName("verbose=assign-abbrevs")
+            .setDescription("Show how abbreviations are assigned"));
 
     ArgsParser::Optional<bool> TraceCompressedIntOutputFlag(
         CompressionFlags.TraceCompressedIntOutput);

--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -41,19 +41,25 @@ void AbbreviationsCollector::assignAbbreviations() {
   {
     CountNode::PtrVector Others;
     Root->getOthers(Others);
-    for (CountNode::Ptr Nd : Others)
-      addAbbreviation(Nd);
-  }
-  TRACE(uint64_t, "WeightCutoff", WeightCutoff);
-  collect(makeFlags(CollectionFlag::All));
-  buildHeap();
-  while (!ValuesHeap->empty()) {
-    CountNode::Ptr Nd = popHeap();
-    TRACE_BLOCK({
+    for (CountNode::Ptr Nd : Others) {
+      TRACE_BLOCK({
         FILE* Out = getTrace().getFile();
         fprintf(Out, "Considering: ");
         Nd->describe(Out);
       });
+      addAbbreviation(Nd);
+    }
+  }
+  TRACE(uint64_t, "WeightCutoff", WeightCutoff);
+  collect(makeFlags(CollectionFlag::All));
+  buildHeap();
+  while (!ValuesHeap->empty() && Assignments.size() < MaxAbbreviations) {
+    CountNode::Ptr Nd = popHeap();
+    TRACE_BLOCK({
+      FILE* Out = getTrace().getFile();
+      fprintf(Out, "Considering: ");
+      Nd->describe(Out);
+    });
     if (isa<IntCountNode>(*Nd) && Nd->getWeight() < WeightCutoff) {
       fprintf(stderr, "Removing due to weight cutoff\n");
       continue;

--- a/src/intcomp/AbbreviationsCollector.h
+++ b/src/intcomp/AbbreviationsCollector.h
@@ -29,8 +29,10 @@ class AbbreviationsCollector : public CountNodeCollector {
  public:
   AbbreviationsCollector(CountNode::RootPtr Root,
                          interp::IntTypeFormat AbbrevFormat,
-                         CountNode::PtrVector& Assignments)
+                         CountNode::PtrVector& Assignments,
+                         size_t MaxAbbreviations)
       : CountNodeCollector(Root),
+        MaxAbbreviations(MaxAbbreviations),
         AbbrevFormat(AbbrevFormat),
         Assignments(Assignments) {}
   void assignAbbreviations();
@@ -45,6 +47,7 @@ class AbbreviationsCollector : public CountNodeCollector {
   bool hasTrace() const { return bool(Trace); }
 
  private:
+  const size_t MaxAbbreviations;
   interp::IntTypeFormat AbbrevFormat;
   CountNode::PtrVector& Assignments;
   std::shared_ptr<utils::TraceClass> Trace;

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -78,12 +78,12 @@ void CountNodeCollector::collectNode(CountNode::Ptr Nd, CollectionFlags Flags) {
     Nd = ToAdd.back();
     ToAdd.pop_back();
     if (!Nd)  // This shouldn't happen, but be safe.
-     continue;
+      continue;
     TRACE_BLOCK({
-        FILE* Out = getTrace().getFile();
-        fprintf(Out, "Consider: ");
-        Nd->describe(Out);
-      });
+      FILE* Out = getTrace().getFile();
+      fprintf(Out, "Consider: ");
+      Nd->describe(Out);
+    });
     auto* IntNd = dyn_cast<IntCountNode>(Nd.get());
     bool IsIntNode = IntNd != nullptr;
     uint64_t Weight = Nd->getWeight();

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -43,6 +43,7 @@ class IntCompressor FINAL {
     uint64_t CountCutoff;
     uint64_t WeightCutoff;
     size_t LengthLimit;
+    size_t MaxAbbreviations;
     interp::IntTypeFormat AbbrevFormat;
     bool MinimizeCodeSize;
     bool TraceReadingInput;
@@ -94,12 +95,15 @@ class IntCompressor FINAL {
     describeCutoff(Out, MyFlags.CountCutoff, MyFlags.WeightCutoff, Flags);
   }
 
-  void describeCutoff(FILE* Out, uint64_t CountCutoff,
+  void describeCutoff(FILE* Out,
+                      uint64_t CountCutoff,
                       CollectionFlags Flags = makeFlags(CollectionFlag::All)) {
     describeCutoff(Out, CountCutoff, CountCutoff, Flags);
   }
 
-  void describeCutoff(FILE* Out, uint64_t CountCutoff, uint64_t WeightCutoff,
+  void describeCutoff(FILE* Out,
+                      uint64_t CountCutoff,
+                      uint64_t WeightCutoff,
                       CollectionFlags Flags = makeFlags(CollectionFlag::All));
 
  private:


### PR DESCRIPTION
Experimented with limiting the number of abbreviations to see if there is a sweet spot where compression occurs. Discovered that for the banana bread example, we can compress the file 25% by limiting the number (verses 3% with unlimited number of abbreviations) of abbreviations to 8196. Hence, added a command-line argument to allow user-controlled experimentation.