### PR TITLE
Fix bit reader/writer.

### DIFF
--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -110,6 +110,7 @@ int main(const int Argc, const char* Argv[]) {
   bool MinimizeBlockSize = false;
   bool UseCApi = false;
   size_t NumTries = 1;
+  InterpreterFlags InterpFlags;
 
   {
     ArgsParser Args("Decompress WASM binary file");
@@ -205,12 +206,12 @@ int main(const int Argc, const char* Argv[]) {
     auto Writer = std::make_shared<ByteWriter>(BackedOutput);
     Interpreter Decompressor(
         std::make_shared<ByteReader>(std::make_shared<ReadBackedQueue>(Input)),
-        Writer);
+        Writer, InterpFlags);
     auto AlgState = std::make_shared<DecompAlgState>();
     Decompressor.addSelector(std::make_shared<DecompressSelector>(
-        getAlgwasm0xdSymtab(), AlgState, false));
+        getAlgwasm0xdSymtab(), AlgState, false, InterpFlags));
     Decompressor.addSelector(std::make_shared<DecompressSelector>(
-        getAlgcasm0x0Symtab(), AlgState, true));
+        getAlgcasm0x0Symtab(), AlgState, true, InterpFlags));
     Writer->setMinimizeBlockSize(MinimizeBlockSize);
     if (VerboseTrace) {
       auto Trace = std::make_shared<TraceClass>("Decompress");

--- a/src/exec/decompress.cpp
+++ b/src/exec/decompress.cpp
@@ -106,7 +106,6 @@ int runUsingCApi(bool TraceProgress) {
 int main(const int Argc, const char* Argv[]) {
   // TODO(karlschimpf) Add other default algorithms.
   bool Verbose = false;
-  bool VerboseTrace = false;
   bool MinimizeBlockSize = false;
   bool UseCApi = false;
   size_t NumTries = 1;
@@ -160,9 +159,16 @@ int main(const int Argc, const char* Argv[]) {
                  .setLongName("verbose")
                  .setDescription("Show progress of decompression"));
 
-    ArgsParser::Optional<bool> VerboseTraceFlag(VerboseTrace);
-    Args.add(VerboseTraceFlag.setLongName("verbose=trace")
+    ArgsParser::Optional<bool> VerboseTraceFlag(InterpFlags.TraceProgress);
+    Args.add(VerboseTraceFlag.setLongName("verbose=progress")
                  .setDescription("Show trace of each pass in decompression"));
+
+    ArgsParser::Optional<bool> TraceIntermediateStreamsFlag(
+        InterpFlags.TraceIntermediateStreams);
+    Args.add(
+        TraceIntermediateStreamsFlag.setLongName("verbose=intermediate")
+            .setDescription(
+                "Show contents of each stream between each applied algorithm"));
 
     switch (Args.parse(Argc, Argv)) {
       case ArgsParser::State::Good:
@@ -213,7 +219,7 @@ int main(const int Argc, const char* Argv[]) {
     Decompressor.addSelector(std::make_shared<DecompressSelector>(
         getAlgcasm0x0Symtab(), AlgState, true, InterpFlags));
     Writer->setMinimizeBlockSize(MinimizeBlockSize);
-    if (VerboseTrace) {
+    if (InterpFlags.TraceProgress) {
       auto Trace = std::make_shared<TraceClass>("Decompress");
       Trace->setTraceProgress(true);
       Decompressor.setTrace(Trace);

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -113,7 +113,8 @@ CountNode::RootPtr IntCompressor::getRoot() {
 void IntCompressor::readInput() {
   Contents = std::make_shared<IntStream>();
   auto MyWriter = std::make_shared<IntWriter>(Contents);
-  Interpreter MyReader(std::make_shared<ByteReader>(Input), MyWriter, MyFlags.InterpFlags, Symtab);
+  Interpreter MyReader(std::make_shared<ByteReader>(Input), MyWriter,
+                       MyFlags.InterpFlags, Symtab);
   if (MyFlags.TraceReadingInput)
     MyReader.getTrace().setTraceProgress(true);
   MyReader.algorithmRead();
@@ -138,7 +139,8 @@ void IntCompressor::writeDataOutput(const BitWriteCursor& StartPos,
                                     std::shared_ptr<SymbolTable> Symtab) {
   auto Writer = std::make_shared<ByteWriter>(Output);
   Writer->setPos(StartPos);
-  Interpreter MyReader(std::make_shared<IntReader>(IntOutput), Writer, MyFlags.InterpFlags, Symtab);
+  Interpreter MyReader(std::make_shared<IntReader>(IntOutput), Writer,
+                       MyFlags.InterpFlags, Symtab);
   if (MyFlags.TraceWritingDataOutput)
     MyReader.getTrace().setTraceProgress(true);
   MyReader.useFileHeader(Symtab->getTargetHeader());
@@ -165,7 +167,8 @@ bool IntCompressor::compressUpToSize(size_t Size) {
   Writer->setCountCutoff(MyFlags.CountCutoff);
   Writer->setUpToSize(Size);
 
-  IntInterperter Reader(std::make_shared<IntReader>(Contents), Writer, MyFlags.InterpFlags, Symtab);
+  IntInterperter Reader(std::make_shared<IntReader>(Contents), Writer,
+                        MyFlags.InterpFlags, Symtab);
   if (MyFlags.TraceReadingIntStream)
     Reader.getTrace().setTraceProgress(true);
   Reader.structuralRead();
@@ -264,7 +267,8 @@ bool IntCompressor::generateIntOutput() {
   auto Writer = std::make_shared<AbbrevAssignWriter>(
       Root, IntOutput, MyFlags.LengthLimit, MyFlags.AbbrevFormat,
       !MyFlags.UseHuffmanEncoding);
-  IntInterperter Reader(std::make_shared<IntReader>(Contents), Writer, MyFlags.InterpFlags, Symtab);
+  IntInterperter Reader(std::make_shared<IntReader>(Contents), Writer,
+                        MyFlags.InterpFlags, Symtab);
   if (MyFlags.TraceIntStreamGeneration)
     Reader.getTrace().setTraceProgress(true);
   Reader.structuralRead();

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -113,7 +113,7 @@ CountNode::RootPtr IntCompressor::getRoot() {
 void IntCompressor::readInput() {
   Contents = std::make_shared<IntStream>();
   auto MyWriter = std::make_shared<IntWriter>(Contents);
-  Interpreter MyReader(std::make_shared<ByteReader>(Input), MyWriter, Symtab);
+  Interpreter MyReader(std::make_shared<ByteReader>(Input), MyWriter, MyFlags.InterpFlags, Symtab);
   if (MyFlags.TraceReadingInput)
     MyReader.getTrace().setTraceProgress(true);
   MyReader.algorithmRead();
@@ -138,7 +138,7 @@ void IntCompressor::writeDataOutput(const BitWriteCursor& StartPos,
                                     std::shared_ptr<SymbolTable> Symtab) {
   auto Writer = std::make_shared<ByteWriter>(Output);
   Writer->setPos(StartPos);
-  Interpreter MyReader(std::make_shared<IntReader>(IntOutput), Writer, Symtab);
+  Interpreter MyReader(std::make_shared<IntReader>(IntOutput), Writer, MyFlags.InterpFlags, Symtab);
   if (MyFlags.TraceWritingDataOutput)
     MyReader.getTrace().setTraceProgress(true);
   MyReader.useFileHeader(Symtab->getTargetHeader());
@@ -165,7 +165,7 @@ bool IntCompressor::compressUpToSize(size_t Size) {
   Writer->setCountCutoff(MyFlags.CountCutoff);
   Writer->setUpToSize(Size);
 
-  IntInterperter Reader(std::make_shared<IntReader>(Contents), Writer, Symtab);
+  IntInterperter Reader(std::make_shared<IntReader>(Contents), Writer, MyFlags.InterpFlags, Symtab);
   if (MyFlags.TraceReadingIntStream)
     Reader.getTrace().setTraceProgress(true);
   Reader.structuralRead();
@@ -264,7 +264,7 @@ bool IntCompressor::generateIntOutput() {
   auto Writer = std::make_shared<AbbrevAssignWriter>(
       Root, IntOutput, MyFlags.LengthLimit, MyFlags.AbbrevFormat,
       !MyFlags.UseHuffmanEncoding);
-  IntInterperter Reader(std::make_shared<IntReader>(Contents), Writer, Symtab);
+  IntInterperter Reader(std::make_shared<IntReader>(Contents), Writer, MyFlags.InterpFlags, Symtab);
   if (MyFlags.TraceIntStreamGeneration)
     Reader.getTrace().setTraceProgress(true);
   Reader.structuralRead();

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -21,6 +21,7 @@
 
 #include "intcomp/CompressionFlags.h"
 #include "intcomp/IntCountNode.h"
+#include "interp/Interpreter.h"
 #include "interp/IntFormats.h"
 #include "interp/IntStream.h"
 #include "sexp/Ast.h"
@@ -66,6 +67,7 @@ class IntCompressor FINAL {
     bool TraceAssigningAbbreviations;
     bool TraceCompressedIntOutput;
     std::shared_ptr<utils::TraceClass> Trace;
+    interp::InterpreterFlags InterpFlags;
     Flags();
   };
 

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -52,6 +52,7 @@ struct Decompressor {
   std::shared_ptr<ByteWriter> Writer;
   std::shared_ptr<DecompAlgState> AlgState;
   State MyState;
+  InterpreterFlags Flags;
   Decompressor();
   uint8_t* getBuffer(int32_t Size);
   int32_t resume(int32_t Size);
@@ -177,11 +178,11 @@ void* create_decompressor() {
   auto* Decomp = new Decompressor();
   Decomp->Writer = std::make_shared<ByteWriter>(Decomp->OutputPipe.getInput());
   Decomp->MyReader = std::make_shared<Interpreter>(
-      std::make_shared<ByteReader>(Decomp->Input), Decomp->Writer);
+      std::make_shared<ByteReader>(Decomp->Input), Decomp->Writer, Decomp->Flags);
   Decomp->MyReader->addSelector(std::make_shared<DecompressSelector>(
-      getAlgwasm0xdSymtab(), Decomp->AlgState, false));
+      getAlgwasm0xdSymtab(), Decomp->AlgState, false, Decomp->Flags));
   Decomp->MyReader->addSelector(std::make_shared<DecompressSelector>(
-      getAlgcasm0x0Symtab(), Decomp->AlgState, true));
+      getAlgcasm0x0Symtab(), Decomp->AlgState, true, Decomp->Flags));
   Decomp->MyReader->algorithmStart();
   return Decomp;
 }

--- a/src/interp/Decompress.cpp
+++ b/src/interp/Decompress.cpp
@@ -177,8 +177,9 @@ extern "C" {
 void* create_decompressor() {
   auto* Decomp = new Decompressor();
   Decomp->Writer = std::make_shared<ByteWriter>(Decomp->OutputPipe.getInput());
-  Decomp->MyReader = std::make_shared<Interpreter>(
-      std::make_shared<ByteReader>(Decomp->Input), Decomp->Writer, Decomp->Flags);
+  Decomp->MyReader =
+      std::make_shared<Interpreter>(std::make_shared<ByteReader>(Decomp->Input),
+                                    Decomp->Writer, Decomp->Flags);
   Decomp->MyReader->addSelector(std::make_shared<DecompressSelector>(
       getAlgwasm0xdSymtab(), Decomp->AlgState, false, Decomp->Flags));
   Decomp->MyReader->addSelector(std::make_shared<DecompressSelector>(

--- a/src/interp/DecompressSelector.cpp
+++ b/src/interp/DecompressSelector.cpp
@@ -79,6 +79,8 @@ bool DecompressSelector::applyNextQueuedAlgorithm(Interpreter* R) {
 }
 
 bool DecompressSelector::configureData(Interpreter* R) {
+  if (State->IntermediateStream && Flags.TraceIntermediateStreams)
+    State->IntermediateStream->describe(stderr, "Intermediate stream");
   return State->AlgQueue.empty() ? applyDataAlgorithm(R)
                                  : applyNextQueuedAlgorithm(R);
 }

--- a/src/interp/DecompressSelector.h
+++ b/src/interp/DecompressSelector.h
@@ -67,7 +67,10 @@ class DecompressSelector : public AlgorithmSelector {
                      std::shared_ptr<DecompAlgState> State,
                      bool IsAlgorithm,
                      const InterpreterFlags& Flags)
-      : AlgorithmSelector(Flags), Symtab(Symtab), State(State), IsAlgorithm(IsAlgorithm) {}
+      : AlgorithmSelector(Flags),
+        Symtab(Symtab),
+        State(State),
+        IsAlgorithm(IsAlgorithm) {}
   ~DecompressSelector() OVERRIDE;
   const filt::FileHeaderNode* getTargetHeader() OVERRIDE;
   bool configure(Interpreter* R) OVERRIDE;

--- a/src/interp/DecompressSelector.h
+++ b/src/interp/DecompressSelector.h
@@ -65,8 +65,9 @@ class DecompressSelector : public AlgorithmSelector {
  public:
   DecompressSelector(std::shared_ptr<filt::SymbolTable> Symtab,
                      std::shared_ptr<DecompAlgState> State,
-                     bool IsAlgorithm)
-      : Symtab(Symtab), State(State), IsAlgorithm(IsAlgorithm) {}
+                     bool IsAlgorithm,
+                     const InterpreterFlags& Flags)
+      : AlgorithmSelector(Flags), Symtab(Symtab), State(State), IsAlgorithm(IsAlgorithm) {}
   ~DecompressSelector() OVERRIDE;
   const filt::FileHeaderNode* getTargetHeader() OVERRIDE;
   bool configure(Interpreter* R) OVERRIDE;
@@ -76,6 +77,7 @@ class DecompressSelector : public AlgorithmSelector {
   std::shared_ptr<filt::SymbolTable> Symtab;
   std::shared_ptr<DecompAlgState> State;
   bool IsAlgorithm;
+
   bool configureAlgorithm(Interpreter* R);
   bool configureData(Interpreter* R);
   bool resetAlgorithm(Interpreter* R);

--- a/src/interp/IntInterpreter.cpp
+++ b/src/interp/IntInterpreter.cpp
@@ -28,8 +28,9 @@ namespace interp {
 
 IntInterperter::IntInterperter(std::shared_ptr<IntReader> Input,
                                std::shared_ptr<Writer> Output,
+                               const InterpreterFlags& Flags,
                                std::shared_ptr<filt::SymbolTable> Symtab)
-    : Interpreter(Input, Output, Symtab), IntInput(Input) {
+    : Interpreter(Input, Output, Flags, Symtab), IntInput(Input) {
   // TODO(karlschimpf) Modify structuralStart() to mimic algorithmStart(),
   // except that it calls structuralResume() to remove this assertion.
   assert(Symtab && "IntInterperter must be given algorithm at construction");

--- a/src/interp/IntInterpreter.h
+++ b/src/interp/IntInterpreter.h
@@ -39,6 +39,7 @@ class IntInterperter : public Interpreter {
  public:
   IntInterperter(std::shared_ptr<IntReader> Input,
                  std::shared_ptr<Writer> Output,
+                 const InterpreterFlags& Flags,
                  std::shared_ptr<filt::SymbolTable> Symtab);
   ~IntInterperter() OVERRIDE;
 

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -100,8 +100,7 @@ struct {
 }  // end of anonymous namespace
 
 InterpreterFlags::InterpreterFlags()
-    : TraceProgress(false),
-      TraceIntermediateStreams(false) {
+    : TraceProgress(false), TraceIntermediateStreams(false) {
 }
 
 void Interpreter::setInput(std::shared_ptr<Reader> Value) {

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -99,6 +99,11 @@ struct {
 
 }  // end of anonymous namespace
 
+InterpreterFlags::InterpreterFlags()
+    : TraceProgress(false),
+      TraceIntermediateStreams(false) {
+}
+
 void Interpreter::setInput(std::shared_ptr<Reader> Value) {
   Input = Value;
   if (Trace) {
@@ -181,9 +186,11 @@ const char* Interpreter::getName(SectionCode Code) {
 
 Interpreter::Interpreter(std::shared_ptr<Reader> Input,
                          std::shared_ptr<Writer> Output,
+                         const InterpreterFlags& Flags,
                          std::shared_ptr<filt::SymbolTable> Symtab)
     : Input(Input),
       Output(Output),
+      Flags(Flags),
       Symtab(Symtab),
       LastReadValue(0),
       DispatchedMethod(Method::NO_SUCH_METHOD),

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -39,13 +39,20 @@ namespace interp {
 
 class Interpreter;
 
+
+struct InterpreterFlags {
+  InterpreterFlags();
+  bool TraceProgress;
+  bool TraceIntermediateStreams;
+};
+
 class AlgorithmSelector
     : public std::enable_shared_from_this<AlgorithmSelector> {
   AlgorithmSelector(const AlgorithmSelector&) = delete;
   AlgorithmSelector& operator=(const AlgorithmSelector&) = delete;
 
  public:
-  explicit AlgorithmSelector() {}
+  explicit AlgorithmSelector(const InterpreterFlags& Flags) : Flags(Flags) {}
   virtual ~AlgorithmSelector() {}
 
   // Returns the header to match.
@@ -58,6 +65,8 @@ class AlgorithmSelector
   // Called after reading from file using the symbol table. Allows one
   // to restore/reconfigure the reader.
   virtual bool reset(Interpreter* R) = 0;
+
+  const InterpreterFlags& Flags;
 };
 
 class Interpreter {
@@ -66,8 +75,10 @@ class Interpreter {
   Interpreter& operator=(const Interpreter&) = delete;
 
  public:
+
   Interpreter(std::shared_ptr<Reader> Input,
               std::shared_ptr<Writer> Output,
+              const InterpreterFlags& Flags,
               std::shared_ptr<filt::SymbolTable> Symtab =
                   std::shared_ptr<filt::SymbolTable>());
   virtual ~Interpreter();
@@ -242,6 +253,7 @@ class Interpreter {
 
   std::shared_ptr<Reader> Input;
   std::shared_ptr<Writer> Output;
+  const InterpreterFlags& Flags;
   std::shared_ptr<filt::SymbolTable> Symtab;
   std::vector<std::shared_ptr<AlgorithmSelector>> Selectors;
   // The current section name (if applicable).

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -39,7 +39,6 @@ namespace interp {
 
 class Interpreter;
 
-
 struct InterpreterFlags {
   InterpreterFlags();
   bool TraceProgress;
@@ -75,7 +74,6 @@ class Interpreter {
   Interpreter& operator=(const Interpreter&) = delete;
 
  public:
-
   Interpreter(std::shared_ptr<Reader> Input,
               std::shared_ptr<Writer> Output,
               const InterpreterFlags& Flags,

--- a/src/sexp/CasmReader.cpp
+++ b/src/sexp/CasmReader.cpp
@@ -78,8 +78,8 @@ void CasmReader::readBinary(std::shared_ptr<Queue> Binary,
                             std::shared_ptr<SymbolTable> AlgSymtab) {
   auto Inflator = std::make_shared<InflateAst>();
   InterpreterFlags Flags;
-  Interpreter MyReader(std::make_shared<ByteReader>(Binary), Inflator,
-                       Flags, AlgSymtab);
+  Interpreter MyReader(std::make_shared<ByteReader>(Binary), Inflator, Flags,
+                       AlgSymtab);
   if (TraceRead || TraceTree) {
     auto Trace = std::make_shared<TraceClass>("CasmInterpreter");
     Trace->setTraceProgress(true);

--- a/src/sexp/CasmReader.cpp
+++ b/src/sexp/CasmReader.cpp
@@ -77,8 +77,9 @@ void CasmReader::readText(charstring Filename) {
 void CasmReader::readBinary(std::shared_ptr<Queue> Binary,
                             std::shared_ptr<SymbolTable> AlgSymtab) {
   auto Inflator = std::make_shared<InflateAst>();
+  InterpreterFlags Flags;
   Interpreter MyReader(std::make_shared<ByteReader>(Binary), Inflator,
-                       AlgSymtab);
+                       Flags, AlgSymtab);
   if (TraceRead || TraceTree) {
     auto Trace = std::make_shared<TraceClass>("CasmInterpreter");
     Trace->setTraceProgress(true);

--- a/src/sexp/CasmWriter.cpp
+++ b/src/sexp/CasmWriter.cpp
@@ -76,7 +76,8 @@ const BitWriteCursor& CasmWriter::writeBinary(
     Writer = Tee;
   }
   InterpreterFlags Flags;
-  Interpreter MyReader(std::make_shared<IntReader>(IntSeq), Writer, Flags, AlgSymtab);
+  Interpreter MyReader(std::make_shared<IntReader>(IntSeq), Writer, Flags,
+                       AlgSymtab);
   MyReader.setFreezeEofAtExit(FreezeEofAtExit);
   if (TraceWriter || TraceTree) {
     auto Trace = std::make_shared<TraceClass>("CasmWriter");

--- a/src/sexp/CasmWriter.cpp
+++ b/src/sexp/CasmWriter.cpp
@@ -75,7 +75,8 @@ const BitWriteCursor& CasmWriter::writeBinary(
     Tee->add(Writer, true, false, true);
     Writer = Tee;
   }
-  Interpreter MyReader(std::make_shared<IntReader>(IntSeq), Writer, AlgSymtab);
+  InterpreterFlags Flags;
+  Interpreter MyReader(std::make_shared<IntReader>(IntSeq), Writer, Flags, AlgSymtab);
   MyReader.setFreezeEofAtExit(FreezeEofAtExit);
   if (TraceWriter || TraceTree) {
     auto Trace = std::make_shared<TraceClass>("CasmWriter");

--- a/src/stream/BitReadCursor.cpp
+++ b/src/stream/BitReadCursor.cpp
@@ -88,12 +88,12 @@ void BitReadCursor::describeDerivedExtensions(FILE* File, bool IncludeDetail) {
   fprintf(File, ":%u", BitsInByte - NumBits);
 }
 
-#define BITREAD(Mask, MaskSize)                                 \
+#define BITREAD_TYPED(Mask, MaskSize)                           \
   do {                                                          \
     if (NumBits >= MaskSize) {                                  \
       NumBits -= MaskSize;                                      \
       uint8_t Value = uint8_t(CurWord >> NumBits);              \
-      CurWord &= ~Mask << NumBits;                              \
+      CurWord &= ~(Mask << NumBits);                            \
       return Value;                                             \
     }                                                           \
     if (atEob())                                                \
@@ -108,6 +108,9 @@ void BitReadCursor::describeDerivedExtensions(FILE* File, bool IncludeDetail) {
   CurWord = 0;                                                  \
   NumBits = 0;                                                  \
   return Value;
+
+#define BITREAD(Mask, MaskSize) \
+  BITREAD_TYPED(WordType(Mask), unsigned(MaskSize))
 
 namespace {
 

--- a/src/stream/BitReadCursor.h
+++ b/src/stream/BitReadCursor.h
@@ -45,7 +45,7 @@ class BitReadCursor : public ReadCursor {
 
   void swap(BitReadCursor& C);
 
-  uint8_t readByte();
+  uint8_t readByte() OVERRIDE;
   uint8_t readBit();
   void alignToByte();
 

--- a/src/stream/BitWriteCursor.h
+++ b/src/stream/BitWriteCursor.h
@@ -53,7 +53,7 @@ class BitWriteCursor : public WriteCursor {
 
   void swap(BitWriteCursor& C);
 
-  void writeByte(uint8_t Byte);
+  void writeByte(uint8_t Byte) OVERRIDE;
   void writeBit(uint8_t Bit);
   void alignToByte();
 

--- a/src/stream/ReadCursor.cpp
+++ b/src/stream/ReadCursor.cpp
@@ -44,6 +44,10 @@ size_t ReadCursor::advance(size_t Distance) {
   return DistanceMoved;
 }
 
+uint8_t ReadCursor::readByte() {
+  return (CurAddress < GuaranteedBeforeEob) ? readOneByte() : readByteAfterReadFill();
+}
+
 uint8_t ReadCursor::readOneByte() {
   assert(CurPage);
   uint8_t Byte = *getBufferPtr();

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -67,13 +67,8 @@ class ReadCursor : public Cursor {
     updateGuaranteedBeforeEob();
   }
 
-  // Reads next byte. Returns zero if at end of file. NOTE: Assumes byte
-  // aligned!
-  uint8_t readByte() {
-    if (CurAddress < GuaranteedBeforeEob)
-      return readOneByte();
-    return readByteAfterReadFill();
-  }
+  // Reads next byte. Returns zero if at end of file.
+  virtual uint8_t readByte();
 
   // Try to advance Distance bytes. Returns actual number of bytes advanced.  If
   // zero is returned (and Distance > 0), no more bytes are available to advance

--- a/src/stream/WriteCursorBase.cpp
+++ b/src/stream/WriteCursorBase.cpp
@@ -23,6 +23,13 @@ namespace decode {
 WriteCursorBase::~WriteCursorBase() {
 }
 
+void WriteCursorBase::writeByte(uint8_t Byte) {
+  if (CurAddress < GuaranteedBeforeEob)
+    writeOneByte(Byte);
+  else
+    writeFillWriteByte(Byte);
+}
+
 void WriteCursorBase::writeOneByte(uint8_t Byte) {
   *getBufferPtr() = Byte;
   ++CurAddress;

--- a/src/stream/WriteCursorBase.h
+++ b/src/stream/WriteCursorBase.h
@@ -47,13 +47,8 @@ class WriteCursorBase : public Cursor {
     return *this;
   }
 
-  // Writes next byte. Fails if at end of file. NOTE: Assumed byte aligned!
-  void writeByte(uint8_t Byte) {
-    if (CurAddress < GuaranteedBeforeEob)
-      writeOneByte(Byte);
-    else
-      writeFillWriteByte(Byte);
-  }
+  // Writes next byte. Fails if at end of file.
+  virtual void writeByte(uint8_t Byte);
 
  protected:
   void writeOneByte(uint8_t Byte);


### PR DESCRIPTION
1) made readByte/writeByte virtual in Cursors (making sure correct read/write method is called).

2) Fixed typing associated with macro READBIT, which was causing the wrong bits to be masked on read.

4) Improve tracing capabilities via a "flags" class for interpreters, so that there is a finer granularity on tracing.