### PR TITLE
Change alignment to automatically add before block enter/exits.

### DIFF
--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -123,7 +123,6 @@ bool AbbrevAssignWriter::writeAction(const filt::SymbolNode* Action) {
     case PredefinedSymbol::Block_exit:
       writeUntilBufferEmpty();
       flushDefaultValues();
-      alignIfNecessary();
       assert(Root->getBlockExit()->hasAbbrevIndex());
       forwardAbbrevValue(Root->getBlockExit()->getAbbrevIndex());
       return true;

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -218,7 +218,7 @@ void IntCompressor::compress() {
   Root->getDefaultMultiple()->setCount(std::numeric_limits<uint32_t>::max());
   if (MyFlags.UseHuffmanEncoding)
     // Assume an alignment added at end of file.
-    Root->getAlign()->setCount(Root->getAlign()->getCount() + 1);
+    Root->getAlign()->setCount(1);
   CountNode::Int2PtrMap AbbrevAssignments;
   assignInitialAbbreviations(AbbrevAssignments);
   if (MyFlags.TraceAbbreviationAssignments)

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -217,8 +217,8 @@ void IntCompressor::compress() {
   Root->getDefaultSingle()->setCount(std::numeric_limits<uint32_t>::max());
   Root->getDefaultMultiple()->setCount(std::numeric_limits<uint32_t>::max());
   if (MyFlags.UseHuffmanEncoding)
-    // Assume one is added at the end of each block, and one at eof.
-    Root->getAlign()->setCount(Root->getBlockExit()->getCount() + 1);
+    // Assume an alignment added at end of file.
+    Root->getAlign()->setCount(Root->getAlign()->getCount() + 1);
   CountNode::Int2PtrMap AbbrevAssignments;
   assignInitialAbbreviations(AbbrevAssignments);
   if (MyFlags.TraceAbbreviationAssignments)

--- a/src/interp/ByteReader.cpp
+++ b/src/interp/ByteReader.cpp
@@ -109,6 +109,9 @@ bool ByteReader::readAction(const SymbolNode* Action) {
   switch (Action->getPredefinedSymbol()) {
     case PredefinedSymbol::Block_enter:
     case PredefinedSymbol::Block_enter_readonly: {
+      // Force alignment before processing, in case non-byte encodings
+      // are used.
+      ReadPos.alignToByte();
       const uint32_t OldSize = Input->readBlockSize(ReadPos);
       TRACE(uint32_t, "block size", OldSize);
       Input->pushEobAddress(ReadPos, OldSize);
@@ -116,6 +119,8 @@ bool ByteReader::readAction(const SymbolNode* Action) {
     }
     case PredefinedSymbol::Block_exit:
     case PredefinedSymbol::Block_exit_readonly:
+      // Force alignment before processing, in case non-byte encodings
+      ReadPos.alignToByte();
       ReadPos.popEobAddress();
       return true;
     case PredefinedSymbol::Align:

--- a/src/interp/ByteWriter.cpp
+++ b/src/interp/ByteWriter.cpp
@@ -102,12 +102,18 @@ bool ByteWriter::writeAction(const filt::SymbolNode* Action) {
   switch (Action->getPredefinedSymbol()) {
     case PredefinedSymbol::Block_enter:
     case PredefinedSymbol::Block_enter_writeonly:
+      // Force alignment before processing, in case non-byte encodings
+      // are used.
+      WritePos.alignToByte();
       BlockStartStack.push(WritePos);
       Stream->writeFixedBlockSize(WritePos, 0);
       BlockStartStack.push(WritePos);
       return true;
     case PredefinedSymbol::Block_exit:
     case PredefinedSymbol::Block_exit_writeonly:
+      // Force alignment before processing, in case non-byte encodings
+      // are used.
+      WritePos.alignToByte();
       if (MinimizeBlockSize) {
         // Mimimized block. Backpatch new size of block. If needed, move
         // block to fill gap between fixed and variable widths for block


### PR DESCRIPTION
Simplify handling of alignment. Since only blocks (and eof) need to be aligned, fix as follows:

1) Rather than making the compressor add alignment for blocks, just have block enter/exit force alignment. This is cleaner in that when this is done, the size of the block (when not byte aligned) becomes clear (and hence, remove problems that may be introduced by incorrectly coded algorithms).

2) When compressing, still add an alignment as the last abbreviation, so that files (matching the physical representation) are always byte aligned.
