### PR TITLE
Add alignment abbreviation index to compressed algorithms.

### DIFF
--- a/src/intcomp/AbbreviationCodegen.cpp
+++ b/src/intcomp/AbbreviationCodegen.cpp
@@ -117,6 +117,8 @@ Node* AbbreviationCodegen::generateAction(CountNode::Ptr Nd) {
     return generateBlockAction(BlkPtr);
   else if (auto* DefaultPtr = dyn_cast<DefaultCountNode>(NdPtr))
     return generateDefaultAction(DefaultPtr);
+  else if (isa<AlignCountNode>(NdPtr))
+    return generateAlignAction();
   return Symtab->create<ErrorNode>();
 }
 
@@ -146,6 +148,10 @@ Node* AbbreviationCodegen::generateDefaultMultipleAction() {
 
 Node* AbbreviationCodegen::generateDefaultSingleAction() {
   return Symtab->create<Varint64Node>();
+}
+
+Node* AbbreviationCodegen::generateAlignAction() {
+  return Symtab->create<CallbackNode>(Symtab->getPredefined(PredefinedSymbol::Align));
 }
 
 Node* AbbreviationCodegen::generateIntType(IntType Value) {

--- a/src/intcomp/AbbreviationCodegen.h
+++ b/src/intcomp/AbbreviationCodegen.h
@@ -60,6 +60,7 @@ class AbbreviationCodegen {
   filt::Node* generateDefaultAction(DefaultCountNode* Default);
   filt::Node* generateDefaultMultipleAction();
   filt::Node* generateDefaultSingleAction();
+  filt::Node* generateAlignAction();
   filt::Node* generateIntType(decode::IntType Value);
   filt::Node* generateIntLitAction(IntCountNode* Nd);
   filt::Node* generateIntLitActionRead(IntCountNode* Nd);

--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -86,7 +86,6 @@ void AbbreviationsCollector::assignAbbreviations() {
     }
     addAbbreviation(Nd);
   }
-  TRACE_MESSAGE("Huffman encoding abbreviations");
 }
 
 HuffmanEncoder::NodePtr AbbreviationsCollector::assignHuffmanAbbreviations() {

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -96,10 +96,10 @@ void CountNodeCollector::collectAbbreviations() {
 
 void CountNodeCollector::collect() {
   if (hasFlag(CollectionFlag::TopLevel, Flags)) {
-    collectNode(Root->getBlockEnter());
-    collectNode(Root->getBlockExit());
-    collectNode(Root->getDefaultSingle());
-    collectNode(Root->getDefaultMultiple());
+    CountNode::PtrVector Others;
+    Root->getOthers(Others);
+    for (CountNode::Ptr Nd : Others)
+      collectNode(Nd);
   }
   for (CountNode::SuccMapIterator Iter = Root->getSuccBegin(),
                                   End = Root->getSuccEnd();

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -157,6 +157,7 @@ bool CountNodeWithSuccs::implementsClass(Kind K) {
       return true;
     case Kind::Block:
     case Kind::Default:
+    case Kind::Align:
       return false;
   }
   WASM_RETURN_UNREACHABLE(false);
@@ -167,7 +168,8 @@ RootCountNode::RootCountNode()
       BlockEnter(std::make_shared<BlockCountNode>(true)),
       BlockExit(std::make_shared<BlockCountNode>(false)),
       DefaultSingle(std::make_shared<DefaultCountNode>(true)),
-      DefaultMultiple(std::make_shared<DefaultCountNode>(false)) {
+      DefaultMultiple(std::make_shared<DefaultCountNode>(false)),
+      AlignCount(std::make_shared<AlignCountNode>()) {
 }
 
 RootCountNode::~RootCountNode() {
@@ -178,6 +180,7 @@ void RootCountNode::getOthers(PtrVector& L) const {
   L.push_back(BlockExit);
   L.push_back(DefaultSingle);
   L.push_back(DefaultMultiple);
+  L.push_back(AlignCount);
 }
 
 void RootCountNode::describe(FILE* Out, size_t NestLevel) const {
@@ -239,6 +242,14 @@ void DefaultCountNode::describe(FILE* Out, size_t NestLevel) const {
   indent(Out, NestLevel);
   fputs(": default.", Out);
   fputs(IsSingle ? "single" : "multiple", Out);
+  newline(Out);
+}
+
+AlignCountNode::~AlignCountNode() {}
+
+void AlignCountNode::describe(FILE* Out, size_t NestLevel) const {
+  indent(Out, NestLevel);
+  fputs(": align", Out);
   newline(Out);
 }
 

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -39,6 +39,7 @@ class BlockCountNode;
 class CountNode;
 class CountNodeWithSuccs;
 class DefaultCountNode;
+class AlignCountNode;
 class IntCountNode;
 class RootCountNode;
 
@@ -54,6 +55,7 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
   typedef std::shared_ptr<IntCountNode> IntPtr;
   typedef std::shared_ptr<BlockCountNode> BlockPtr;
   typedef std::shared_ptr<DefaultCountNode> DefaultPtr;
+  typedef std::shared_ptr<AlignCountNode> AlignPtr;
   typedef std::weak_ptr<IntCountNode> ParentPtr;
   typedef std::shared_ptr<RootCountNode> RootPtr;
   typedef std::shared_ptr<CountNodeWithSuccs> WithSuccsPtr;
@@ -72,7 +74,8 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
   static CompareFcnType CompareGt;
 
   virtual ~CountNode();
-  enum class Kind { Root, Block, Default, Singleton, IntSequence };
+
+  enum class Kind { Root, Block, Default, Align, Singleton, IntSequence };
   size_t getCount() const { return Count; }
   void setCount(size_t NewValue) { Count = NewValue; }
   size_t getWeight() const { return getWeight(getCount()); }
@@ -210,6 +213,19 @@ class DefaultCountNode : public CountNode {
   bool IsSingle;
 };
 
+// Used for modeling alignment (used once in codegen) so that the
+// same representation can be used for all abbreviations/actions.
+class AlignCountNode : public CountNode {
+  AlignCountNode(const AlignCountNode&) = delete;
+  AlignCountNode& operator=(const AlignCountNode&) = delete;
+
+ public:
+  AlignCountNode() : CountNode(Kind::Align) {}
+  ~AlignCountNode() OVERRIDE;
+  void describe(FILE* Out, size_t NestLevel = 0) const OVERRIDE;
+  static bool implementsClass(Kind K) { return K == Kind::Align; }
+};
+
 class RootCountNode : public CountNodeWithSuccs {
   RootCountNode(const RootCountNode&) = delete;
   RootCountNode& operator=(const RootCountNode&) = delete;
@@ -233,6 +249,7 @@ class RootCountNode : public CountNodeWithSuccs {
   CountNode::BlockPtr BlockExit;
   CountNode::DefaultPtr DefaultSingle;
   CountNode::DefaultPtr DefaultMultiple;
+  CountNode::AlignPtr AlignCount;
 };
 
 // Node defining an IntValue

--- a/src/utils/ArgsParse.cpp
+++ b/src/utils/ArgsParse.cpp
@@ -409,7 +409,8 @@ ArgsParser::ArgsParser(charstring Description)
       Help(false),
       HelpFlag(Help, "Describe how to use"),
       CurArg(0),
-      Status(State::Good) {
+      Status(State::Good),
+      TraceProgress(false) {
   HelpFlag.setDefault(false).setShortName('h').setLongName("help");
   add(HelpFlag);
 }
@@ -515,6 +516,8 @@ ArgsParser::Arg* ArgsParser::parseNextLong(charstring Argument,
 void ArgsParser::parseNextArg() {
   if (CurArg == Argc)
     return;
+  if (TraceProgress)
+    fprintf(stderr, "parse arg[%d] = '%s'\n", CurArg, Argv[CurArg]);
   if (Status == State::Usage)
     return;
   charstring Argument = Argv[CurArg++];
@@ -533,6 +536,10 @@ void ArgsParser::parseNextArg() {
     }
     if (MatchingOption->select(Leftover) && MaybeUseNextArg)
       ++CurArg;
+    if (TraceProgress) {
+      fprintf(stderr, "Matched:\n");
+      MatchingOption->describe(stderr, TabWidth);
+    }
     if (MatchingOption == &HelpFlag)
       showUsage();
     return;
@@ -540,6 +547,10 @@ void ArgsParser::parseNextArg() {
   if (CurPlacement < PlacementArgs.size()) {
     Arg* Placement = PlacementArgs[CurPlacement++];
     Placement->setOptionFound(true);
+    if (TraceProgress) {
+      fprintf(stderr, "Matched:\n");
+      Placement->describe(stderr, TabWidth);
+    }
     if (!Placement->select(Argument)) {
       fprintf(stderr, "Can't assign option:\n");
       Placement->describe(stderr, TabWidth);

--- a/src/utils/ArgsParse.h
+++ b/src/utils/ArgsParse.h
@@ -296,6 +296,9 @@ class ArgsParser {
                      charstring Argument,
                      charstring& Leftover) const;
 
+  void setTraceProgress(bool Value) { TraceProgress = Value; }
+  bool getTraceProgress() const { return TraceProgress; }
+
  private:
   charstring ExecName;
   charstring Description;
@@ -311,6 +314,7 @@ class ArgsParser {
   int CurArg;
   size_t CurPlacement;
   State Status;
+  bool TraceProgress;
 
   void parseNextArg();
   Arg* parseNextShort(charstring Argument, charstring& Leftover);


### PR DESCRIPTION
The alignment operator is needed in order to add Huffman codes. That is, once Huffman codes are added, we are no longer guaranteed to generate data that is byte aligned. To fix this, we need to introduce an abbreviation to force alignment.

The next PR will use this by adding the alignment abbreviation as the last record in the compressed data.