### PR TITLE
Simplify insertion of trace contexts.

### DIFF
--- a/src/interp/ByteReader.h
+++ b/src/interp/ByteReader.h
@@ -62,7 +62,7 @@ class ByteReader : public Reader {
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
  private:
-  decode::ReadCursorWithTraceContext ReadPos;
+  decode::ReadCursor ReadPos;
   std::shared_ptr<ReadStream> Input;
   // The input position needed to fill to process now.
   size_t FillPos;

--- a/src/interp/ByteWriter.h
+++ b/src/interp/ByteWriter.h
@@ -58,7 +58,7 @@ class ByteWriter : public Writer {
   void describeState(FILE* File) OVERRIDE;
 
  private:
-  decode::WriteCursorWithTraceContext Pos;
+  decode::WriteCursor Pos;
   std::shared_ptr<WriteStream> Stream;
   // The stack of block patch locations.
   decode::WriteCursor BlockStart;

--- a/src/interp/IntReader.h
+++ b/src/interp/IntReader.h
@@ -81,7 +81,7 @@ class IntReader : public Reader {
   }
 
  private:
-  IntStream::ReadCursorWithTraceContext Pos;
+  IntStream::ReadCursor Pos;
   IntStream::StreamPtr Input;
   size_t HeaderIndex;
   // Shows how many are still available since last call to

--- a/src/interp/IntStream.cpp
+++ b/src/interp/IntStream.cpp
@@ -58,6 +58,11 @@ IntStream::Cursor& IntStream::Cursor::operator=(const IntStream::Cursor& C) {
   return *this;
 }
 
+TraceClass::ContextPtr
+IntStream::Cursor::getTraceContext() {
+  return std::make_shared<IntStream::Cursor::TraceContext>(*this);
+}
+
 FILE* IntStream::Cursor::describe(FILE* File,
                                   bool IncludeDetail,
                                   bool AddEoln) {
@@ -140,13 +145,6 @@ bool IntStream::WriteCursor::closeBlock() {
   return true;
 }
 
-TraceClass::ContextPtr
-IntStream::WriteCursorWithTraceContext::getTraceContext() {
-  if (!TraceContext)
-    TraceContext = std::make_shared<IntStream::Cursor::TraceContext>(*this);
-  return TraceContext;
-}
-
 IntType IntStream::ReadCursor::read() {
   // TODO(karlschimpf): Add capability to communicate failure to caller.
   assert(!EnclosingBlocks.empty());
@@ -174,13 +172,6 @@ bool IntStream::ReadCursor::closeBlock() {
   if (!Blk)
     return false;
   return Blk->getEndIndex() == Index;
-}
-
-TraceClass::ContextPtr
-IntStream::ReadCursorWithTraceContext::getTraceContext() {
-  if (!TraceContext)
-    TraceContext = std::make_shared<IntStream::Cursor::TraceContext>(*this);
-  return TraceContext;
 }
 
 void IntStream::reset() {

--- a/src/interp/IntStream.h
+++ b/src/interp/IntStream.h
@@ -96,6 +96,7 @@ class IntStream : public std::enable_shared_from_this<IntStream> {
     FILE* describe(FILE* File,
                    bool IncludeDetail = false,
                    bool AddEoln = false);
+    utils::TraceClass::ContextPtr getTraceContext();
 
    protected:
     size_t Index;
@@ -117,24 +118,6 @@ class IntStream : public std::enable_shared_from_this<IntStream> {
     bool freezeEof();
     bool openBlock();
     bool closeBlock();
-  };
-
-  class WriteCursorWithTraceContext : public WriteCursor {
-   public:
-    WriteCursorWithTraceContext() : WriteCursor() {}
-    explicit WriteCursorWithTraceContext(StreamPtr Stream)
-        : WriteCursor(Stream) {}
-    explicit WriteCursorWithTraceContext(const WriteCursor& C)
-        : WriteCursor(C) {}
-    WriteCursorWithTraceContext& operator=(const WriteCursor& C) {
-      WriteCursor::operator=(C);
-      return *this;
-    }
-
-    utils::TraceClass::ContextPtr getTraceContext();
-
-   private:
-    utils::TraceClass::ContextPtr TraceContext;
   };
 
   class ReadCursor : public Cursor {
@@ -161,23 +144,6 @@ class IntStream : public std::enable_shared_from_this<IntStream> {
    private:
     IntStream::BlockIterator NextBlock;
     IntStream::BlockIterator EndBlocks;
-  };
-
-  class ReadCursorWithTraceContext : public ReadCursor {
-   public:
-    ReadCursorWithTraceContext() : ReadCursor() {}
-    explicit ReadCursorWithTraceContext(StreamPtr Stream)
-        : ReadCursor(Stream) {}
-    explicit ReadCursorWithTraceContext(const ReadCursor& C) : ReadCursor(C) {}
-    ReadCursorWithTraceContext& operator=(const ReadCursor& C) {
-      ReadCursor::operator=(C);
-      return *this;
-    }
-
-    utils::TraceClass::ContextPtr getTraceContext();
-
-   private:
-    utils::TraceClass::ContextPtr TraceContext;
   };
 
   // WARNING: Don't call constructor directly. Call std::make_shared().

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -32,7 +32,7 @@ IntWriter::IntWriter(std::shared_ptr<IntStream> Output)
 
 void IntWriter::reset() {
   Output->reset();
-  IntStream::WriteCursorWithTraceContext StartPos(Output);
+  IntStream::WriteCursor StartPos(Output);
   Pos = StartPos;
 }
 

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -58,7 +58,7 @@ class IntWriter : public Writer {
 
  private:
   std::shared_ptr<IntStream> Output;
-  IntStream::WriteCursorWithTraceContext Pos;
+  IntStream::WriteCursor Pos;
 
   const char* getDefaultTraceName() const OVERRIDE;
 };

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -18,6 +18,8 @@
 
 namespace wasm {
 
+using namespace utils;
+
 namespace decode {
 
 Cursor::TraceContext::~TraceContext() {
@@ -25,6 +27,10 @@ Cursor::TraceContext::~TraceContext() {
 
 void Cursor::TraceContext::describe(FILE* File) {
   Pos.describe(File);
+}
+
+TraceClass::ContextPtr Cursor::getTraceContext() {
+  return std::make_shared<Cursor::TraceContext>(*this);
 }
 
 void Cursor::close() {

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -97,6 +97,8 @@ class Cursor : public PageCursor {
   // For debugging.
   FILE* describe(FILE* File, bool IncludeDetail = false, bool AddEoln = false);
 
+  utils::TraceClass::ContextPtr getTraceContext();
+
  protected:
   StreamType Type;
   // The byte queue the cursor points to.

--- a/src/stream/ReadCursor.cpp
+++ b/src/stream/ReadCursor.cpp
@@ -51,12 +51,6 @@ uint8_t ReadCursor::readOneByte() {
   return Byte;
 }
 
-TraceClass::ContextPtr ReadCursorWithTraceContext::getTraceContext() {
-  if (!TraceContext)
-    TraceContext = std::make_shared<Cursor::TraceContext>(*this);
-  return TraceContext;
-}
-
 }  // end of namespace decode
 
 }  // end of namespace wasm

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -86,28 +86,6 @@ class ReadCursor : public Cursor {
   uint8_t readByteAfterReadFill();
 };
 
-class ReadCursorWithTraceContext : public ReadCursor {
- public:
-  ReadCursorWithTraceContext() : ReadCursor() {}
-
-  ReadCursorWithTraceContext(std::shared_ptr<Queue> Que) : ReadCursor(Que) {}
-
-  ReadCursorWithTraceContext(StreamType Type, std::shared_ptr<Queue> Que)
-      : ReadCursor(Type, Que) {}
-
-  explicit ReadCursorWithTraceContext(const Cursor& C) : ReadCursor(C) {}
-
-  ReadCursorWithTraceContext& operator=(const ReadCursor& C) {
-    ReadCursor::operator=(C);
-    return *this;
-  }
-
-  utils::TraceClass::ContextPtr getTraceContext();
-
- private:
-  utils::TraceClass::ContextPtr TraceContext;
-};
-
 }  // end of namespace decode
 
 }  // end of namespace wasm

--- a/src/stream/WriteCursor.cpp
+++ b/src/stream/WriteCursor.cpp
@@ -32,12 +32,6 @@ void WriteCursor::writeFillWriteByte(uint8_t Byte) {
   writeOneByte(Byte);
 }
 
-TraceClass::ContextPtr WriteCursorWithTraceContext::getTraceContext() {
-  if (!TraceContext)
-    TraceContext = std::make_shared<Cursor::TraceContext>(*this);
-  return TraceContext;
-}
-
 }  // end of namespace decode
 
 }  // end of namespace wasm

--- a/src/stream/WriteCursor.h
+++ b/src/stream/WriteCursor.h
@@ -50,32 +50,6 @@ class WriteCursor : public WriteCursorBase {
   void writeFillWriteByte(uint8_t Byte) OVERRIDE;
 };
 
-class WriteCursorWithTraceContext : public WriteCursor {
- public:
-  // Note: The nullary write cursor should not be used until it has been
-  // assigned a value.
-  WriteCursorWithTraceContext() : WriteCursor() {}
-
-  WriteCursorWithTraceContext(std::shared_ptr<Queue> Que) : WriteCursor(Que) {}
-
-  WriteCursorWithTraceContext(StreamType Type, std::shared_ptr<Queue> Que)
-      : WriteCursor(Type, Que) {}
-
-  explicit WriteCursorWithTraceContext(const WriteCursor& C) : WriteCursor(C) {}
-
-  WriteCursorWithTraceContext(const Cursor& C, size_t StartAddress)
-      : WriteCursor(C, StartAddress) {}
-
-  WriteCursorWithTraceContext& operator=(const WriteCursor& C) {
-    WriteCursor::operator=(C);
-    return *this;
-  }
-
-  utils::TraceClass::ContextPtr getTraceContext();
-
- private:
-  utils::TraceClass::ContextPtr TraceContext;
-};
 }  // end of namespace decode
 
 }  // end of namespace wasm


### PR DESCRIPTION
Get rid of special classes used just to insert trace contexts for read/write cursors. This simplifies the class hierarchy, as well as remove unnecessary code.