### PR TITLE
Add singleton integers to patterns, and remove weighting on length

### DIFF
--- a/src/intcomp/AbbreviationCodegen.cpp
+++ b/src/intcomp/AbbreviationCodegen.cpp
@@ -115,12 +115,9 @@ Node* AbbreviationCodegen::generateSwitchStatement() {
   SwitchStmt->append(generateAbbreviationRead());
   SwitchStmt->append(Symtab->create<ErrorNode>());
   for (size_t i = 0; i < Assignments.size(); ++i) {
-    if (EncodingRoot) {
-      CountNode::Ptr Nd = Assignments[i];
-      SwitchStmt->append(generateCase(Nd->getAbbrevIndex(), Nd));
-    } else {
-      SwitchStmt->append(generateCase(i, Assignments[i]));
-    }
+    CountNode::Ptr Nd = Assignments[i];
+    assert(Nd->hasAbbrevIndex());
+    SwitchStmt->append(generateCase(Nd->getAbbrevIndex(), Nd));
   }
   return SwitchStmt;
 }

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -307,26 +307,12 @@ void IntCountNode::describe(FILE* Out, size_t NestLevel) const {
 SingletonCountNode::~SingletonCountNode() {
 }
 
-size_t SingletonCountNode::getWeight(size_t Count) const {
-  return Count * getLocalWeight();
-}
-
 void SingletonCountNode::describeValues(FILE* Out) const {
   fputs("Value: ", Out);
   fprint_IntType(Out, getValue());
 }
 
 IntSeqCountNode::~IntSeqCountNode() {
-}
-
-size_t IntSeqCountNode::getWeight(size_t Count) const {
-  size_t Weight = 0;
-  const IntCountNode* Nd = this;
-  while (Nd) {
-    Weight += Nd->getLocalWeight() * Count;
-    Nd = dyn_cast<IntCountNode>(Nd->getParent().get());
-  }
-  return Weight;
 }
 
 void IntSeqCountNode::describeValues(FILE* Out) const {

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -141,7 +141,8 @@ void CountNode::newline(FILE* Out) const {
   fprintf(Out, " - Count: %" PRIuMAX "", uintmax_t(getCount()));
   if (hasAbbrevIndex())
     fprintf(Out, " Abbrev: %" PRIuMAX "", uintmax_t(getAbbrevIndex()));
-  if (AbbrevSymbol)
+  if (AbbrevSymbol && AbbrevSymbol->getNumBits())
+    // Assume binary encoded, so add binary encoding.
     fprintf(Out, " -> 0x%" PRIxMAX ":%u", uintmax_t(AbbrevSymbol->getPath()),
             AbbrevSymbol->getNumBits());
   fputc('\n', Out);

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -265,7 +265,7 @@ class IntCountNode : public CountNodeWithSuccs {
   ~IntCountNode() OVERRIDE {}
   int compare(const CountNode& Nd) const OVERRIDE;
   void describe(FILE* Out, size_t NestLevel = 0) const OVERRIDE;
-  size_t getValue() const { return Value; }
+  decode::IntType getValue() const { return Value; }
   size_t getPathLength() const { return PathLength; }
   CountNode::IntPtr getParent() const { return Parent.lock(); }
   size_t getLocalWeight() const;

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -302,7 +302,6 @@ class SingletonCountNode : public IntCountNode {
   SingletonCountNode(decode::IntType Value)
       : IntCountNode(Kind::Singleton, Value) {}
   ~SingletonCountNode() OVERRIDE;
-  size_t getWeight(size_t Count) const OVERRIDE;
   static bool implementsClass(Kind NodeKind) {
     return NodeKind == Kind::Singleton;
   }
@@ -321,7 +320,6 @@ class IntSeqCountNode : public IntCountNode {
       : IntCountNode(Kind::IntSequence, Value, Parent) {}
 
   ~IntSeqCountNode() OVERRIDE;
-  size_t getWeight(size_t Count) const OVERRIDE;
   static bool implementsClass(Kind NodeKind) {
     return NodeKind == Kind::IntSequence;
   }

--- a/src/utils/HuffmanEncoding.cpp
+++ b/src/utils/HuffmanEncoding.cpp
@@ -153,7 +153,8 @@ HuffmanEncoder::NodePtr HuffmanEncoder::Selector::installPaths(
     NodePtr K1 = Sel->getKid1();
     K1 = K1->installPaths(K1, Encoder, Path, KidBits);
     NodePtr K2 = Sel->getKid2();
-    K2 = K2->installPaths(K2, Encoder, Path | (1 << NumBits), KidBits);
+    K2 =
+        K2->installPaths(K2, Encoder, Path | (PathType(1) << NumBits), KidBits);
     if (K1 && K2) {
       Sel->Kid1 = K1;
       Sel->Kid2 = K2;


### PR DESCRIPTION
Do some clean ups based on testing, that shows ways to improve compression by about 3 percent.

Note: Weights based on length actually made things worse, and ignoring singleton integers removed several candidates that would do better (about 7).