### PR TITLE
Fix bit read in BitReadCursor to read a bit.

### DIFF
--- a/src/interp/ByteReader.cpp
+++ b/src/interp/ByteReader.cpp
@@ -20,6 +20,10 @@
 
 #include "interp/ByteReadStream.h"
 
+#if 1
+#include "sexp/TextWriter.h"
+#endif
+
 namespace wasm {
 
 using namespace decode;
@@ -131,9 +135,23 @@ bool ByteReader::readAction(const SymbolNode* Action) {
   }
 }
 
-bool ByteReader::readBinary(const Node* Encoding, IntType& Value) {
+bool ByteReader::readBinary(const Node* Eval, IntType& Value) {
   Value = 0;
-  fprintf(stderr, "ByteReader::readBinary not implemented!\n");
+  if (!isa<BinaryEvalNode>(Eval))
+    return false;
+  const Node* Encoding = cast<BinaryEvalNode>(Eval)->getKid(0);
+  while (1) {
+    switch (Encoding->getType()) {
+      case OpBinaryAccept:
+        Value = cast<BinaryAcceptNode>(Encoding)->getValue();
+        return true;
+      case OpBinarySelect:
+        Encoding = const_cast<Node*>(Encoding->getKid(ReadPos.readBit()));
+        break;
+      default:
+        return false;
+    }
+  }
   return false;
 }
 

--- a/src/interp/ByteWriter.cpp
+++ b/src/interp/ByteWriter.cpp
@@ -108,10 +108,9 @@ bool ByteWriter::writeBinary(IntType Value, const Node* Encoding) {
   const auto* Accept = cast<BinaryAcceptNode>(Enc);
   unsigned NumBits = Accept->getNumBits();
   IntType Bits = Accept->getValue();
-  for (unsigned i = 0; i < NumBits; ++i) {
-    uint8_t Bit = uint8_t(Bits & 1);
-    WritePos.writeBit(Bit);
-    Bits >>= 1;
+  while (NumBits) {
+    --NumBits;
+    WritePos.writeBit(uint8_t((Bits >> NumBits) & 0x1));
   }
   return true;
 }

--- a/src/stream/BitWriteCursor.cpp
+++ b/src/stream/BitWriteCursor.cpp
@@ -54,6 +54,12 @@ BitWriteCursor::BitWriteCursor(const BitWriteCursor& C, size_t StartAddress)
 BitWriteCursor::~BitWriteCursor() {
 }
 
+bool BitWriteCursor::atEof() const OVERRIDE {
+  if (!WriteCursor::atEof())
+    return false;
+  return NumBits == 0;
+}
+
 void BitWriteCursor::assign(const BitWriteCursor& C) {
   WriteCursor::assign(C);
   CurWord = C.CurWord;

--- a/src/stream/BitWriteCursor.cpp
+++ b/src/stream/BitWriteCursor.cpp
@@ -54,7 +54,7 @@ BitWriteCursor::BitWriteCursor(const BitWriteCursor& C, size_t StartAddress)
 BitWriteCursor::~BitWriteCursor() {
 }
 
-bool BitWriteCursor::atEof() const OVERRIDE {
+bool BitWriteCursor::atEof() const {
   if (!WriteCursor::atEof())
     return false;
   return NumBits == 0;

--- a/src/stream/BitWriteCursor.h
+++ b/src/stream/BitWriteCursor.h
@@ -42,6 +42,8 @@ class BitWriteCursor : public WriteCursor {
 
   ~BitWriteCursor() OVERRIDE;
 
+  bool atEof() const OVERRIDE;
+
   void assign(const BitWriteCursor& C);
 
   BitWriteCursor& operator=(const BitWriteCursor& C) {

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -25,6 +25,10 @@ namespace decode {
 Cursor::TraceContext::~TraceContext() {
 }
 
+bool Cursor::atEof() const {
+  return CurAddress == Que->getEofAddress();
+}
+
 void Cursor::swap(Cursor& C) {
   std::swap(Type, C.Type);
   std::swap(Que, C.Que);

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -61,7 +61,7 @@ class Cursor : public PageCursor {
 
   bool isEofFrozen() const { return Que->isEofFrozen(); }
 
-  bool atEof() const { return CurAddress == Que->getEofAddress(); }
+  virtual bool atEof() const;
 
   size_t getEofAddress() const { return Que->getEofAddress(); }
 


### PR DESCRIPTION
Now bit reading/writing of cursors is consistent, and handle Huffman encodings (or at least many cases). However, there is still a bug where the reader gets lost (to be fixed in later PR's).