### PR TITLE
Change to use BitWriteCursor for ByteWriter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ STRM_OBJDIR_BOOT = $(OBJDIR_BOOT)/stream
 STRM_SRCS = \
 	ArrayReader.cpp \
 	BitReadCursor.cpp \
+	BitWriteCursor.cpp \
 	FileReader.cpp \
 	FileWriter.cpp \
 	Cursor.cpp \

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -124,14 +124,8 @@ void IntCompressor::readInput() {
   return;
 }
 
-#if 0
-const WriteCursor IntCompressor::writeCodeOutput(
-    std::shared_ptr<SymbolTable> Symtab)
-#else
 const BitWriteCursor IntCompressor::writeCodeOutput(
-    std::shared_ptr<SymbolTable> Symtab)
-#endif
-{
+    std::shared_ptr<SymbolTable> Symtab) {
   CasmWriter Writer;
   return Writer.setTraceWriter(MyFlags.TraceWritingCodeOutput)
       .setTraceTree(MyFlags.TraceWritingCodeOutput)
@@ -140,14 +134,8 @@ const BitWriteCursor IntCompressor::writeCodeOutput(
       .writeBinary(Symtab, Output);
 }
 
-#if 0
-void IntCompressor::writeDataOutput(const WriteCursor& StartPos,
-                                    std::shared_ptr<SymbolTable> Symtab)
-#else
 void IntCompressor::writeDataOutput(const BitWriteCursor& StartPos,
-                                    std::shared_ptr<SymbolTable> Symtab)
-#endif
-{
+                                    std::shared_ptr<SymbolTable> Symtab) {
   auto Writer = std::make_shared<ByteWriter>(Output);
   Writer->setPos(StartPos);
   Interpreter MyReader(std::make_shared<IntReader>(IntOutput), Writer, Symtab);
@@ -238,11 +226,7 @@ void IntCompressor::compress() {
   if (MyFlags.TraceCompressedIntOutput)
     IntOutput->describe(stderr, "Output int stream");
   TRACE_MESSAGE("Appending compression algorithm to output");
-#if 0
-  const WriteCursor Pos =
-#else
   const BitWriteCursor Pos =
-#endif
       writeCodeOutput(generateCodeForReading(AbbrevAssignments));
   if (errorsFound()) {
     fprintf(stderr, "Unable to compress, output malformed\n");

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -124,8 +124,14 @@ void IntCompressor::readInput() {
   return;
 }
 
+#if 0
 const WriteCursor IntCompressor::writeCodeOutput(
-    std::shared_ptr<SymbolTable> Symtab) {
+    std::shared_ptr<SymbolTable> Symtab)
+#else
+const BitWriteCursor IntCompressor::writeCodeOutput(
+    std::shared_ptr<SymbolTable> Symtab)
+#endif
+{
   CasmWriter Writer;
   return Writer.setTraceWriter(MyFlags.TraceWritingCodeOutput)
       .setTraceTree(MyFlags.TraceWritingCodeOutput)
@@ -134,8 +140,14 @@ const WriteCursor IntCompressor::writeCodeOutput(
       .writeBinary(Symtab, Output);
 }
 
+#if 0
 void IntCompressor::writeDataOutput(const WriteCursor& StartPos,
-                                    std::shared_ptr<SymbolTable> Symtab) {
+                                    std::shared_ptr<SymbolTable> Symtab)
+#else
+void IntCompressor::writeDataOutput(const BitWriteCursor& StartPos,
+                                    std::shared_ptr<SymbolTable> Symtab)
+#endif
+{
   auto Writer = std::make_shared<ByteWriter>(Output);
   Writer->setPos(StartPos);
   Interpreter MyReader(std::make_shared<IntReader>(IntOutput), Writer, Symtab);
@@ -226,7 +238,11 @@ void IntCompressor::compress() {
   if (MyFlags.TraceCompressedIntOutput)
     IntOutput->describe(stderr, "Output int stream");
   TRACE_MESSAGE("Appending compression algorithm to output");
+#if 0
   const WriteCursor Pos =
+#else
+  const BitWriteCursor Pos =
+#endif
       writeCodeOutput(generateCodeForReading(AbbrevAssignments));
   if (errorsFound()) {
     fprintf(stderr, "Unable to compress, output malformed\n");

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -25,7 +25,11 @@
 #include "interp/IntStream.h"
 #include "sexp/Ast.h"
 #include "stream/Queue.h"
+#if 0
 #include "stream/WriteCursor.h"
+#else
+#include "stream/BitWriteCursor.h"
+#endif
 #include "utils/HuffmanEncoding.h"
 
 namespace wasm {
@@ -128,10 +132,17 @@ class IntCompressor FINAL {
   std::shared_ptr<interp::IntStream> IntOutput;
   bool ErrorsFound;
   void readInput();
+#if 0
   const decode::WriteCursor writeCodeOutput(
       std::shared_ptr<filt::SymbolTable> Symtab);
   void writeDataOutput(const decode::WriteCursor& StartPos,
                        std::shared_ptr<filt::SymbolTable> Symtab);
+#else
+  const decode::BitWriteCursor writeCodeOutput(
+      std::shared_ptr<filt::SymbolTable> Symtab);
+  void writeDataOutput(const decode::BitWriteCursor& StartPos,
+                       std::shared_ptr<filt::SymbolTable> Symtab);
+#endif
   bool compressUpToSize(size_t Size);
   void removeSmallUsageCounts();
   void assignInitialAbbreviations(CountNode::Int2PtrMap& Assignments);

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -25,11 +25,7 @@
 #include "interp/IntStream.h"
 #include "sexp/Ast.h"
 #include "stream/Queue.h"
-#if 0
-#include "stream/WriteCursor.h"
-#else
 #include "stream/BitWriteCursor.h"
-#endif
 #include "utils/HuffmanEncoding.h"
 
 namespace wasm {
@@ -132,17 +128,10 @@ class IntCompressor FINAL {
   std::shared_ptr<interp::IntStream> IntOutput;
   bool ErrorsFound;
   void readInput();
-#if 0
-  const decode::WriteCursor writeCodeOutput(
-      std::shared_ptr<filt::SymbolTable> Symtab);
-  void writeDataOutput(const decode::WriteCursor& StartPos,
-                       std::shared_ptr<filt::SymbolTable> Symtab);
-#else
   const decode::BitWriteCursor writeCodeOutput(
       std::shared_ptr<filt::SymbolTable> Symtab);
   void writeDataOutput(const decode::BitWriteCursor& StartPos,
                        std::shared_ptr<filt::SymbolTable> Symtab);
-#endif
   bool compressUpToSize(size_t Size);
   void removeSmallUsageCounts();
   void assignInitialAbbreviations(CountNode::Int2PtrMap& Assignments);

--- a/src/interp/ByteWriter.cpp
+++ b/src/interp/ByteWriter.cpp
@@ -38,11 +38,20 @@ ByteWriter::~ByteWriter() {
 }
 
 void ByteWriter::reset() {
+#if 0
   BlockStart = WriteCursor();
+#else
+  BlockStart = BitWriteCursor();
+#endif
   BlockStartStack.clear();
 }
 
-WriteCursor& ByteWriter::getPos() {
+#if 0
+WriteCursor& ByteWriter::getPos()
+#else
+BitWriteCursor& ByteWriter::getPos()
+#endif
+{
   return Pos;
 }
 

--- a/src/interp/ByteWriter.cpp
+++ b/src/interp/ByteWriter.cpp
@@ -38,20 +38,11 @@ ByteWriter::~ByteWriter() {
 }
 
 void ByteWriter::reset() {
-#if 0
-  BlockStart = WriteCursor();
-#else
   BlockStart = BitWriteCursor();
-#endif
   BlockStartStack.clear();
 }
 
-#if 0
-WriteCursor& ByteWriter::getPos()
-#else
-BitWriteCursor& ByteWriter::getPos()
-#endif
-{
+BitWriteCursor& ByteWriter::getPos() {
   return Pos;
 }
 

--- a/src/interp/ByteWriter.h
+++ b/src/interp/ByteWriter.h
@@ -21,7 +21,11 @@
 
 #include "interp/Writer.h"
 #include "interp/WriteStream.h"
+#if 0
 #include "stream/WriteCursor.h"
+#else
+#include "stream/BitWriteCursor.h"
+#endif
 #include "utils/ValueStack.h"
 
 namespace wasm {
@@ -36,12 +40,24 @@ class ByteWriter : public Writer {
  public:
   ByteWriter(std::shared_ptr<decode::Queue> Output);
   ~ByteWriter() OVERRIDE;
+#if 0
   decode::WriteCursor& getPos();
+#else
+  decode::BitWriteCursor& getPos();
+#endif
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
+#if 0
   void setPos(const decode::WriteCursor& NewPos) { Pos = NewPos; }
+#else
+  void setPos(const decode::BitWriteCursor& NewPos) { Pos = NewPos; }
+#endif
 
+#if 0
   const decode::WriteCursor& getWritePos() const { return Pos; }
+#else
+  const decode::BitWriteCursor& getWritePos() const { return Pos; }
+#endif
 
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
@@ -58,11 +74,20 @@ class ByteWriter : public Writer {
   void describeState(FILE* File) OVERRIDE;
 
  private:
+#if 0
   decode::WriteCursor Pos;
+#else
+  decode::BitWriteCursor Pos;
+#endif
   std::shared_ptr<WriteStream> Stream;
   // The stack of block patch locations.
+#if 0
   decode::WriteCursor BlockStart;
   utils::ValueStack<decode::WriteCursor> BlockStartStack;
+#else
+  decode::BitWriteCursor BlockStart;
+  utils::ValueStack<decode::BitWriteCursor> BlockStartStack;
+#endif
   void describeBlockStartStack(FILE* File);
   const char* getDefaultTraceName() const OVERRIDE;
 };

--- a/src/interp/ByteWriter.h
+++ b/src/interp/ByteWriter.h
@@ -21,11 +21,7 @@
 
 #include "interp/Writer.h"
 #include "interp/WriteStream.h"
-#if 0
-#include "stream/WriteCursor.h"
-#else
 #include "stream/BitWriteCursor.h"
-#endif
 #include "utils/ValueStack.h"
 
 namespace wasm {
@@ -40,24 +36,11 @@ class ByteWriter : public Writer {
  public:
   ByteWriter(std::shared_ptr<decode::Queue> Output);
   ~ByteWriter() OVERRIDE;
-#if 0
-  decode::WriteCursor& getPos();
-#else
   decode::BitWriteCursor& getPos();
-#endif
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
 
-#if 0
-  void setPos(const decode::WriteCursor& NewPos) { Pos = NewPos; }
-#else
   void setPos(const decode::BitWriteCursor& NewPos) { Pos = NewPos; }
-#endif
-
-#if 0
-  const decode::WriteCursor& getWritePos() const { return Pos; }
-#else
   const decode::BitWriteCursor& getWritePos() const { return Pos; }
-#endif
 
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
@@ -74,20 +57,11 @@ class ByteWriter : public Writer {
   void describeState(FILE* File) OVERRIDE;
 
  private:
-#if 0
-  decode::WriteCursor Pos;
-#else
   decode::BitWriteCursor Pos;
-#endif
   std::shared_ptr<WriteStream> Stream;
   // The stack of block patch locations.
-#if 0
-  decode::WriteCursor BlockStart;
-  utils::ValueStack<decode::WriteCursor> BlockStartStack;
-#else
   decode::BitWriteCursor BlockStart;
   utils::ValueStack<decode::BitWriteCursor> BlockStartStack;
-#endif
   void describeBlockStartStack(FILE* File);
   const char* getDefaultTraceName() const OVERRIDE;
 };

--- a/src/sexp/CasmWriter.cpp
+++ b/src/sexp/CasmWriter.cpp
@@ -60,18 +60,10 @@ void CasmWriter::writeBinary(std::shared_ptr<SymbolTable> Symtab,
     ErrorsFound = true;
 }
 
-#if 0
-const WriteCursor& CasmWriter::writeBinary(
-    std::shared_ptr<SymbolTable> Symtab,
-    std::shared_ptr<Queue> Output,
-    std::shared_ptr<SymbolTable> AlgSymtab)
-#else
 const BitWriteCursor& CasmWriter::writeBinary(
     std::shared_ptr<SymbolTable> Symtab,
     std::shared_ptr<Queue> Output,
-    std::shared_ptr<SymbolTable> AlgSymtab)
-#endif
-{
+    std::shared_ptr<SymbolTable> AlgSymtab) {
   std::shared_ptr<IntStream> IntSeq = std::make_shared<IntStream>();
   writeBinary(Symtab, IntSeq);
   auto StrmWriter = std::make_shared<ByteWriter>(Output);
@@ -99,16 +91,9 @@ const BitWriteCursor& CasmWriter::writeBinary(
 }
 
 #if WASM_BOOT == 0
-#if 0
-const WriteCursor& CasmWriter::writeBinary(
-    std::shared_ptr<filt::SymbolTable> Symtab,
-    std::shared_ptr<Queue> Output)
-#else
 const BitWriteCursor& CasmWriter::writeBinary(
     std::shared_ptr<filt::SymbolTable> Symtab,
-    std::shared_ptr<Queue> Output)
-#endif
-{
+    std::shared_ptr<Queue> Output) {
   return writeBinary(Symtab, Output, getAlgcasm0x0Symtab());
 }
 #endif

--- a/src/sexp/CasmWriter.cpp
+++ b/src/sexp/CasmWriter.cpp
@@ -60,10 +60,18 @@ void CasmWriter::writeBinary(std::shared_ptr<SymbolTable> Symtab,
     ErrorsFound = true;
 }
 
+#if 0
 const WriteCursor& CasmWriter::writeBinary(
     std::shared_ptr<SymbolTable> Symtab,
     std::shared_ptr<Queue> Output,
-    std::shared_ptr<SymbolTable> AlgSymtab) {
+    std::shared_ptr<SymbolTable> AlgSymtab)
+#else
+const BitWriteCursor& CasmWriter::writeBinary(
+    std::shared_ptr<SymbolTable> Symtab,
+    std::shared_ptr<Queue> Output,
+    std::shared_ptr<SymbolTable> AlgSymtab)
+#endif
+{
   std::shared_ptr<IntStream> IntSeq = std::make_shared<IntStream>();
   writeBinary(Symtab, IntSeq);
   auto StrmWriter = std::make_shared<ByteWriter>(Output);
@@ -91,9 +99,16 @@ const WriteCursor& CasmWriter::writeBinary(
 }
 
 #if WASM_BOOT == 0
+#if 0
 const WriteCursor& CasmWriter::writeBinary(
     std::shared_ptr<filt::SymbolTable> Symtab,
-    std::shared_ptr<Queue> Output) {
+    std::shared_ptr<Queue> Output)
+#else
+const BitWriteCursor& CasmWriter::writeBinary(
+    std::shared_ptr<filt::SymbolTable> Symtab,
+    std::shared_ptr<Queue> Output)
+#endif
+{
   return writeBinary(Symtab, Output, getAlgcasm0x0Symtab());
 }
 #endif

--- a/src/sexp/CasmWriter.h
+++ b/src/sexp/CasmWriter.h
@@ -23,7 +23,11 @@
 #include "utils/Defs.h"
 #include "sexp/Ast.h"
 #include "stream/Queue.h"
+#if 0
 #include "stream/WriteCursor.h"
+#else
+#include "stream/BitWriteCursor.h"
+#endif
 #include "utils/Defs.h"
 
 #include <memory>
@@ -45,16 +49,29 @@ class CasmWriter {
 
   // Write aglorithm in Symtab to Output, using CASM algorithm in AlgSymtab.
   // Returns final write position.
+#if 0
   const decode::WriteCursor& writeBinary(
       std::shared_ptr<filt::SymbolTable> Symtab,
       std::shared_ptr<Queue> Output,
       std::shared_ptr<filt::SymbolTable> AlgSymtab);
+#else
+  const BitWriteCursor& writeBinary(
+      std::shared_ptr<filt::SymbolTable> Symtab,
+      std::shared_ptr<Queue> Output,
+      std::shared_ptr<filt::SymbolTable> AlgSymtab);
+#endif
 
 #if WASM_BOOT == 0
   // Same as above, but using default aglorithm casm0x0.
+#if 0
   const decode::WriteCursor& writeBinary(
       std::shared_ptr<filt::SymbolTable> Symtab,
       std::shared_ptr<Queue> Output);
+#else
+  const BitWriteCursor& writeBinary(
+      std::shared_ptr<filt::SymbolTable> Symtab,
+      std::shared_ptr<Queue> Output);
+#endif
 #endif
 
   bool hasErrors() const { return ErrorsFound; }

--- a/src/sexp/CasmWriter.h
+++ b/src/sexp/CasmWriter.h
@@ -23,11 +23,7 @@
 #include "utils/Defs.h"
 #include "sexp/Ast.h"
 #include "stream/Queue.h"
-#if 0
-#include "stream/WriteCursor.h"
-#else
 #include "stream/BitWriteCursor.h"
-#endif
 #include "utils/Defs.h"
 
 #include <memory>
@@ -49,29 +45,15 @@ class CasmWriter {
 
   // Write aglorithm in Symtab to Output, using CASM algorithm in AlgSymtab.
   // Returns final write position.
-#if 0
-  const decode::WriteCursor& writeBinary(
-      std::shared_ptr<filt::SymbolTable> Symtab,
-      std::shared_ptr<Queue> Output,
-      std::shared_ptr<filt::SymbolTable> AlgSymtab);
-#else
   const BitWriteCursor& writeBinary(
       std::shared_ptr<filt::SymbolTable> Symtab,
       std::shared_ptr<Queue> Output,
       std::shared_ptr<filt::SymbolTable> AlgSymtab);
-#endif
 
 #if WASM_BOOT == 0
   // Same as above, but using default aglorithm casm0x0.
-#if 0
-  const decode::WriteCursor& writeBinary(
-      std::shared_ptr<filt::SymbolTable> Symtab,
-      std::shared_ptr<Queue> Output);
-#else
-  const BitWriteCursor& writeBinary(
-      std::shared_ptr<filt::SymbolTable> Symtab,
-      std::shared_ptr<Queue> Output);
-#endif
+  const BitWriteCursor& writeBinary(std::shared_ptr<filt::SymbolTable> Symtab,
+                                    std::shared_ptr<Queue> Output);
 #endif
 
   bool hasErrors() const { return ErrorsFound; }

--- a/src/stream/BitReadCursor.cpp
+++ b/src/stream/BitReadCursor.cpp
@@ -56,8 +56,8 @@ void BitReadCursor::assign(const BitReadCursor& C) {
 
 void BitReadCursor::swap(BitReadCursor& C) {
   ReadCursor::swap(C);
-  CurWord = C.CurWord;
-  NumBits = C.NumBits;
+  std::swap(CurWord, C.CurWord);
+  std::swap(NumBits, C.NumBits);
 }
 
 void BitReadCursor::alignToByte() {

--- a/src/stream/BitWriteCursor.cpp
+++ b/src/stream/BitWriteCursor.cpp
@@ -1,0 +1,92 @@
+// -*- C++ -*-
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines a pointer to a byte stream (for reading) that can written a bit at a
+// time.
+
+#include "stream/BitWriteCursor.h"
+
+namespace wasm {
+
+namespace decode {
+
+BitWriteCursor::BitWriteCursor() { initFields(); }
+
+BitWriteCursor::BitWriteCursor(std::shared_ptr<Queue> Que)
+    : WriteCursor(Que) {
+  initFields();
+}
+
+BitWriteCursor::BitWriteCursor(StreamType Type, std::shared_ptr<Queue> Que)
+    : WriteCursor(Type, Que) {
+  initFields();
+}
+
+BitWriteCursor::BitWriteCursor(const BitWriteCursor& C)
+    : WriteCursor(C), CurWord(C.CurWord), NumBits(C.NumBits) {
+}
+
+BitWriteCursor::BitWriteCursor(const BitWriteCursor& C, size_t StartAddress)
+    : WriteCursor(C, StartAddress), CurWord(C.CurWord), NumBits(C.NumBits) {
+}
+
+void BitWriteCursor::assign(const BitWriteCursor& C) {
+  WriteCursor::assign(C);
+  CurWord = C.CurWord;
+  NumBits = C.NumBits;
+}
+
+void BitWriteCursor::swap(BitWriteCursor& C) {
+  WriteCursor::swap(C);
+  std::swap(CurWord, C.CurWord);
+  std::swap(NumBits, C.NumBits);
+}
+
+void BitWriteCursor::writeByte(uint8_t Byte) {
+  if (NumBits == 0)
+    return WriteCursor::writeByte(Byte);
+  CurWord = (CurWord << sizeof(uint8_t)) | Byte;
+  WriteCursor::writeByte(CurWord >> NumBits);
+  CurWord &= (1 << WordType(NumBits)) - 1;
+}
+
+void BitWriteCursor::writeBit(uint8_t Bit) {
+  assert(Bit <= 1);
+  CurWord = (CurWord << 1) | Bit;
+  ++NumBits;
+  if (NumBits >= sizeof(uint8_t)) {
+    NumBits -= sizeof(uint8_t);
+    WriteCursor::writeByte(CurWord >> NumBits);
+    CurWord &= (1 << WordType(NumBits)) - 1;
+  }
+}
+
+void BitWriteCursor::alignToByte() {
+  if (NumBits == 0)
+    return;
+  WriteCursor::writeByte(CurWord << (sizeof(uint8_t) - NumBits));
+  CurWord = 0;
+  NumBits = 0;
+}
+
+void BitWriteCursor::describeDerivedExtensions(FILE* File) {
+  if (NumBits > 0)
+    fprintf(File, "+%u", NumBits);
+}
+
+}  // end of namespace decode
+
+}  // end of namespace wasm

--- a/src/stream/BitWriteCursor.cpp
+++ b/src/stream/BitWriteCursor.cpp
@@ -23,10 +23,11 @@ namespace wasm {
 
 namespace decode {
 
-BitWriteCursor::BitWriteCursor() { initFields(); }
+BitWriteCursor::BitWriteCursor() {
+  initFields();
+}
 
-BitWriteCursor::BitWriteCursor(std::shared_ptr<Queue> Que)
-    : WriteCursor(Que) {
+BitWriteCursor::BitWriteCursor(std::shared_ptr<Queue> Que) : WriteCursor(Que) {
   initFields();
 }
 
@@ -43,7 +44,8 @@ BitWriteCursor::BitWriteCursor(const BitWriteCursor& C, size_t StartAddress)
     : WriteCursor(C, StartAddress), CurWord(C.CurWord), NumBits(C.NumBits) {
 }
 
-BitWriteCursor::~BitWriteCursor() {}
+BitWriteCursor::~BitWriteCursor() {
+}
 
 void BitWriteCursor::assign(const BitWriteCursor& C) {
   WriteCursor::assign(C);

--- a/src/stream/BitWriteCursor.cpp
+++ b/src/stream/BitWriteCursor.cpp
@@ -43,6 +43,8 @@ BitWriteCursor::BitWriteCursor(const BitWriteCursor& C, size_t StartAddress)
     : WriteCursor(C, StartAddress), CurWord(C.CurWord), NumBits(C.NumBits) {
 }
 
+BitWriteCursor::~BitWriteCursor() {}
+
 void BitWriteCursor::assign(const BitWriteCursor& C) {
   WriteCursor::assign(C);
   CurWord = C.CurWord;

--- a/src/stream/BitWriteCursor.h
+++ b/src/stream/BitWriteCursor.h
@@ -14,39 +14,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Defines a pointer to a byte stream (for reading) that can read a bit
-// at a time.
+// Defines a pointer to a byte stream (for reading) that can written a bit at a
+// time.
 
-#ifndef DECOMPRESSOR_SRC_STREAM_BITREADCURSOR_H
-#define DECOMPRESSOR_SRC_STREAM_BITREADCURSOR_H
+#ifndef DECOMPRESSOR_SRC_STREAM_BITWRITECURSOR_H
+#define DECOMPRESSOR_SRC_STREAM_BITWRITECURSOR_H
 
-#include "stream/ReadCursor.h"
+#include "stream/WriteCursor.h"
 
 namespace wasm {
 
 namespace decode {
 
-class BitReadCursor : public ReadCursor {
+class BitWriteCursor : public WriteCursor {
  public:
   typedef uint32_t WordType;
-  BitReadCursor();
-  BitReadCursor(std::shared_ptr<Queue> Que);
-  BitReadCursor(StreamType Type, std::shared_ptr<Queue> Que);
-  explicit BitReadCursor(const BitReadCursor& C);
-  BitReadCursor(const BitReadCursor& C, size_t StartAddress);
-  ~BitReadCursor();
 
-  void assign(const BitReadCursor& C);
+  BitWriteCursor();
 
-  BitReadCursor& operator=(const BitReadCursor& C) {
+  BitWriteCursor(std::shared_ptr<Queue> Que);
+
+  BitWriteCursor(StreamType Type, std::shared_ptr<Queue> Que);
+
+  explicit BitWriteCursor(const BitWriteCursor& C);
+
+  BitWriteCursor(const BitWriteCursor& C, size_t StartAddress);
+
+  ~BitWriteCursor() OVERRIDE;
+
+  void assign(const BitWriteCursor& C);
+
+  BitWriteCursor& operator=(const BitWriteCursor& C) {
     assign(C);
     return *this;
   }
 
-  void swap(BitReadCursor& C);
+  void swap(BitWriteCursor& C);
 
-  uint8_t readByte();
-  uint8_t readBit();
+  void writeByte(uint8_t Byte);
+  void writeBit(uint8_t Bit);
   void alignToByte();
 
   void describeDerivedExtensions(FILE* File) OVERRIDE;
@@ -65,4 +71,4 @@ class BitReadCursor : public ReadCursor {
 
 }  // end of namespace wasm
 
-#endif  // DECOMPRESSOR_SRC_STREAM_BITREADCURSOR_H
+#endif  // DECOMPRESSOR_SRC_STREAM_BITWRITECURSOR_H

--- a/src/stream/BitWriteCursor.h
+++ b/src/stream/BitWriteCursor.h
@@ -36,7 +36,7 @@ class BitWriteCursor : public WriteCursor {
 
   BitWriteCursor(StreamType Type, std::shared_ptr<Queue> Que);
 
-  explicit BitWriteCursor(const BitWriteCursor& C);
+  BitWriteCursor(const BitWriteCursor& C);
 
   BitWriteCursor(const BitWriteCursor& C, size_t StartAddress);
 


### PR DESCRIPTION
Change the byte writer to also be able to write single bits, not just bytes. This is in preparation of adding variable bit-width formatting for (Huffman encoded) abbreviations.