### PR TITLE
Dynamically refactor initial abbreviation assighments

### DIFF
--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -118,7 +118,6 @@ void AbbreviationsCollector::addAbbreviation(CountNode::Ptr Nd) {
   }
   CountNode* NdPtr = Nd.get();
   uint64_t Count = NdPtr->getCount();
-  bool ErasedParents = false;
   while (auto* IntNd = dyn_cast<IntCountNode>(NdPtr)) {
     CountNode::IntPtr Parent = IntNd->getParent();
     if (!Parent)
@@ -143,7 +142,6 @@ void AbbreviationsCollector::addAbbreviation(CountNode::Ptr Nd) {
     if (Assignments.count(Parent) > 0) {
       TRACE_MESSAGE("Removing from assignments");
       Assignments.erase(Parent);
-      ErasedParents = true;
     }
     NdPtr = ParentPtr;
   }

--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -154,19 +154,34 @@ void AbbreviationsCollector::addAbbreviation(CountNode::Ptr Nd) {
     if (OldCount == NewCount)
       break;
     ParentPtr->setCount(NewCount);
-    if (CountNode::HeapEntryType Entry = ParentPtr->getAssociatedHeapEntry())
-      Entry->reinsert();
     TRACE_BLOCK({
         FILE* Out = getTrace().getFile();
         fprintf(Out, "Updated Parent: ");
         ParentPtr->describe(Out);
       });
+    if (CountNode::HeapEntryType Entry = ParentPtr->getAssociatedHeapEntry()) {
+      fprintf(stderr, "Before updating:\n");
+      ValuesHeap->describe(stderr,
+                           [](FILE* Out, CountNode::HeapValueType Nd) {
+                             Nd->describe(Out);
+                           });
+      if (! Entry->reinsert()) {
+        CountNode::Ptr Nd = Parent;
+        ValuesHeap->push(Nd);
+      }
+      fprintf(stderr, "After updating:\n");
+      ValuesHeap->describe(stderr,
+                           [](FILE* Out, CountNode::HeapValueType Nd) {
+                             Nd->describe(Out);
+                           });
+    }
     if (Assignments.count(Parent) > 0) {
       TRACE_MESSAGE("Removing from assignments");
       Assignments.erase(Parent);
     }
     NdPtr = ParentPtr;
   }
+  TRACE(size_t, "Number assignements", Assignments.size());
 }
 
 }  // end of namespace intcomp

