### PR TITLE
Used Huffman encoded values in algorithsm.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -867,8 +867,8 @@ $(TEST_EXECS): $(TEST_EXECDIR)/%$(EXE): $(TEST_OBJDIR)/%.o $(LIBS)
 ###### Testing ######
 
 test: build-all test-parser test-raw-streams test-byte-queues \
-	test-decompress test-casm2cast test-cast2casm test-casm-cast \
-	test-compress test-huffman
+	test-huffman test-decompress test-casm2cast test-cast2casm \
+	test-casm-cast test-compress 
 	@echo "*** all tests passed ***"
 
 .PHONY: test
@@ -943,6 +943,8 @@ $(TEST_CASM_DF_GEN_FILES): $(TEST_0XD_GENDIR)/%.df-out: $(TEST_SRCS_DIR)/%.wasm 
 $(TEST_WASM_COMP_FILES): $(TEST_0XD_GENDIR)/%.wasm-comp: $(TEST_0XD_SRCDIR)/%.wasm \
 		$(BUILD_EXECDIR)/compress-int $(BUILD_EXECDIR)/decompress
 	$(BUILD_EXECDIR)/compress-int --min-int-count 2 --min-weight 5 $< \
+	| $(BUILD_EXECDIR)/decompress - | cmp - $<
+	$(BUILD_EXECDIR)/compress-int --Huffman --min-int-count 2 --min-weight 5 $< \
 	| $(BUILD_EXECDIR)/decompress - | cmp - $<
 
 .PHONY: $(TEST_WASM_COMP_FILES)

--- a/src/intcomp/AbbreviationCodegen.h
+++ b/src/intcomp/AbbreviationCodegen.h
@@ -33,6 +33,7 @@ class AbbreviationCodegen {
 
  public:
   AbbreviationCodegen(CountNode::RootPtr Root,
+                      utils::HuffmanEncoder::NodePtr EncodingRoot,
                       interp::IntTypeFormat AbbrevFormat,
                       CountNode::Int2PtrMap& Assignments);
   ~AbbreviationCodegen();
@@ -42,6 +43,7 @@ class AbbreviationCodegen {
  private:
   std::shared_ptr<filt::SymbolTable> Symtab;
   CountNode::RootPtr Root;
+  utils::HuffmanEncoder::NodePtr EncodingRoot;
   interp::IntTypeFormat AbbrevFormat;
   CountNode::Int2PtrMap& Assignments;
   bool ToRead;

--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -89,34 +89,13 @@ void AbbreviationsCollector::assignAbbreviations() {
   TRACE_MESSAGE("Huffman encoding abbreviations");
 }
 
-#if 0
-void AbbreviationsCollector::assignHuffmanAbbreviations() {
+HuffmanEncoder::NodePtr AbbreviationsCollector::assignHuffmanAbbreviations() {
   // Start by extracting out candidates based on weight. Then use resulting
   // selected patterns as alphabet for Huffman encoding.
   assignAbbreviations();
-  CountNode::PtrVector Alphabet;
-  for (const auto& Pair : Assignments) {
-    Alphabet.push_back(Pair.second);
-    Pair.second->clearAbbrevIndex();
-  }
-  Assignments.clear();
-  clearHeap();
-// Now build heap (sorted by smaller weights first) to assign abbreviation
-// values.
-#if 0
-  ValuesHeap.setLtFcn(CountNode::CompareGt);
-  for (auto& Nd : Alphabet)
-    Nd->associateWithHeap(ValuesHeap->push(Value));
-  // Create nodes over two smallest values in heap.
-  while (ValuesHeap.size() > 1) {
-    Ptr Nd1 = ValuesHeap.top();
-    ValuesHeap.pop();
-    Ptr Nd2 = ValuesHeap.top();
-    ValuesHeap.pop();
-  }
-#endif
+  HuffmanRoot = Encoder->encodeSymbols();
+  return HuffmanRoot;
 }
-#endif
 
 void AbbreviationsCollector::addAbbreviation(CountNode::Ptr Nd) {
   addAbbreviation(Nd, Nd->getWeight());

--- a/src/intcomp/AbbreviationsCollector.h
+++ b/src/intcomp/AbbreviationsCollector.h
@@ -40,6 +40,9 @@ class AbbreviationsCollector : public CountNodeCollector {
   // candidate patterns to use as abbreviations.
   void assignAbbreviations();
 
+  // Same as assignAbbreviations, but does this based on Huffman encodings.
+  utils::HuffmanEncoder::NodePtr assignHuffmanAbbreviations();
+
   utils::TraceClass& getTrace() { return *getTracePtr(); }
   std::shared_ptr<utils::TraceClass> getTracePtr();
   void setTrace(std::shared_ptr<utils::TraceClass> NewTrace);
@@ -51,6 +54,7 @@ class AbbreviationsCollector : public CountNodeCollector {
   uint64_t CountCutoff;
   uint64_t WeightCutoff;
   std::shared_ptr<utils::HuffmanEncoder> Encoder;
+  utils::HuffmanEncoder::NodePtr HuffmanRoot;
   utils::HuffmanEncoder::NodePtr Encoding;
   std::shared_ptr<utils::TraceClass> Trace;
 

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -246,7 +246,10 @@ void IntCompressor::assignInitialAbbreviations(
                                    MyFlags.MaxAbbreviations);
   if (MyFlags.TraceAssigningAbbreviations && hasTrace())
     Collector.setTrace(getTracePtr());
-  Collector.assignAbbreviations();
+  if (MyFlags.UseHuffmanEncoding)
+    EncodingRoot = Collector.assignHuffmanAbbreviations();
+  else
+    Collector.assignAbbreviations();
 }
 
 bool IntCompressor::generateIntOutput() {
@@ -265,7 +268,8 @@ std::shared_ptr<SymbolTable> IntCompressor::generateCode(
     CountNode::Int2PtrMap& Assignments,
     bool ToRead,
     bool Trace) {
-  AbbreviationCodegen Codegen(Root, MyFlags.AbbrevFormat, Assignments);
+  AbbreviationCodegen Codegen(Root, EncodingRoot, MyFlags.AbbrevFormat,
+                              Assignments);
   std::shared_ptr<SymbolTable> Symtab = Codegen.getCodeSymtab(ToRead);
   if (Trace) {
     TextWriter Writer;

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -26,6 +26,7 @@
 #include "sexp/Ast.h"
 #include "stream/Queue.h"
 #include "stream/WriteCursor.h"
+#include "utils/HuffmanEncoding.h"
 
 namespace wasm {
 
@@ -118,6 +119,7 @@ class IntCompressor FINAL {
 
  private:
   std::shared_ptr<RootCountNode> Root;
+  utils::HuffmanEncoder::NodePtr EncodingRoot;
   std::shared_ptr<decode::Queue> Input;
   std::shared_ptr<decode::Queue> Output;
   Flags& MyFlags;


### PR DESCRIPTION
This PR moves the implementation using Huffman codes forward. With the --Huffman command-line option, compress-int will use the integer encoding of Huffman codes, but still doesn't fix the reading/writing to use bit encoding.

The bit encoding must be delayed until git reading/writing is added to the algorithms