### PR TITLE
Add BinaryEval node to algorithms.

### DIFF
--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -50,6 +50,7 @@
 (literal 'accept'         (u8.const 0x28))
 (literal 'reject'         (u8.const 0x29))
 (literal 'binary'         (u8.const 0x2a))
+(literal 'bin.eval'       (u8.const 0x2b))
 
 # Boolean expressions
 (literal 'and'            (u8.const 0x30))
@@ -125,6 +126,7 @@
     (case 'accept'              (=> 'postorder.inst'))
     (case 'and'                 (=> 'postorder.inst'))
     (case 'binary'              (=> 'postorder.inst'))
+    (case 'bin.eval'            (=> 'postorder.inst'))
     (case 'bitwise.and'         (=> 'postorder.inst'))
     (case 'bitwise.negate'      (=> 'postorder.inst'))
     (case 'bitwise.or'          (=> 'postorder.inst'))

--- a/src/interp/ByteWriter.cpp
+++ b/src/interp/ByteWriter.cpp
@@ -99,18 +99,22 @@ bool ByteWriter::writeFreezeEof() {
 }
 
 bool ByteWriter::writeBinary(IntType Value, const Node* Encoding) {
+  fprintf(stderr, "-> writeBinary %" PRIxMAX "\n", uintmax_t(Value));
   unsigned NumBits = 0;
   while (Encoding != nullptr) {
     switch (Encoding->getType()) {
       default:
       case OpBinaryReject:
+        fprintf(stderr, "<- writeBinary reject\n");
         return false;
       case OpBinaryAccept:
         assert(NumBits == cast<BinaryAcceptNode>(Encoding)->getNumBits());
+        fprintf(stderr, "<- writeBinary bits = %u\n", NumBits);
         return true;
       case OpBinarySelect: {
         auto* Sel = cast<BinarySelectNode>(Encoding);
         uint8_t Val = uint8_t(Value & 1);
+        fprintf(stderr, "Val = %u\n", unsigned(Val));
         WritePos.writeBit(Val);
         Encoding = Val ? Sel->getKid(1) : Sel->getKid(0);
         Value >>= 1;
@@ -119,6 +123,7 @@ bool ByteWriter::writeBinary(IntType Value, const Node* Encoding) {
       }
     }
   }
+  fprintf(stderr, "<- writeBinary not encoded\n");
   return false;
 }
 

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -518,11 +518,9 @@ void Interpreter::algorithmResume() {
       case Method::Eval:
         switch (Frame.Nd->getType()) {
           case NO_SUCH_NODETYPE:
-#if 0
           case OpBinaryAccept:
           case OpBinaryReject:
           case OpBinarySelect:
-#endif
           case OpParams:
           case OpLastSymbolIs:
           case OpLiteralDef:
@@ -758,9 +756,7 @@ void Interpreter::algorithmResume() {
             popAndReturn(LastReadValue);
             break;
           }
-          case OpBinaryAccept:
-          case OpBinaryReject:
-          case OpBinarySelect:
+          case OpBinaryEval:
             if (hasReadMode())
               if (!readBinary(Frame.Nd, LastReadValue))
                 return throwCantRead();

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -435,7 +435,9 @@ format_directive
         | "(" "varuint64" ")" {
             $$ = Driver.create<Varuint64Node>();
           }
-        | format_binary { $$ = $1; }
+        | "(" "opcode" format_binary ")" {
+            $$ = Driver.create<BinaryEvalNode>($3);
+          }
         ;
 
 format_binary

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -64,6 +64,7 @@
   X(BinaryAccept,      0x28, "accept",           nullptr,           0, 0)      \
   X(BinaryReject,      0x29, "reject",           nullptr,           0, 0)      \
   X(BinarySelect,      0x2a, "binary",           nullptr,           0, 0)      \
+  X(BinaryEval,        0x2b, "opcode",           "BinaryEval",      1, 0)      \
                                                                                \
   /* Boolean Expressions */                                                    \
   X(And,               0x30, "and",              nullptr,           2, 0)      \
@@ -152,8 +153,6 @@
   X(Undefine,)                                                                 \
   X(UnknownSection,)                                                           \
 
-
-
 //#define X(tag, NODE_DECLS)
 #define AST_BINARYNODE_TABLE                                                   \
   X(And,)                                                                      \
@@ -219,6 +218,7 @@
 
 //#define X(tag)
 #define AST_NODE_NEVER_SAME_LINE                                               \
+  X(BinaryEval)                                                                \
   X(BinarySelect)                                                              \
   X(Block)                                                                     \
   X(Case)                                                                      \

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -307,6 +307,8 @@ class Node {
 
   // Recursively walks tree and validates (Scope allows lexical validation).
   // Returns true if validation succeeds.
+  bool validateKid(NodeVectorType& Parents, Node* Kid);
+  bool validateKids(NodeVectorType& Parents);
   bool validateSubtree(NodeVectorType& Parents);
 
   void setLastKid(Node* N) { setKid(getNumKids() - 1, N); }
@@ -775,6 +777,26 @@ class OpcodeNode FINAL : public SelectBaseNode {
   typedef std::vector<WriteRange> CaseRangeVectorType;
   CaseRangeVectorType CaseRangeVector;
   void installCaseRanges();
+};
+
+class BinaryEvalNode : public UnaryNode {
+  BinaryEvalNode() = delete;
+  BinaryEvalNode(const BinaryEvalNode&) = delete;
+  BinaryEvalNode& operator=(const BinaryEvalNode&) = delete;
+
+ public:
+  explicit BinaryEvalNode(SymbolTable& Symtab, Node* Encoding);
+  ~BinaryEvalNode() OVERRIDE;
+  bool validateNode(NodeVectorType& Parents) OVERRIDE;
+
+  const Node* getEncoding(decode::IntType Value) const;
+  bool addEncoding(BinaryLeafNode* Encoding);
+
+  static bool implementsClass(NodeType Type) { return OpBinaryEval == Type; }
+
+ private:
+  std::unordered_map<decode::IntType, const Node*> LookupMap;
+  BinaryRejectNode* NotFound;
 };
 
 }  // end of namespace filt

--- a/src/sexp/FlattenAst.cpp
+++ b/src/sexp/FlattenAst.cpp
@@ -119,6 +119,7 @@ void FlattenAst::flattenNode(const Node* Nd) {
     case OpBlock:
     // TODO(karlschimpf): Compress BinaryAccept/Select into bitsequence?
     case OpBinaryAccept:
+    case OpBinaryEval:
     case OpBinaryReject:
     case OpBinarySelect:
     case OpBitwiseAnd:

--- a/src/sexp/InflateAst.cpp
+++ b/src/sexp/InflateAst.cpp
@@ -194,6 +194,8 @@ bool InflateAst::applyOp(IntType Op) {
       return buildBinary<AndNode>();
     case OpBinaryAccept:
       return buildNullary<BinaryAcceptNode>();
+    case OpBinaryEval:
+      return buildUnary<BinaryEvalNode>();
     case OpBinaryReject:
       return buildNullary<BinaryRejectNode>();
     case OpBinarySelect:

--- a/test/test-sources/BinaryFormat.cast
+++ b/test/test-sources/BinaryFormat.cast
@@ -3,15 +3,17 @@
 
 (define 'file' (params)
   (switch
-    (binary
+    (opcode
       (binary
-        (accept)
         (binary
           (accept)
-          (accept)
+          (binary
+            (accept)
+            (accept)
+          )
         )
+        (accept)
       )
-      (accept)
     )
     (void)
     # NOTE: Paths are parsed right-to-left, but use left-to-right encoding to make

--- a/test/test-sources/BinaryFormat.cast-out
+++ b/test/test-sources/BinaryFormat.cast-out
@@ -2,15 +2,17 @@
 (void)
 (define 'file' (params)
   (switch
-    (binary
+    (opcode
       (binary
-        (accept 0x0:2)
         (binary
-          (accept 0x2:3)
-          (accept 0x6:3)
+          (accept 0x0:2)
+          (binary
+            (accept 0x2:3)
+            (accept 0x6:3)
+          )
         )
+        (accept 0x1:1)
       )
-      (accept 0x1:1)
     )
     (void)
     (case (u32.const 0x0) (void))


### PR DESCRIPTION
The BinaryEval node has been added to fix writing binary-encoded values. The node defines a map from the write value, to the corresponding (binary) leaf node that defines how the value should be encoded. Without this node, the code would have to do a full linear search of the ast on every write.