--- a/src/intcomp/AbbreviationsCollector.h
+++ b/src/intcomp/AbbreviationsCollector.h
@@ -56,8 +56,6 @@ class AbbreviationsCollector : public CountNodeCollector {
   std::shared_ptr<utils::TraceClass> Trace;
 
   void addAbbreviation(CountNode::Ptr Nd);
-  void removeAbbreviation(CountNode::Ptr Nd);
-  void removeAbbreviationSuccs(CountNode::Ptr Nd);
 };
 
 }  // end of namespace intcomp

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -67,8 +67,17 @@ void CountNodeCollector::clear() {
 }
 
 void CountNodeCollector::buildHeap() {
+#if 1
   for (auto& Value : Values)
     Value->associateWithHeap(ValuesHeap->push(Value));
+#else
+  for (auto& Value : Values) {
+    fprintf(stderr, "Add: ");
+    Value->describe(stderr);
+    Value->associateWithHeap(ValuesHeap->push(Value));
+    ValuesHeap->showEntryPtrs(stderr);
+  }
+#endif
 }
 
 void CountNodeCollector::collectUsingCutoffs(size_t MyCountCutoff,

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -67,17 +67,26 @@ void CountNodeCollector::clear() {
 }
 
 void CountNodeCollector::buildHeap() {
-#if 1
   for (auto& Value : Values)
-    Value->associateWithHeap(ValuesHeap->push(Value));
-#else
-  for (auto& Value : Values) {
-    fprintf(stderr, "Add: ");
-    Value->describe(stderr);
-    Value->associateWithHeap(ValuesHeap->push(Value));
-    ValuesHeap->showEntryPtrs(stderr);
-  }
-#endif
+    pushHeap(Value);
+}
+
+void CountNodeCollector::pushHeap(CountNode::Ptr Nd) {
+  assert(ValuesHeap);
+  Nd->associateWithHeap(ValuesHeap->push(Nd));
+}
+
+CountNode::HeapValueType CountNodeCollector::popHeap() {
+  assert(ValuesHeap);
+  CountNode::HeapEntryType Entry = ValuesHeap->top();
+  ValuesHeap->pop();
+  return Entry->getValue();
+}
+
+void CountNodeCollector::describeHeap(FILE* Out) {
+  ValuesHeap->describe(Out, [](FILE* Out, CountNode::HeapValueType Value) {
+    Value->describe(Out);
+  });
 }
 
 void CountNodeCollector::collectUsingCutoffs(size_t MyCountCutoff,

--- a/src/intcomp/CountNodeCollector.h
+++ b/src/intcomp/CountNodeCollector.h
@@ -51,18 +51,10 @@ class CountNodeCollector {
       CollectionFlags Flags = makeFlags(CollectionFlag::All));
   void collectAbbreviations();
   void buildHeap();
-  CountNode::HeapValueType popHeap() {
-    assert(ValuesHeap);
-    CountNode::HeapEntryType Entry = ValuesHeap->top();
-    ValuesHeap->pop();
-    return Entry->getValue();
-  }
+  void pushHeap(CountNode::Ptr Nd);
+  CountNode::HeapValueType popHeap();
   void clearHeap();
-  void describeHeap(FILE* Out) {
-    ValuesHeap->describe(Out, [](FILE* Out, CountNode::HeapValueType Value) {
-      Value->describe(Out);
-    });
-  }
+  void describeHeap(FILE* Out);
   void clear();
   void collectNode(CountNode::Ptr Nd);
 

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -70,24 +70,9 @@ CountNode::~CountNode() {
   disassociateFromHeap();
 }
 
-#if 1
-void CountNode::associateWithHeap(HeapEntryType Entry) {
-  HeapEntry = Entry;
-#if 1
-  fprintf(stderr, "Associate: ");
-  describe(stderr);
-  fprintf(stderr, "Is valid = %d\n", HeapEntry->isValid());
-#endif
-}
-#endif
-
 void CountNode::disassociateFromHeap() {
   if (!HeapEntry)
     return;
-#if 1
-  fprintf(stderr, "Disassociate: ");
-  describe(stderr);
-#endif
   HeapEntry->remove();
   HeapEntry.reset();
 }

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -70,9 +70,24 @@ CountNode::~CountNode() {
   disassociateFromHeap();
 }
 
+#if 1
+void CountNode::associateWithHeap(HeapEntryType Entry) {
+  HeapEntry = Entry;
+#if 1
+  fprintf(stderr, "Associate: ");
+  describe(stderr);
+  fprintf(stderr, "Is valid = %d\n", HeapEntry->isValid());
+#endif
+}
+#endif
+
 void CountNode::disassociateFromHeap() {
   if (!HeapEntry)
     return;
+#if 1
+  fprintf(stderr, "Disassociate: ");
+  describe(stderr);
+#endif
   HeapEntry->remove();
   HeapEntry.reset();
 }

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -87,11 +87,7 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
 
   // The following two handle associating a heap entry with this.
   HeapEntryType getAssociatedHeapEntry() { return HeapEntry; }
-#if 0
   void associateWithHeap(HeapEntryType Entry) { HeapEntry = Entry; }
-#else
-  void associateWithHeap(HeapEntryType Entry);
-#endif
   void disassociateFromHeap();
 
   static bool isAbbrevDefined(decode::IntType Abbrev) {

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -87,7 +87,11 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
 
   // The following two handle associating a heap entry with this.
   HeapEntryType getAssociatedHeapEntry() { return HeapEntry; }
+#if 0
   void associateWithHeap(HeapEntryType Entry) { HeapEntry = Entry; }
+#else
+  void associateWithHeap(HeapEntryType Entry);
+#endif
   void disassociateFromHeap();
 
   static bool isAbbrevDefined(decode::IntType Abbrev) {

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -86,7 +86,7 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
   void increment(size_t Cnt = 1) { Count += Cnt; }
 
   // The following two handle associating a heap entry with this.
-  HeapEntryType getAssociatedHeadEntry() { return HeapEntry; }
+  HeapEntryType getAssociatedHeapEntry() { return HeapEntry; }
   void associateWithHeap(HeapEntryType Entry) { HeapEntry = Entry; }
   void disassociateFromHeap();
 

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -59,7 +59,7 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
     value_type getValue() { return Value; }
     bool reinsert() {
       bool Inserted = false;
-      if (auto HeapPtr = HeapWeakPtr->lock()) {
+      if (auto HeapPtr = HeapWeakPtr.lock()) {
         if (HeapPtr->isValidEntry(this)) {
           HeapPtr->reinsert(Index);
           Inserted = true;

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -73,11 +73,9 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
       bool Removed = false;
       if (auto HeapPtr = HeapWeakPtr.lock()) {
         if (HeapPtr->isValidEntry(this)) {
-          fprintf(stderr, "Is valid entry\n");
           HeapPtr->remove(Index);
           Removed = true;
         } else {
-          fprintf(stderr, "Is invalid entry\n");
           HeapWeakPtr.reset();
         }
       }
@@ -101,8 +99,7 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
   typedef std::function<bool(value_type, value_type)> CompareFcn;
   // WARNING: Only create using std::make_shared<heap<value_type>>(); DO NOT
   // call constructor directly!
-  heap(CompareFcn LtFcn)
-      : LtFcn(LtFcn) {}
+  heap(CompareFcn LtFcn) : LtFcn(LtFcn) {}
 
   ~heap() {}
 
@@ -118,13 +115,6 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
   bool isValidEntry(entry* E) {
     if (E->Index >= Contents.size())
       return false;
-#if 1
-
-    fprintf(stderr, "E = %p [%u], C = %p [%u]\n",
-            (void*)E, unsigned(E->Index),
-            (void*)Contents[E->Index].get(), unsigned(Contents[E->Index]->Index));
-    showEntryPtrs(stderr);
-#endif
     return Contents[E->Index].get() == E;
   }
 
@@ -159,16 +149,6 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
     fprintf(Out, "************:\n");
   }
 
-#if 1
-  void showEntryPtrs(FILE* Out) {
-    fprintf(Out, "*** Entry Ptrs ***\n");
-    for (size_t i = 0; i < Contents.size(); ++i)
-      fprintf(Out, "[%u] = %p[%u]\n", unsigned(i), (void*)Contents[i].get(),
-              unsigned(Contents[i]->Index));
-    fprintf(Out, "******************\n");
-  }
-#endif
-
  private:
   std::vector<entry_ptr> Contents;
 
@@ -189,19 +169,9 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
       auto& Kid = Contents[KidIndex];
       if (!LtFcn(Kid->getValue(), Parent->getValue()))
         return Moved;
-#if 0
-      fprintf(stderr, "Before swap: P = %p [%u], K = %p [%u]\n",
-              (void*)Parent.get(), unsigned(Parent->Index),
-              (void*)Kid.get(), unsigned(Kid->Index));
-#endif
       Parent->Index = KidIndex;
       Kid->Index = ParentIndex;
       std::swap(Parent, Kid);
-#if 0
-      fprintf(stderr, "After swap: P = %p [%u], K = %p [%u]\n",
-              (void*)Parent.get(), unsigned(Parent->Index),
-              (void*)Kid.get(), unsigned(Kid->Index));
-#endif
       KidIndex = ParentIndex;
       Moved = true;
     }


### PR DESCRIPTION
Dynamically adds/removes abbreviation patterns, based one a pattern being a prefix of another selected pattern. In such cases, it assumes the longer pattern  will be chosen, and the prefix count is decremented accordingly.

Also fixes bug in heap implementation for dynamically updating when the weight (and hence comparison) changes for a node. The bug was that as elements are swapped on the heap, they did not correctly update the heap index, and hence, the reinsert method (that reinserts a node whose weight may have changed) could not (quickly) find its proper location in the heap.

Also removed incorrect trimming code that removed longer patterns if a shorter patter n is chosen first. In such cases, you need to wait until you can decide if the longer pattern should be added, which is what the algorithm now does.

Note: There is still a bug in the abbreviation insertion code for the generated integer sequence. This results in more integers in the compressed integer sequence. Putting off fixing this latter problem to another PR.