### PR TITLE
Fix tracing bit stream positions so read and write positions match.

### DIFF
--- a/src/interp/ByteReader.cpp
+++ b/src/interp/ByteReader.cpp
@@ -20,10 +20,6 @@
 
 #include "interp/ByteReadStream.h"
 
-#if 1
-#include "sexp/TextWriter.h"
-#endif
-
 namespace wasm {
 
 using namespace decode;

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -280,9 +280,7 @@ class Node {
 
   virtual ~Node() {}
 
-#if 1
   SymbolTable& getSymtab() { return Symtab; }
-#endif
 
   NodeType getRtClassId() const { return Type; }
 

--- a/src/stream/BitReadCursor.cpp
+++ b/src/stream/BitReadCursor.cpp
@@ -73,9 +73,19 @@ void BitReadCursor::alignToByte() {
   CurWord = 0;
 }
 
-void BitReadCursor::describeDerivedExtensions(FILE* File) {
-  if (NumBits > 0)
-    fprintf(File, "-%u", NumBits);
+void BitReadCursor::describeDerivedExtensions(FILE* File, bool IncludeDetail) {
+  size_t Address = getAddress();
+  if (NumBits == 0 || Address == 0) {
+    ReadCursor::describeDerivedExtensions(File, IncludeDetail);
+    if (NumBits > 0)
+      fprintf(File, ":-%u", NumBits);
+    return;
+  }
+  // Correct by moving back one byte, so that it looks the same as when writing.
+  describeAddress(File, Address - 1);
+  if (IncludeDetail)
+    describePage(File, CurPage.get());
+  fprintf(File, ":%u", BitsInByte - NumBits);
 }
 
 #define BITREAD(Mask, MaskSize)                                 \

--- a/src/stream/BitReadCursor.h
+++ b/src/stream/BitReadCursor.h
@@ -49,7 +49,7 @@ class BitReadCursor : public ReadCursor {
   uint8_t readBit();
   void alignToByte();
 
-  void describeDerivedExtensions(FILE* File) OVERRIDE;
+  void describeDerivedExtensions(FILE* File, bool IncludeDetail) OVERRIDE;
 
  private:
   WordType CurWord;

--- a/src/stream/BitWriteCursor.cpp
+++ b/src/stream/BitWriteCursor.cpp
@@ -99,7 +99,8 @@ void BitWriteCursor::alignToByte() {
   NumBits = 0;
 }
 
-void BitWriteCursor::describeDerivedExtensions(FILE* File) {
+void BitWriteCursor::describeDerivedExtensions(FILE* File, bool IncludeDetail) {
+  WriteCursor::describeDerivedExtensions(File, IncludeDetail);
   if (NumBits > 0)
     fprintf(File, ":%u", NumBits);
 }

--- a/src/stream/BitWriteCursor.h
+++ b/src/stream/BitWriteCursor.h
@@ -57,7 +57,7 @@ class BitWriteCursor : public WriteCursor {
   void writeBit(uint8_t Bit);
   void alignToByte();
 
-  void describeDerivedExtensions(FILE* File) OVERRIDE;
+  void describeDerivedExtensions(FILE* File, bool IncludeDetail) OVERRIDE;
 
  private:
   WordType CurWord;

--- a/src/stream/Cursor.cpp
+++ b/src/stream/Cursor.cpp
@@ -90,8 +90,7 @@ void Cursor::writeFillBuffer(size_t WantedSize) {
 FILE* Cursor::describe(FILE* File, bool IncludeDetail, bool AddEoln) {
   if (IncludeDetail)
     fputs("Cursor<", File);
-  PageCursor::describe(File, IncludeDetail);
-  describeDerivedExtensions(File);
+  describeDerivedExtensions(File, IncludeDetail);
   if (IncludeDetail) {
     if (EobPtr->isDefined()) {
       fprintf(File, ", eob=");
@@ -104,7 +103,8 @@ FILE* Cursor::describe(FILE* File, bool IncludeDetail, bool AddEoln) {
   return File;
 }
 
-void Cursor::describeDerivedExtensions(FILE* File) {
+void Cursor::describeDerivedExtensions(FILE* File, bool IncludeDetail) {
+  PageCursor::describe(File, IncludeDetail);
 }
 
 }  // end of namespace decode

--- a/src/stream/Cursor.h
+++ b/src/stream/Cursor.h
@@ -82,7 +82,7 @@ class Cursor : public PageCursor {
   // For debugging.
   FILE* describe(FILE* File, bool IncludeDetail = false, bool AddEoln = false);
   // Adds any extentions to the page address, as defined in a derived class.
-  virtual void describeDerivedExtensions(FILE* File);
+  virtual void describeDerivedExtensions(FILE* File, bool IncludeDetail);
 
   virtual utils::TraceClass::ContextPtr getTraceContext();
 

--- a/src/stream/Page.cpp
+++ b/src/stream/Page.cpp
@@ -40,15 +40,18 @@ PageCursor::PageCursor(Queue* Que)
   assert(CurPage);
 }
 
+void describePage(FILE* File, Page* Pg) {
+  if (Pg == nullptr)
+    fprintf(File, " nullptr");
+  else
+    Pg->describe(File);
+}
+
 FILE* PageCursor::describe(FILE* File, bool IncludePage) {
   AddressType Addr(CurAddress);
   describeAddress(File, Addr);
-  if (IncludePage) {
-    if (CurPage)
-      CurPage->describe(File);
-    else
-      fprintf(File, " nullptr");
-  }
+  if (IncludePage)
+    describePage(File, CurPage.get());
   return File;
 }
 

--- a/src/stream/Page.h
+++ b/src/stream/Page.h
@@ -121,6 +121,8 @@ class Page : public std::enable_shared_from_this<Page> {
   FILE* describe(FILE* File);
 };
 
+void describePage(FILE* File, Page* Pg);
+
 class PageCursor {
   friend class Queue;
 


### PR DESCRIPTION
The old code showed the internal details of bit read/write positions which meant that the byte address differed due to the internal byte buffer. This PR changes it so that the address corresponds to the data position within the byte being accessed, independent of the internal buffering used.

This makes tracing/debugging much easier. Traces with write positions now match the corresponding read positions (in terms of text), making it easier to track when the read data is no longer tracking what was written.