### PR TITLE
Switch ByteReader to use BitReadCursor instead of ReadCursor.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ STRM_OBJDIR_BOOT = $(OBJDIR_BOOT)/stream
 
 STRM_SRCS = \
 	ArrayReader.cpp \
+	BitReadCursor.cpp \
 	FileReader.cpp \
 	FileWriter.cpp \
 	Cursor.cpp \

--- a/src/interp/ByteReader.cpp
+++ b/src/interp/ByteReader.cpp
@@ -38,7 +38,7 @@ ByteReader::ByteReader(std::shared_ptr<decode::Queue> StrmInput)
 ByteReader::~ByteReader() {
 }
 
-void ByteReader::setReadPos(const decode::ReadCursor& StartPos) {
+void ByteReader::setReadPos(const decode::BitReadCursor& StartPos) {
   ReadPos = StartPos;
 }
 
@@ -68,7 +68,7 @@ bool ByteReader::stillMoreInputToProcessNow() {
   return ReadPos.getCurAddress() <= FillPos;
 }
 
-ReadCursor& ByteReader::getPos() {
+BitReadCursor& ByteReader::getPos() {
   return ReadPos;
 }
 
@@ -81,8 +81,7 @@ bool ByteReader::atInputEof() {
 }
 
 void ByteReader::resetPeekPosStack() {
-  PeekPos = ReadCursor();
-  PeekPosStack.clear();
+  PeekPos = BitReadCursor();
 }
 
 void ByteReader::pushPeekPos() {

--- a/src/interp/ByteReader.h
+++ b/src/interp/ByteReader.h
@@ -21,7 +21,7 @@
 
 #include "interp/Reader.h"
 #include "interp/ReadStream.h"
-#include "stream/ReadCursor.h"
+#include "stream/BitReadCursor.h"
 
 namespace wasm {
 
@@ -35,8 +35,8 @@ class ByteReader : public Reader {
  public:
   ByteReader(std::shared_ptr<decode::Queue> Input);
   ~ByteReader() OVERRIDE;
-  void setReadPos(const decode::ReadCursor& ReadPos);
-  decode::ReadCursor& getPos();
+  void setReadPos(const decode::BitReadCursor& ReadPos);
+  decode::BitReadCursor& getPos();
 
   void describePeekPosStack(FILE* Out) OVERRIDE;
   bool canProcessMoreInputNow() OVERRIDE;
@@ -62,15 +62,15 @@ class ByteReader : public Reader {
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
  private:
-  decode::ReadCursor ReadPos;
+  decode::BitReadCursor ReadPos;
   std::shared_ptr<ReadStream> Input;
   // The input position needed to fill to process now.
   size_t FillPos;
   // The input cursor position if back filling.
   decode::ReadCursor FillCursor;
   // The stack of read cursors (used by peek)
-  decode::ReadCursor PeekPos;
-  utils::ValueStack<decode::ReadCursor> PeekPosStack;
+  decode::BitReadCursor PeekPos;
+  utils::ValueStack<decode::BitReadCursor> PeekPosStack;
 };
 
 }  // end of namespace interp

--- a/src/interp/IntStream.cpp
+++ b/src/interp/IntStream.cpp
@@ -58,8 +58,7 @@ IntStream::Cursor& IntStream::Cursor::operator=(const IntStream::Cursor& C) {
   return *this;
 }
 
-TraceClass::ContextPtr
-IntStream::Cursor::getTraceContext() {
+TraceClass::ContextPtr IntStream::Cursor::getTraceContext() {
   return std::make_shared<IntStream::Cursor::TraceContext>(*this);
 }
 

--- a/src/stream/BitReadCursor.cpp
+++ b/src/stream/BitReadCursor.cpp
@@ -1,0 +1,113 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements a pionter to a byte stream (for reading) that can be read a bit at
+// a time.
+
+#include "stream/BitReadCursor.h"
+
+namespace wasm {
+
+namespace decode {
+
+BitReadCursor::BitReadCursor() {
+  initFields();
+}
+
+BitReadCursor::BitReadCursor(std::shared_ptr<Queue> Que)
+    : ReadCursor(StreamType::Byte, Que) {
+  initFields();
+}
+
+BitReadCursor::BitReadCursor(StreamType Type, std::shared_ptr<Queue> Que)
+    : ReadCursor(Type, Que) {
+  initFields();
+}
+
+BitReadCursor::BitReadCursor(const BitReadCursor& C)
+    : ReadCursor(C), CurWord(C.CurWord), NumBits(C.NumBits) {
+}
+
+BitReadCursor::BitReadCursor(const BitReadCursor& C, size_t StartAddress)
+    : ReadCursor(C, StartAddress), CurWord(C.CurWord), NumBits(C.NumBits) {
+}
+
+BitReadCursor::~BitReadCursor() {
+}
+
+void BitReadCursor::assign(const BitReadCursor& C) {
+  ReadCursor::assign(C);
+  CurWord = C.CurWord;
+  NumBits = C.NumBits;
+}
+
+void BitReadCursor::swap(BitReadCursor& C) {
+  ReadCursor::swap(C);
+  CurWord = C.CurWord;
+  NumBits = C.NumBits;
+}
+
+void BitReadCursor::alignToByte() {
+  assert(NumBits < 8);
+  NumBits = 0;
+  CurWord = 0;
+}
+
+void BitReadCursor::describeDerivedExtensions(FILE* File) {
+  if (NumBits > 0)
+    fprintf(File, "+%u", NumBits);
+}
+
+#define BITREAD(Mask, MaskSize)                                      \
+  do {                                                               \
+    if (NumBits >= MaskSize) {                                       \
+      NumBits -= MaskSize;                                           \
+      uint8_t Value = uint8_t(CurWord >> NumBits);                   \
+      CurWord &= ~Mask << NumBits;                                   \
+      return Value;                                                  \
+    }                                                                \
+    if (atEob())                                                     \
+      break;                                                         \
+    /* Not enough bits left, read more in. */                        \
+    CurWord = (CurWord << sizeof(uint8_t)) | ReadCursor::readByte(); \
+    NumBits += sizeof(uint8_t);                                      \
+  } while (1);                                                       \
+  /* Leftover bits, fix (as best as possible) */                     \
+  fail();                                                            \
+  uint8_t Value = uint8_t(CurWord);                                  \
+  CurWord = 0;                                                       \
+  NumBits = 0;                                                       \
+  return Value;
+
+namespace {
+
+static constexpr BitReadCursor::WordType ByteMask = (1 << sizeof(uint8_t)) - 1;
+
+}  // end of anonymous namespace
+
+uint8_t BitReadCursor::readByte() {
+  if (NumBits == 0)
+    return ReadCursor::readByte();
+  BITREAD(ByteMask, sizeof(uint8_t));
+}
+
+uint8_t BitReadCursor::readBit() {
+  BITREAD(1, 1);
+}
+
+}  // end of namespace decode
+
+}  // end of namespace wasm

--- a/src/stream/BitReadCursor.h
+++ b/src/stream/BitReadCursor.h
@@ -34,7 +34,7 @@ class BitReadCursor : public ReadCursor {
   BitReadCursor(StreamType Type, std::shared_ptr<Queue> Que);
   explicit BitReadCursor(const BitReadCursor& C);
   BitReadCursor(const BitReadCursor& C, size_t StartAddress);
-  ~BitReadCursor() OVERRIDE;
+  ~BitReadCursor();
 
   void assign(const BitReadCursor& C);
 

--- a/src/stream/BitReadCursor.h
+++ b/src/stream/BitReadCursor.h
@@ -1,0 +1,69 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a pointer to a byte stream (for reading) that can read a bit
+// at a time.
+
+#ifndef DECOMPRESSOR_STC_STREAM_BITREADCURSOR_H
+#define DECOMPRESSOR_STC_STREAM_BITREADCURSOR_H
+
+#include "stream/ReadCursor.h"
+
+namespace wasm {
+
+namespace decode {
+
+class BitReadCursor : public ReadCursor {
+ public:
+  typedef uint32_t WordType;
+  BitReadCursor();
+  BitReadCursor(std::shared_ptr<Queue> Que);
+  BitReadCursor(StreamType Type, std::shared_ptr<Queue> Que);
+  explicit BitReadCursor(const BitReadCursor& C);
+  BitReadCursor(const BitReadCursor& C, size_t StartAddress);
+  ~BitReadCursor() OVERRIDE;
+
+  void assign(const BitReadCursor& C);
+
+  BitReadCursor& operator=(const BitReadCursor& C) {
+    assign(C);
+    return *this;
+  }
+
+  void swap(BitReadCursor& C);
+
+  uint8_t readByte();
+
+  uint8_t readBit();
+
+  void alignToByte();
+
+  void describeDerivedExtensions(FILE* File) OVERRIDE;
+
+ private:
+  void initFields() {
+    CurWord = 0;
+    NumBits = 0;
+  }
+  WordType CurWord;
+  unsigned NumBits;
+};
+
+}  // end of namespace decode
+
+}  // end of namespace wasm
+
+#endif  // DECOMPRESSOR_STC_STREAM_BITREADCURSOR_H

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -25,6 +25,25 @@ namespace decode {
 Cursor::TraceContext::~TraceContext() {
 }
 
+void Cursor::swap(Cursor& C) {
+  std::swap(Type, C.Type);
+  std::swap(Que, C.Que);
+  std::swap(static_cast<PageCursor&>(*this), static_cast<PageCursor&>(C));
+  std::swap(EobPtr, C.EobPtr);
+  std::swap(CurByte, C.CurByte);
+  std::swap(CurByte, C.CurByte);
+  std::swap(GuaranteedBeforeEob, C.GuaranteedBeforeEob);
+}
+
+void Cursor::assign(const Cursor& C) {
+  Type = C.Type;
+  Que = C.Que;
+  static_cast<PageCursor&>(*this) = static_cast<const PageCursor&>(C);
+  EobPtr = C.EobPtr;
+  CurByte = C.CurByte;
+  GuaranteedBeforeEob = C.GuaranteedBeforeEob;
+}
+
 void Cursor::TraceContext::describe(FILE* File) {
   Pos.describe(File);
 }
@@ -68,6 +87,7 @@ FILE* Cursor::describe(FILE* File, bool IncludeDetail, bool AddEoln) {
   if (IncludeDetail)
     fputs("Cursor<", File);
   PageCursor::describe(File, IncludeDetail);
+  describeDerivedExtensions(File);
   if (IncludeDetail) {
     if (EobPtr->isDefined()) {
       fprintf(File, ", eob=");
@@ -78,6 +98,9 @@ FILE* Cursor::describe(FILE* File, bool IncludeDetail, bool AddEoln) {
   if (AddEoln)
     fputc('\n', File);
   return File;
+}
+
+void Cursor::describeDerivedExtensions(FILE* File) {
 }
 
 }  // end of namespace decode

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -47,24 +47,9 @@ class Cursor : public PageCursor {
   };
   ~Cursor() {}
 
-  void swap(Cursor& C) {
-    std::swap(Type, C.Type);
-    std::swap(Que, C.Que);
-    std::swap(static_cast<PageCursor&>(*this), static_cast<PageCursor&>(C));
-    std::swap(EobPtr, C.EobPtr);
-    std::swap(CurByte, C.CurByte);
-    std::swap(CurByte, C.CurByte);
-    std::swap(GuaranteedBeforeEob, C.GuaranteedBeforeEob);
-  }
+  void swap(Cursor& C);
 
-  void assign(const Cursor& C) {
-    Type = C.Type;
-    Que = C.Que;
-    static_cast<PageCursor&>(*this) = static_cast<const PageCursor&>(C);
-    EobPtr = C.EobPtr;
-    CurByte = C.CurByte;
-    GuaranteedBeforeEob = C.GuaranteedBeforeEob;
-  }
+  void assign(const Cursor& C);
 
   StreamType getType() const { return Type; }
 
@@ -96,8 +81,10 @@ class Cursor : public PageCursor {
 
   // For debugging.
   FILE* describe(FILE* File, bool IncludeDetail = false, bool AddEoln = false);
+  // Adds any extentions to the page address, as defined in a derived class.
+  virtual void describeDerivedExtensions(FILE* File);
 
-  utils::TraceClass::ContextPtr getTraceContext();
+  virtual utils::TraceClass::ContextPtr getTraceContext();
 
  protected:
   StreamType Type;

--- a/src/stream/Queue.h
+++ b/src/stream/Queue.h
@@ -75,10 +75,12 @@ class BlockEob : public std::enable_shared_from_this<BlockEob> {
   BlockEob& operator=(const BlockEob&) = delete;
 
  public:
-  explicit BlockEob(AddressType Address = kMaxEofAddress) : EobAddress(Address) {
+  explicit BlockEob(AddressType Address = kMaxEofAddress)
+      : EobAddress(Address) {
     init();
   }
-  BlockEob(AddressType ByteAddr, const std::shared_ptr<BlockEob> EnclosingEobPtr)
+  BlockEob(AddressType ByteAddr,
+           const std::shared_ptr<BlockEob> EnclosingEobPtr)
       : EobAddress(ByteAddr), EnclosingEobPtr(EnclosingEobPtr) {
     init();
   }


### PR DESCRIPTION
Change to using a bit read cursor that can read single bits, as well as bytes.

Note that bit cursor no longer requires a byte read to be byte-aligned. Rather, it just returns the next 8 bits from the input stream.
