### PR TITLE
Extend heap implementation to define ordering as argument.

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -169,6 +169,12 @@ int main(int Argc, const char* Argv[]) {
         TraceIntCountsFlag.setLongName("verbose=int-counts")
             .setDescription("Show frequency of integers in the input stream"));
 
+    ArgsParser::Optional<bool> TraceIntCountsCollectionFlag(
+        CompressionFlags.TraceIntCountsCollection);
+    Args.add(TraceIntCountsCollectionFlag.setLongName(
+                                              "verbose=int-counts-collection")
+                 .setDescription("Show how int counts were selected"));
+
     ArgsParser::Optional<bool> TraceSequenceCountsFlag(
         CompressionFlags.TraceSequenceCounts);
     Args.add(TraceSequenceCountsFlag.setLongName("verbose=seq-counts")
@@ -176,10 +182,27 @@ int main(int Argc, const char* Argv[]) {
                      "Show frequency of integer sequences in the "
                      "input stream"));
 
+    ArgsParser::Optional<bool> TraceSequenceCountsCollectionFlag(
+        CompressionFlags.TraceSequenceCountsCollection);
+    Args.add(
+        TraceSequenceCountsCollectionFlag.setLongName(
+                                              "verbose=seq-counts-collection")
+            .setDescription(
+                "Show how frequency of integer sequences were "
+                "selected"));
+
     ArgsParser::Optional<bool> TraceAbbreviationAssignmentsFlag(
         CompressionFlags.TraceAbbreviationAssignments);
     Args.add(TraceAbbreviationAssignmentsFlag.setLongName("verbose=abbrev")
                  .setDescription("Show (initial) abbreviation assignments"));
