### PR TITLE
Make method atEob virtual for read cursors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -949,10 +949,8 @@ $(TEST_WASM_COMP_FILES): $(TEST_0XD_GENDIR)/%.wasm-comp: $(TEST_0XD_SRCDIR)/%.wa
 		$(BUILD_EXECDIR)/compress-int $(BUILD_EXECDIR)/decompress
 	$(BUILD_EXECDIR)/compress-int --min-int-count 2 --min-weight 5 $< \
 	| $(BUILD_EXECDIR)/decompress - | cmp - $<
-
-# TODO(karlschimpf) Turn test back on when binary bit reading/writing working.
-#	$(BUILD_EXECDIR)/compress-int --Huffman --min-int-count 2 --min-weight 5 $< \
-#	| $(BUILD_EXECDIR)/decompress - | cmp - $<
+	$(BUILD_EXECDIR)/compress-int --Huffman --min-int-count 2 --min-weight 5 $< \
+	| $(BUILD_EXECDIR)/decompress - | cmp - $<
 
 .PHONY: $(TEST_WASM_COMP_FILES)
 

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1276,8 +1276,7 @@ void Interpreter::algorithmResume() {
               return throwMessage(
                   "Unable to reset state after appplying algorithm");
             TRACE_MESSAGE("Reset did not specify any more symtabs");
-            TRACE(bool, "atEof", Input->atInputEof());
-            if (Input->atInputEof()) {
+            if (atInputEob()) {
               LoopCounterStack.pop();
               Frame.CallState = State::Exit;
               break;

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -178,7 +178,7 @@ void TextWriter::writeNode(const Node* Nd,
     if (!Int->isDefaultValue()) {
       fputc(' ', File);
       writeInt(File, Int->getValue(), Int->getFormat());
-      if (const auto* Accept = dyn_cast<BinaryAcceptNode>(Int)) {
+      if (const auto* Accept = dyn_cast<BinaryLeafNode>(Int)) {
         fputc(':', File);
         fprintf(File, "%u", Accept->getNumBits());
       }

--- a/src/stream/BitReadCursor.cpp
+++ b/src/stream/BitReadCursor.cpp
@@ -118,6 +118,12 @@ static constexpr BitReadCursor::WordType ByteMask = (1 << BitsInByte) - 1;
 
 }  // end of anonymous namespace
 
+bool BitReadCursor::atEob() {
+  if (!ReadCursor::atEob())
+    return false;
+  return NumBits == 0;
+}
+
 uint8_t BitReadCursor::readByte() {
   if (NumBits == 0)
     return ReadCursor::readByte();

--- a/src/stream/BitReadCursor.h
+++ b/src/stream/BitReadCursor.h
@@ -45,6 +45,7 @@ class BitReadCursor : public ReadCursor {
 
   void swap(BitReadCursor& C);
 
+  bool atEob() OVERRIDE;
   uint8_t readByte() OVERRIDE;
   uint8_t readBit();
   void alignToByte();

--- a/src/stream/ReadCursor.cpp
+++ b/src/stream/ReadCursor.cpp
@@ -22,6 +22,14 @@ using namespace utils;
 
 namespace decode {
 
+bool ReadCursor::atEob() {
+  if (CurAddress < GuaranteedBeforeEob)
+    return false;
+  bool Result = CurAddress >= getEobAddress() || !readFillBuffer();
+  updateGuaranteedBeforeEob();
+  return Result;
+}
+
 uint8_t ReadCursor::readByteAfterReadFill() {
   bool atEof = isIndexAtEndOfPage() && !readFillBuffer();
   updateGuaranteedBeforeEob();

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -48,13 +48,7 @@ class ReadCursor : public Cursor {
     return *this;
   }
 
-  bool atEob() {
-    if (CurAddress < GuaranteedBeforeEob)
-      return false;
-    bool Result = CurAddress >= getEobAddress() || !readFillBuffer();
-    updateGuaranteedBeforeEob();
-    return Result;
-  }
+  virtual bool atEob();
 
   void pushEobAddress(AddressType NewValue) {
     EobPtr = std::make_shared<BlockEob>(NewValue, EobPtr);


### PR DESCRIPTION
Fixes bug where the BitReadCursor must be aware whether all bits within buffer have been read.