### PR TITLE
Allow cast2casm to strip actions and literals.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -527,9 +527,10 @@ $(ALG_GEN_H_SRCS): $(ALG_GENDIR)/%.h: $(ALG_GENDIR)/%.cast \
 $(ALG_GEN_CPP_SRCS): $(ALG_GENDIR)/%.cpp: $(ALG_GENDIR)/%.cast \
 		$(BUILD_EXECDIR_BOOT)/cast2casm $(ALG_GENDIR_ALG)
 	$(BUILD_EXECDIR_BOOT)/cast2casm -a $(ALG_GENDIR_ALG) \
-		$< -o $@ --function \
+		$< -o $@ --strip-literals --function \
 		$(patsubst $(ALG_GENDIR)/%.cast, getAlg%Symtab, $<) \
-		$(if $(call eq, "$(ALG_GENDIR)/casm0x0.cast", "$<") ,  , --array)
+		$(if $(call eq, "$(ALG_GENDIR)/casm0x0.cast", "$<") \
+                      ,  , --strip-actions --array)
 
 -include $(foreach dep,$(ALG_GEN_CPP_SRCS:.cpp=.d),$(ALG_OBJDIR)/$(dep))
 

--- a/src/algorithms/wasm0xd.cast
+++ b/src/algorithms/wasm0xd.cast
@@ -390,7 +390,6 @@
   (=> 'import.section.end')
 )
 
-
 (define 'import_entry' (params)
   (=> 'import_entry.begin')
   (eval 'symbol_name')

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -178,7 +178,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceIntCountsCollectionFlag(
         CompressionFlags.TraceIntCountsCollection);
     Args.add(TraceIntCountsCollectionFlag.setLongName(
-                                             "verbose=int-counts-collection")
+                                              "verbose=int-counts-collection")
                  .setDescription("Show how int counts were selected"));
 
     ArgsParser::Optional<bool> TraceSequenceCountsFlag(
@@ -192,7 +192,7 @@ int main(int Argc, const char* Argv[]) {
         CompressionFlags.TraceSequenceCountsCollection);
     Args.add(
         TraceSequenceCountsCollectionFlag.setLongName(
-                                             "verbose=seq-counts-collection")
+                                              "verbose=seq-counts-collection")
             .setDescription(
                 "Show how frequency of integer sequences were "
                 "selected"));

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -40,6 +40,7 @@
 #include "utils/Trace.h"
 
 #include <array>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <map>
@@ -199,11 +200,12 @@ class SymbolTable : public std::enable_shared_from_this<SymbolTable> {
 
   // Strips all callback actions from the algorithm, except for the names
   // specified. Returns the updated tree.
-  Node* stripCallbacksExcept(std::vector<std::string>& KeepActions, Node* Root);
-
   void stripCallbacksExcept(std::vector<std::string>& KeepActions) {
     install(stripCallbacksExcept(KeepActions, Root));
   }
+
+  // Strips out literal definitions and replaces literal uses.
+  void stripLiterals();
 
   void setTraceProgress(bool NewValue);
   virtual void setTrace(std::shared_ptr<utils::TraceClass> Trace);
@@ -234,6 +236,11 @@ class SymbolTable : public std::enable_shared_from_this<SymbolTable> {
   void installSubtreeCaches(Node* Nd,
                             VisitedNodesType& VisitedNoes,
                             NodeVectorType& AdditionalNodes);
+
+  Node* stripUsing(Node* Root, std::function<Node*(Node*)> stripKid);
+  Node* stripCallbacksExcept(std::vector<std::string>& KeepActions, Node* Root);
+  Node* stripLiteralUses(Node* Root);
+  Node* stripLiteralDefs(Node* Root);
 };
 
 class Node {
@@ -634,6 +641,7 @@ class NaryNode : public Node {
   void setKid(int Index, Node* N) OVERRIDE FINAL { Kids[Index] = N; }
 
   void append(Node* Kid) FINAL OVERRIDE;
+  void clearKids() { Kids.clear(); }
   ~NaryNode() OVERRIDE {}
 
   static bool implementsClass(NodeType Type);


### PR DESCRIPTION
Generalize stripping and extend to strip literals definitions/uses from algorithms, which saves space in compiled algorithms.