+
+    ArgsParser::Optional<bool> TraceAbbreviationAssignmentsCollectionFlag(
+        CompressionFlags.TraceAbbreviationAssignmentsCollection);
+    Args.add(TraceAbbreviationAssignmentsCollectionFlag
+                 .setLongName("vebose=abbrev-collection")
+                 .setDescription(
+                     "Show how the (initial) abbreviation assignments "
+                     "were selected"));
 
     ArgsParser::Optional<bool> TraceAssigningAbbreviationsFlag(
         CompressionFlags.TraceAssigningAbbreviations);

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -71,7 +71,6 @@ void CountNodeCollector::collect(CollectionFlags Flags) {
 
 void CountNodeCollector::collectNode(CountNode::Ptr Nd, CollectionFlags Flags) {
   TRACE_METHOD("collectNode");
-  TRACE_BLOCK({ Nd->describe(stderr); });
   std::vector<CountNode::Ptr> ToAdd;
   ToAdd.push_back(Nd);
   while (!ToAdd.empty()) {
@@ -79,11 +78,7 @@ void CountNodeCollector::collectNode(CountNode::Ptr Nd, CollectionFlags Flags) {
     ToAdd.pop_back();
     if (!Nd)  // This shouldn't happen, but be safe.
       continue;
-    TRACE_BLOCK({
-      FILE* Out = getTrace().getFile();
-      fprintf(Out, "Consider: ");
-      Nd->describe(Out);
-    });
+    TRACE_BLOCK({ Nd->describe(getTrace().getFile()); });
     auto* IntNd = dyn_cast<IntCountNode>(Nd.get());
     bool IsIntNode = IntNd != nullptr;
     uint64_t Weight = Nd->getWeight();

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -30,6 +30,23 @@ void CountNodeCollector::setTrace(std::shared_ptr<TraceClass> NewTrace) {
   Trace = NewTrace;
 }
 
+CountNodeCollector::CountNodeCollector(CountNode::RootPtr Root)
+    : Root(Root),
+      ValuesHeap(std::make_shared<CountNode::HeapType>(CountNode::CompareLt)),
+      WeightTotal(0),
+      CountTotal(0),
+      WeightReported(0),
+      CountReported(0),
+      NumNodesReported(0),
+      CountCutoff(1),
+      WeightCutoff(1) {
+}
+
+void CountNodeCollector::setCompareFcn(CountNode::CompareFcnType LtFcn) {
+  assert(ValuesHeap->empty());
+  ValuesHeap->setLtFcn(LtFcn);
+}
+
 std::shared_ptr<TraceClass> CountNodeCollector::getTracePtr() {
   if (!Trace)
     setTrace(std::make_shared<TraceClass>("IntCompress"));

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -47,6 +47,7 @@ void CountNodeCollector::setCompareFcn(CountNode::CompareFcnType LtFcn) {
   ValuesHeap->setLtFcn(LtFcn);
 }
 
+
 std::shared_ptr<TraceClass> CountNodeCollector::getTracePtr() {
   if (!Trace)
     setTrace(std::make_shared<TraceClass>("IntCompress"));

--- a/src/intcomp/CountNodeCollector.h
+++ b/src/intcomp/CountNodeCollector.h
@@ -42,17 +42,11 @@ class CountNodeCollector {
   uint64_t WeightCutoff;
   std::shared_ptr<utils::TraceClass> Trace;
 
-  explicit CountNodeCollector(CountNode::RootPtr Root)
-      : Root(Root),
-        ValuesHeap(std::make_shared<CountNode::HeapType>()),
-        WeightTotal(0),
-        CountTotal(0),
-        WeightReported(0),
-        CountReported(0),
-        NumNodesReported(0),
-        CountCutoff(1),
-        WeightCutoff(1) {}
+  explicit CountNodeCollector(CountNode::RootPtr Root);
   ~CountNodeCollector() { clear(); }
+
+  // Note: Can only be applied when the heap is empty!
+  void setCompareFcn(CountNode::CompareFcnType LtFcn);
 
   void collect(CollectionFlags Flags = makeFlags(CollectionFlag::All));
   void buildHeap();

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -69,8 +69,11 @@ IntCompressor::Flags::Flags()
       TraceCodeGenerationForWriting(false),
       TraceInputIntStream(false),
       TraceIntCounts(false),
+      TraceIntCountsCollection(false),
       TraceSequenceCounts(false),
+      TraceSequenceCountsCollection(false),
       TraceAbbreviationAssignments(false),
+      TraceAbbreviationAssignmentsCollection(false),
       TraceAssigningAbbreviations(false),
       TraceCompressedIntOutput(false) {
 }
@@ -194,7 +197,8 @@ void IntCompressor::compress() {
     return;
   if (MyFlags.TraceIntCounts)
     describeCutoff(stderr, MyFlags.CountCutoff,
-                   makeFlags(CollectionFlag::TopLevel));
+                   makeFlags(CollectionFlag::TopLevel),
+                   MyFlags.TraceIntCountsCollection);
   removeSmallUsageCounts();
   if (MyFlags.LengthLimit > 1) {
     if (!compressUpToSize(MyFlags.LengthLimit))
@@ -203,13 +207,14 @@ void IntCompressor::compress() {
   }
   if (MyFlags.TraceSequenceCounts)
     describeCutoff(stderr, MyFlags.WeightCutoff,
-                   makeFlags(CollectionFlag::IntPaths));
+                   makeFlags(CollectionFlag::IntPaths),
+                   MyFlags.TraceSequenceCountsCollection);
   TRACE_MESSAGE("Assigning (initial) abbreviations to integer sequences");
   CountNode::PtrVector AbbrevAssignments;
   assignInitialAbbreviations(AbbrevAssignments);
   if (MyFlags.TraceAbbreviationAssignments)
-    describeCutoff(stderr, MyFlags.WeightCutoff,
-                   makeFlags(CollectionFlag::All));
+    describeCutoff(stderr, MyFlags.WeightCutoff, makeFlags(CollectionFlag::All),
+                   MyFlags.TraceAbbreviationAssignmentsCollection);
   IntOutput = std::make_shared<IntStream>();
   TRACE_MESSAGE("Generating compressed integer stream");
   if (!generateIntOutput())
@@ -272,9 +277,10 @@ std::shared_ptr<SymbolTable> IntCompressor::generateCode(
 void IntCompressor::describeCutoff(FILE* Out,
                                    uint64_t CountCutoff,
                                    uint64_t WeightCutoff,
-                                   CollectionFlags Flags) {
+                                   CollectionFlags Flags,
+                                   bool Trace) {
   CountNodeCollector Collector(getRoot());
-  if (hasTrace())
+  if (Trace)
     Collector.setTrace(getTracePtr());
   Collector.CountCutoff = CountCutoff;
   Collector.WeightCutoff = WeightCutoff;

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -56,8 +56,11 @@ class IntCompressor FINAL {
     bool TraceCodeGenerationForWriting;
     bool TraceInputIntStream;
     bool TraceIntCounts;
+    bool TraceIntCountsCollection;
     bool TraceSequenceCounts;
+    bool TraceSequenceCountsCollection;
     bool TraceAbbreviationAssignments;
+    bool TraceAbbreviationAssignmentsCollection;
     bool TraceAssigningAbbreviations;
     bool TraceCompressedIntOutput;
     std::shared_ptr<utils::TraceClass> Trace;
@@ -91,20 +94,24 @@ class IntCompressor FINAL {
   bool hasTrace() { return bool(MyFlags.Trace); }
 
   void describe(FILE* Out,
-                CollectionFlags Flags = makeFlags(CollectionFlag::All)) {
-    describeCutoff(Out, MyFlags.CountCutoff, MyFlags.WeightCutoff, Flags);
+                CollectionFlags Flags = makeFlags(CollectionFlag::All),
+                bool Trace = false) {
+    describeCutoff(Out, MyFlags.CountCutoff, MyFlags.WeightCutoff, Flags,
+                   Trace);
   }
 
   void describeCutoff(FILE* Out,
                       uint64_t CountCutoff,
-                      CollectionFlags Flags = makeFlags(CollectionFlag::All)) {
-    describeCutoff(Out, CountCutoff, CountCutoff, Flags);
+                      CollectionFlags Flags = makeFlags(CollectionFlag::All),
+                      bool Trace = false) {
+    describeCutoff(Out, CountCutoff, CountCutoff, Flags, Trace);
   }
 
   void describeCutoff(FILE* Out,
                       uint64_t CountCutoff,
                       uint64_t WeightCutoff,
-                      CollectionFlags Flags = makeFlags(CollectionFlag::All));
+                      CollectionFlags Flags = makeFlags(CollectionFlag::All),
+                      bool Trace = false);
 
  private:
   std::shared_ptr<RootCountNode> Root;

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -54,6 +54,14 @@ using namespace interp;
 
 namespace intcomp {
 
+// NOTE(karlschimpf): Created here because g++ version on Travis not happy
+// when used in initializer to heap.
+std::function<bool(CountNode::Ptr, CountNode::Ptr)> CountNode::CompareLt =
+    [](CountNode::Ptr V1, CountNode::Ptr V2) { return V1 < V2; };
+
+std::function<bool(CountNode::Ptr, CountNode::Ptr)> CountNode::CompareGt =
+    [](CountNode::Ptr V1, CountNode::Ptr V2) { return V1 > V2; };
+
 const decode::IntType CountNode::BAD_ABBREV_INDEX =
     std::numeric_limits<decode::IntType>::max();
 

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -62,8 +62,12 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
   typedef Ptr HeapValueType;
   typedef utils::heap<HeapValueType> HeapType;
   typedef std::shared_ptr<HeapType::entry> HeapEntryType;
+  typedef std::function<bool(Ptr, Ptr)> CompareFcnType;
 
   static const decode::IntType BAD_ABBREV_INDEX;
+
+  static CompareFcnType CompareLt;
+  static CompareFcnType CompareGt;
 
   virtual ~CountNode();
   enum class Kind { Root, Block, Default, Singleton, IntSequence };

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -147,13 +147,8 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
       size_t ParentIndex = getParentIndex(KidIndex);
       auto& Parent = Contents[ParentIndex];
       auto& Kid = Contents[KidIndex];
-#if 0
-      if (!(Kid->getValue() < Parent->getValue()))
-        return Moved;
-#else
       if (!LtFcn(Kid->getValue(), Parent->getValue()))
         return Moved;
-#endif
       std::swap(Parent, Kid);
       Parent->Index = KidIndex;
       Kid->Index = ParentIndex;
@@ -170,20 +165,14 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
       size_t KidIndex = ParentIndex;
       if (LeftKidIndex >= Contents.size())
         return;
-      if (Contents[LeftKidIndex]->getValue() <
-          Contents[ParentIndex]->getValue())
+      if (LtFcn(Contents[LeftKidIndex]->getValue(),
+                Contents[ParentIndex]->getValue()))
         KidIndex = LeftKidIndex;
       size_t RightKidIndex = getRightKidIndex(ParentIndex);
       if (RightKidIndex < Contents.size()) {
-#if 0
-        if (Contents[RightKidIndex]->getValue() <
-            Contents[KidIndex]->getValue())
-          KidIndex = RightKidIndex;
-#else
         if (LtFcn(Contents[RightKidIndex]->getValue(),
                   Contents[KidIndex]->getValue()))
           KidIndex = RightKidIndex;
-#endif
       }
       if (KidIndex == ParentIndex)
         return;

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -92,9 +92,9 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
   // WARNING: Only create using std::make_shared<heap<value_type>>(); DO NOT
   // call constructor directly!
   heap(CompareFcn LtFcn =
-       // TODO(karlschimpf): Why didn't std::less<Value_type>() not work!
-       [](value_type V1, value_type V2) { return V1 < V2; }
-       ) : LtFcn(LtFcn) {}
+           // TODO(karlschimpf): Why didn't std::less<Value_type>() not work!
+       [](value_type V1, value_type V2) { return V1 < V2; })
+      : LtFcn(LtFcn) {}
 
   ~heap() {}
 

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -91,12 +91,18 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
   typedef std::function<bool(value_type, value_type)> CompareFcn;
   // WARNING: Only create using std::make_shared<heap<value_type>>(); DO NOT
   // call constructor directly!
-  heap(CompareFcn LtFcn =
-           // TODO(karlschimpf): Why didn't std::less<Value_type>() not work!
-       [](value_type V1, value_type V2) { return V1 < V2; })
+  heap(CompareFcn LtFcn  // =
+       // TODO(karlschimpf): Why didn't std::less<Value_type>() not work!
+       // [](value_type V1, value_type V2) { return V1 < V2; }
+       )
       : LtFcn(LtFcn) {}
 
   ~heap() {}
+
+  heap& setLtFcn(CompareFcn NewLtFcn) {
+    LtFcn = NewLtFcn;
+    return *this;
+  }
 
   bool empty() const { return Contents.empty(); }
 


### PR DESCRIPTION
This is in preparation for generating Huffman encodings, which needs to sort elements by smallest (rather than largest) patterns.