### PR TITLE
Change abbreviation assignments from vector to map.

### DIFF
--- a/src/intcomp/AbbreviationCodegen.cpp
+++ b/src/intcomp/AbbreviationCodegen.cpp
@@ -30,7 +30,7 @@ namespace intcomp {
 
 AbbreviationCodegen::AbbreviationCodegen(CountNode::RootPtr Root,
                                          IntTypeFormat AbbrevFormat,
-                                         CountNode::PtrVector& Assignments)
+                                         CountNode::Int2PtrMap& Assignments)
     : Root(Root), AbbrevFormat(AbbrevFormat), Assignments(Assignments) {
 }
 

--- a/src/intcomp/AbbreviationCodegen.h
+++ b/src/intcomp/AbbreviationCodegen.h
@@ -34,7 +34,7 @@ class AbbreviationCodegen {
  public:
   AbbreviationCodegen(CountNode::RootPtr Root,
                       interp::IntTypeFormat AbbrevFormat,
-                      CountNode::PtrVector& Assignments);
+                      CountNode::Int2PtrMap& Assignments);
   ~AbbreviationCodegen();
 
   std::shared_ptr<filt::SymbolTable> getCodeSymtab(bool ToRead);
@@ -43,7 +43,7 @@ class AbbreviationCodegen {
   std::shared_ptr<filt::SymbolTable> Symtab;
   CountNode::RootPtr Root;
   interp::IntTypeFormat AbbrevFormat;
-  CountNode::PtrVector& Assignments;
+  CountNode::Int2PtrMap& Assignments;
   bool ToRead;
   filt::Node* generateCasmFileHeader();
   filt::Node* generateWasmFileHeader();

--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -74,9 +74,10 @@ void AbbreviationsCollector::assignAbbreviations() {
 void AbbreviationsCollector::addAbbreviation(CountNode::Ptr Nd) {
   if (Nd->hasAbbrevIndex())
     return;
-  TRACE(size_t, "Abbreviation", Assignments.size());
-  Nd->setAbbrevIndex(Assignments.size());
-  Assignments.push_back(Nd);
+  size_t NdIndex = getNextAvailableIndex();
+  TRACE(size_t, "Abbreviation", NdIndex);
+  Nd->setAbbrevIndex(NdIndex);
+  Assignments[NdIndex] = Nd;
 }
 
 }  // end of namespace intcomp

--- a/src/intcomp/AbbreviationsCollector.h
+++ b/src/intcomp/AbbreviationsCollector.h
@@ -29,17 +29,13 @@ class AbbreviationsCollector : public CountNodeCollector {
  public:
   AbbreviationsCollector(CountNode::RootPtr Root,
                          interp::IntTypeFormat AbbrevFormat,
-                         CountNode::PtrVector& Assignments,
+                         CountNode::Int2PtrMap& Assignments,
                          size_t MaxAbbreviations)
       : CountNodeCollector(Root),
         MaxAbbreviations(MaxAbbreviations),
         AbbrevFormat(AbbrevFormat),
         Assignments(Assignments) {}
   void assignAbbreviations();
-
-  size_t getNextAvailableIndex() const { return Assignments.size(); }
-
-  void addAbbreviation(CountNode::Ptr Nd);
 
   utils::TraceClass& getTrace() { return *getTracePtr(); }
   std::shared_ptr<utils::TraceClass> getTracePtr();
@@ -49,8 +45,12 @@ class AbbreviationsCollector : public CountNodeCollector {
  private:
   const size_t MaxAbbreviations;
   interp::IntTypeFormat AbbrevFormat;
-  CountNode::PtrVector& Assignments;
+  CountNode::Int2PtrMap& Assignments;
   std::shared_ptr<utils::TraceClass> Trace;
+
+  size_t getNextAvailableIndex() const { return Assignments.size(); }
+
+  void addAbbreviation(CountNode::Ptr Nd);
 };
 
 }  // end of namespace intcomp

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -47,7 +47,6 @@ void CountNodeCollector::setCompareFcn(CountNode::CompareFcnType LtFcn) {
   ValuesHeap->setLtFcn(LtFcn);
 }
 
-
 std::shared_ptr<TraceClass> CountNodeCollector::getTracePtr() {
   if (!Trace)
     setTrace(std::make_shared<TraceClass>("IntCompress"));

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -210,7 +210,7 @@ void IntCompressor::compress() {
                    makeFlags(CollectionFlag::IntPaths),
                    MyFlags.TraceSequenceCountsCollection);
   TRACE_MESSAGE("Assigning (initial) abbreviations to integer sequences");
-  CountNode::PtrVector AbbrevAssignments;
+  CountNode::Int2PtrMap AbbrevAssignments;
   assignInitialAbbreviations(AbbrevAssignments);
   if (MyFlags.TraceAbbreviationAssignments)
     describeCutoff(stderr, MyFlags.WeightCutoff, makeFlags(CollectionFlag::All),
@@ -239,7 +239,7 @@ void IntCompressor::compress() {
 }
 
 void IntCompressor::assignInitialAbbreviations(
-    CountNode::PtrVector& Assignments) {
+    CountNode::Int2PtrMap& Assignments) {
   AbbreviationsCollector Collector(getRoot(), MyFlags.AbbrevFormat, Assignments,
                                    MyFlags.MaxAbbreviations);
   if (MyFlags.TraceAssigningAbbreviations && hasTrace())
@@ -262,7 +262,7 @@ bool IntCompressor::generateIntOutput() {
 }
 
 std::shared_ptr<SymbolTable> IntCompressor::generateCode(
-    CountNode::PtrVector& Assignments,
+    CountNode::Int2PtrMap& Assignments,
     bool ToRead,
     bool Trace) {
   AbbreviationCodegen Codegen(Root, MyFlags.AbbrevFormat, Assignments);

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -129,17 +129,17 @@ class IntCompressor FINAL {
                        std::shared_ptr<filt::SymbolTable> Symtab);
   bool compressUpToSize(size_t Size);
   void removeSmallUsageCounts();
-  void assignInitialAbbreviations(CountNode::PtrVector& Assignments);
+  void assignInitialAbbreviations(CountNode::Int2PtrMap& Assignments);
   bool generateIntOutput();
   std::shared_ptr<filt::SymbolTable>
-  generateCode(CountNode::PtrVector& Assignments, bool ToRead, bool Trace);
+  generateCode(CountNode::Int2PtrMap& Assignments, bool ToRead, bool Trace);
   std::shared_ptr<filt::SymbolTable> generateCodeForReading(
-      CountNode::PtrVector& Assignments) {
+      CountNode::Int2PtrMap& Assignments) {
     return generateCode(Assignments, true,
                         MyFlags.TraceCodeGenerationForReading);
   }
   std::shared_ptr<filt::SymbolTable> generateCodeForWriting(
-      CountNode::PtrVector& Assignments) {
+      CountNode::Int2PtrMap& Assignments) {
     return generateCode(Assignments, false,
                         MyFlags.TraceCodeGenerationForWriting);
   }

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -58,6 +58,7 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
   typedef std::shared_ptr<CountNodeWithSuccs> WithSuccsPtr;
   typedef std::map<decode::IntType, CountNode::IntPtr> SuccMap;
   typedef std::vector<Ptr> PtrVector;
+  typedef std::map<size_t, Ptr> Int2PtrMap;
   typedef SuccMap::const_iterator SuccMapIterator;
   typedef Ptr HeapValueType;
   typedef utils::heap<HeapValueType> HeapType;


### PR DESCRIPTION
This is necessary in order to handle Huffman encoding, which can leave gaps in abbreviation values (depending on the probability of the abbreviations).