### PR TITLE
Initial implementation of Huffman encoding an alphabet.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ UTILS_SRCS = \
 	Allocator.cpp \
 	ArgsParse.cpp \
 	Defs.cpp \
+	HuffmanEncoding.cpp \
 	Trace.cpp
 
 UTILS_OBJS=$(patsubst %.cpp, $(UTILS_OBJDIR)/%.o, $(UTILS_SRCS))

--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -82,8 +82,21 @@ void AbbreviationsCollector::assignHuffmanAbbreviations() {
     Pair.second->clearAbbrevIndex();
   }
   Assignments.clear();
-  // Now build heap (sorted by smaller weights first) to assign abbreviation
-  // values.
+  clearHeap();
+// Now build heap (sorted by smaller weights first) to assign abbreviation
+// values.
+#if 0
+  ValuesHeap.setLtFcn(CountNode::CompareGt);
+  for (auto& Nd : Alphabet)
+    Nd->associateWithHeap(ValuesHeap->push(Value));
+  // Create nodes over two smallest values in heap.
+  while (ValuesHeap.size() > 1) {
+    Ptr Nd1 = ValuesHeap.top();
+    ValuesHeap.pop();
+    Ptr Nd2 = ValuesHeap.top();
+    ValuesHeap.pop();
+  }
+#endif
 }
 
 void AbbreviationsCollector::addAbbreviation(CountNode::Ptr Nd) {

--- a/src/utils/HuffmanEncoding.cpp
+++ b/src/utils/HuffmanEncoding.cpp
@@ -1,0 +1,187 @@
+/* -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements a binary tree encoding huffman values.
+
+#include "utils/HuffmanEncoding.h"
+
+#include "utils/heap.h"
+
+#include <algorithm>
+
+namespace wasm {
+
+using namespace decode;
+
+namespace utils {
+
+// Define ordering over nodes, so that we can use a heap to extract smallest
+// weighted subtrees.
+bool operator<(HuffmanEncoder::NodePtr T1, HuffmanEncoder::NodePtr T2) {
+  return T1->getWeight() < T2->getWeight();
+}
+
+HuffmanEncoder::Node::Node(NodeType Type, WeightType Weight, unsigned NumBits)
+    : Type(Type), Weight(Weight), NumBits(NumBits) {
+}
+
+HuffmanEncoder::Node::~Node() {
+}
+
+HuffmanEncoder::Symbol::Symbol(WeightType Weight)
+    : Node(NodeType::Symbol, Weight, 1), Path(0) {
+}
+
+HuffmanEncoder::Symbol::~Symbol() {
+}
+
+HuffmanEncoder::NodePtr HuffmanEncoder::Symbol::installPaths(NodePtr Self,
+                                                             PathType Path,
+                                                             unsigned NumBits) {
+  if (NumBits > MaxPathLength)
+    return NodePtr();
+  this->Path = Path;
+  this->NumBits = NumBits;
+  return Self;
+}
+
+size_t HuffmanEncoder::Symbol::nodeSize() const {
+  return 1;
+}
+
+HuffmanEncoder::Selector::Selector(NodePtr Kid1, NodePtr Kid2)
+    : Node(NodeType::Selector,
+           Kid1->getWeight() + Kid2->getWeight(),
+           std::max(Kid1->getNumBits(), Kid2->getNumBits()) + 1),
+      Kid1(Kid1),
+      Kid2(Kid2),
+      Size(Kid1->nodeSize() + Kid2->nodeSize()) {
+}
+
+void HuffmanEncoder::Selector::FixFields() {
+  Weight = Kid1->getWeight() + Kid2->getWeight();
+  NumBits = std::max(Kid1->getNumBits(), Kid2->getNumBits()) + 1;
+  Size = Kid1->nodeSize() + Kid2->nodeSize();
+}
+
+HuffmanEncoder::Selector::~Selector() {
+}
+
+HuffmanEncoder::NodePtr HuffmanEncoder::Selector::installPaths(
+    NodePtr Self,
+    PathType Path,
+    unsigned NumBits) {
+  PathType KidPath = Path << 1;
+  unsigned KidBits = NumBits + 1;
+  NodePtr K1 = Kid1->installPaths(Kid1, KidPath, KidBits);
+  NodePtr K2 = Kid2->installPaths(Kid2, KidPath + 1, KidBits);
+  if (K1 && K2) {
+    assert(isa<Selector>(Self.get()));
+    auto Sel = cast<Selector>(Self);
+    Sel->Kid1 = K1;
+    Sel->Kid2 = K2;
+    return Self;
+  }
+
+  // Tree is too deep. See if flattened binary tree will fit.
+  unsigned BitsNeeded = 0;
+  size_t Count = Size;
+  while (Count > 0) {
+    ++BitsNeeded;
+    Count >>= 1;
+  }
+  if (NumBits + BitsNeeded > MaxPathLength)
+    // Can't fix at this node, go to parent.
+    return NodePtr();
+
+  // Can flatten tree at this depth. Flatten and assign paths.
+  std::vector<NodePtr> Symbols;
+  std::vector<NodePtr> ToVisit;
+  ToVisit.push_back(Kid1);
+  ToVisit.push_back(Kid2);
+  while (!ToVisit.empty()) {
+    NodePtr Nd = ToVisit.back();
+    ToVisit.pop_back();
+    if (isa<Symbol>(Nd.get())) {
+      Symbols.push_back(Nd);
+      continue;
+    }
+    assert(isa<Selector>(Nd.get()));
+    auto Sel = cast<Selector>(Nd.get());
+    ToVisit.push_back(Sel->getKid1());
+    ToVisit.push_back(Sel->getKid2());
+  }
+  std::vector<NodePtr>* Ply1 = &Symbols;
+  std::vector<NodePtr>* Ply2 = &ToVisit;
+  while (Ply1->size() > 1) {
+    while (Ply1->size() >= 2) {
+      NodePtr N1 = Ply1->back();
+      Ply1->pop_back();
+      NodePtr N2 = Ply1->back();
+      Ply1->pop_back();
+      Ply2->push_back(std::make_shared<Selector>(N1, N2));
+    }
+    if (!Ply1->empty()) {
+      Ply2->push_back(Ply1->back());
+      Ply1->pop_back();
+    }
+    std::reverse(Ply2->begin(), Ply2->end());
+    std::swap(Ply1, Ply2);
+  }
+  NodePtr Root = Ply1->front();
+  // Double check that flattening was done correctly.
+  assert(Root->getNumBits() + NumBits <= MaxPathLength);
+  return Root->installPaths(Root, Path, NumBits);
+}
+
+size_t HuffmanEncoder::Selector::nodeSize() const {
+  return Size;
+}
+
+HuffmanEncoder::HuffmanEncoder() {
+}
+
+HuffmanEncoder::~HuffmanEncoder() {
+}
+
+void HuffmanEncoder::add(SymbolPtr Sym) {
+  Alphabet.push_back(Sym);
+}
+
+HuffmanEncoder::NodePtr HuffmanEncoder::encodeSymbols() {
+  if (Alphabet.empty())
+    return NodePtr();
+  heap<NodePtr> Heap((std::less<NodePtr>()));
+  for (NodePtr& Sym : Alphabet)
+    Heap.push(Sym);
+  while (Heap.size() >= 2) {
+    NodePtr N1 = Heap.top()->getValue();
+    Heap.pop();
+    NodePtr N2 = Heap.top()->getValue();
+    Heap.pop();
+    NodePtr Sel = std::make_shared<Selector>(N1, N2);
+    Heap.push(Sel);
+  }
+  NodePtr Root = Heap.top()->getValue();
+  Root = Root->installPaths(Root, 0, 0);
+  if (!Root)
+    fatal("Can't build Huffman encoding for alphabet!");
+  return Root;
+}
+
+}  // end of namespace utils
+
+}  // end of namespace wasm

--- a/src/utils/HuffmanEncoding.h
+++ b/src/utils/HuffmanEncoding.h
@@ -68,10 +68,9 @@ class HuffmanEncoder : public std::enable_shared_from_this<HuffmanEncoder> {
     friend class HuffmanEncoder;
 
    public:
-    explicit Node(NodeType Type, WeightType Weight, unsigned NumBits);
+    explicit Node(NodeType Type, WeightType Weight);
     virtual ~Node();
     WeightType getWeight() const { return Weight; }
-    unsigned getNumBits() const { return NumBits; }
 
     NodeType getRtClassId() const { return Type; }
 
@@ -79,8 +78,6 @@ class HuffmanEncoder : public std::enable_shared_from_this<HuffmanEncoder> {
     const NodeType Type;
     // The weight of all symbols in the subtree.
     WeightType Weight;
-    // The number of bits needed to represent all paths in subtree.
-    unsigned NumBits;
     // Note: Installs Huffman encoding values into leaves, based on path and
     // number of bits. Returns false if parent needs to rebalance because
     // it was unable to install with path limit.
@@ -103,6 +100,7 @@ class HuffmanEncoder : public std::enable_shared_from_this<HuffmanEncoder> {
     ~Symbol() OVERRIDE;
 
     PathType getPath() const { return Path; }
+    unsigned getNumBits() const { return NumBits; }
 
     static bool implementsClass(NodeType Type) {
       return Type == NodeType::Symbol;
@@ -116,6 +114,7 @@ class HuffmanEncoder : public std::enable_shared_from_this<HuffmanEncoder> {
 
    private:
     PathType Path;
+    unsigned NumBits;
   };
 
   // Defines (binary) selector tree node.
@@ -130,14 +129,13 @@ class HuffmanEncoder : public std::enable_shared_from_this<HuffmanEncoder> {
 
     NodePtr getKid1() const { return Kid1; }
     NodePtr getKid2() const { return Kid2; }
-    NodePtr getKid(unsigned i) const;
 
     static bool implementsClass(NodeType Type) {
       return Type == NodeType::Selector;
     }
 
    protected:
-    void FixFields();
+    void fixFields();
     NodePtr installPaths(NodePtr Self,
                          PathType Path,
                          unsigned NumBits) OVERRIDE;

--- a/src/utils/HuffmanEncoding.h
+++ b/src/utils/HuffmanEncoding.h
@@ -1,0 +1,171 @@
+/* -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a binary tree encoding huffman values.
+//
+// Initially, the alphabet is defined by creating instances of class Symbol.
+// Each symbol in the alphabet is given a probability that is used to define the
+// corresponding Huffman encoding for that value.
+//
+// Note: Probabilities are not used. Rather, weighted values are. The
+// probability for any symbol is it's weigth divided by the sum of weights of
+// all symbols in the alphabet.
+//
+// Note: This implementation limits the binary (Huffman) encodings to 64 bits.
+// This is done to guarantee that each path can be represented as an integer.
+// If necessary, symbols with path length greater than 64 bits are "balanced"
+// with their parents until all paths meet the 64 bit limitation.
+//
+// In addition, to make sure that path values are unique, independent of the
+// number of bits used for the encoding, they are encoded from leaf to root
+// (i.e. the least significant bit always represents the first bit of the path).
+
+#ifndef DECOMPRESSOR_SRc_UTILS_HEAP_H
+#define DECOMPRESSOR_SRc_UTILS_HEAP_H
+
+#include "utils/Defs.h"
+#include "utils/Casting.h"
+
+#include <vector>
+#include <memory>
+
+namespace wasm {
+
+namespace utils {
+
+class HuffmanEncoder : public std::enable_shared_from_this<HuffmanEncoder> {
+ public:
+  class Node;
+  class Symbol;
+  class Selector;
+  typedef uint64_t PathType;
+  typedef uint64_t WeightType;
+  typedef std::shared_ptr<Node> NodePtr;
+  typedef std::shared_ptr<Symbol> SymbolPtr;
+  typedef std::shared_ptr<Selector> SelectorPtr;
+
+  static constexpr unsigned MaxPathLength = sizeof(PathType) * CHAR_BIT;
+  enum class NodeType { Selector, Symbol };
+
+  // Node used to encode binary paths of Huffman encoding.
+  class Node : public std::enable_shared_from_this<Node> {
+    Node() = delete;
+    Node(const Node&) = delete;
+    Node& operator=(const Node&) = delete;
+    friend class HuffmanEncoder;
+
+   public:
+    explicit Node(NodeType Type, WeightType Weight, unsigned NumBits);
+    virtual ~Node();
+    WeightType getWeight() const { return Weight; }
+    unsigned getNumBits() const { return NumBits; }
+
+    NodeType getRtClassId() const { return Type; }
+
+   protected:
+    const NodeType Type;
+    // The weight of all symbols in the subtree.
+    WeightType Weight;
+    // The number of bits needed to represent all paths in subtree.
+    unsigned NumBits;
+    // Note: Installs Huffman encoding values into leaves, based on path and
+    // number of bits. Returns false if parent needs to rebalance because
+    // it was unable to install with path limit.
+    virtual NodePtr installPaths(NodePtr Self,
+                                 PathType Path,
+                                 unsigned NumBits) = 0;
+    // Returns number of nodes in tree.
+    virtual size_t nodeSize() const = 0;
+  };
+
+  // Defines a symbol in the alphabet being Huffman encoded.  Note: Only
+  // construct using std::make_shared<>.
+  class Symbol : public Node {
+    Symbol(const Symbol&) = delete;
+    Symbol& operator=(const Symbol&) = delete;
+
+   public:
+    // Note: Path and number of bits are not defined until installed.
+    Symbol(WeightType Weight);
+    ~Symbol() OVERRIDE;
+
+    PathType getPath() const { return Path; }
+
+    static bool implementsClass(NodeType Type) {
+      return Type == NodeType::Symbol;
+    }
+
+   protected:
+    NodePtr installPaths(NodePtr Self,
+                         PathType Path,
+                         unsigned NumBits) OVERRIDE;
+    size_t nodeSize() const OVERRIDE;
+
+   private:
+    PathType Path;
+  };
+
+  // Defines (binary) selector tree node.
+  class Selector : public Node {
+    Selector() = delete;
+    Selector(const Selector&) = delete;
+    Selector& operator=(const Selector&) = delete;
+
+   public:
+    Selector(NodePtr Kid1, NodePtr Kid2);
+    ~Selector() OVERRIDE;
+
+    NodePtr getKid1() const { return Kid1; }
+    NodePtr getKid2() const { return Kid2; }
+    NodePtr getKid(unsigned i) const;
+
+    static bool implementsClass(NodeType Type) {
+      return Type == NodeType::Selector;
+    }
+
+   protected:
+    void FixFields();
+    NodePtr installPaths(NodePtr Self,
+                         PathType Path,
+                         unsigned NumBits) OVERRIDE;
+    size_t nodeSize() const OVERRIDE;
+
+   private:
+    NodePtr Kid1;
+    NodePtr Kid2;
+    size_t Size;
+  };
+
+  HuffmanEncoder();
+  ~HuffmanEncoder();
+
+  // Add the given symbol to the alphabet to be encoded.
+  void add(SymbolPtr Sym);
+
+  // Define the Huffman encodings for each symbol in the alphabet.
+  // Returns the root of the corresponding tree defining the encoded
+  // symbols.
+  NodePtr encodeSymbols();
+
+ protected:
+  std::vector<NodePtr> Alphabet;
+};
+
+}  // end of namespace utils
+
+}  // end of namespace wasm
+
+#endif  // DECOMPRESSOR_SRc_UTILS_HEAP_H

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -127,6 +127,13 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
 
   void pop() { remove(0); }
 
+  // Reinsert value since key changed.
+  void reinsert(size_t Index) {
+    assert(Index < Contents.size());
+    if (!insertUp(Index))
+      insertDown(Index);
+  }
+
   // Note: This operation is provided to make debugging easier.
   void describe(FILE* Out,
                 std::function<void(FILE*, value_type)> describe_fcn) {
@@ -189,13 +196,6 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
       Kid->Index = ParentIndex;
       ParentIndex = KidIndex;
     } while (true);
-  }
-
-  // Reinsert value since key changed.
-  void reinsert(size_t Index) {
-    assert(Index < Contents.size());
-    if (!insertUp(Index))
-      insertDown(Index);
   }
 
   void remove(size_t Index) {


### PR DESCRIPTION
Note that the implementation assumes all paths <= 64 bits, and if necessary, balances leaf-most sub-trees to make this happen.