### PR TITLE
Properly strip counts for overlapping abbreviation assignments.

### DIFF
--- a/src/intcomp/AbbreviationsCollector.h
+++ b/src/intcomp/AbbreviationsCollector.h
@@ -54,6 +54,7 @@ class AbbreviationsCollector : public CountNodeCollector {
   utils::HuffmanEncoder::NodePtr HuffmanRoot;
   utils::HuffmanEncoder::NodePtr Encoding;
   std::shared_ptr<utils::TraceClass> Trace;
+  CountNode::PtrSet TrimmedNodes;
 
   void addAbbreviation(CountNode::Ptr Nd);
 };

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -132,6 +132,13 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
     return Entry;
   }
 
+  void push(entry* Entry) {
+    Entry->Index = Contents.size();
+    Contents.push_back(Entry);
+    insertUp(Entry->Index);
+    return Entry;
+  }
+
   void pop() { remove(0); }
 
   // Reinsert value since key changed.


### PR DESCRIPTION
Fixed the code that chooses the initial abbreviation assignments to correctly update counts, based on overlapping.  That is, when a longer abbreviation pattern is chosen, remove the corresponding number of instances from prefix abbreviations.

Note that previous code did not always do this update correctly. This Cl adds a set of "TrimmedNodes" that keeps track of nodes that have already been trimmed from its prefixes. This keeps the algorithm from trimming multiple times for those abbreviations that get added/removed multiple times (due to count changes). 