### PR TITLE
Tune window size for selecting abbreviations.

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -1,4 +1,4 @@
-/* -*- C++ -*- */
+//* -*- C++ -*- */
 //
 // Copyright 2016 WebAssembly Community Group participants
 //
@@ -117,12 +117,12 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Optional<size_t> PatternLengthMultiplierFlag(
         MyCompressionFlags.PatternLengthMultiplier);
-    Args.add(PatternLengthMultiplierFlag.setLongName("window-mulitplier")
-             .setOptionName("INTEGER")
-             .setDescription(
-                 "Multiplier of 'max-length' to get window size used to "
-                 "figure out optimal layout of pattern abbreviations for "
-                 "the window"));
+    Args.add(PatternLengthMultiplierFlag.setLongName("window-multiplier")
+                 .setOptionName("INTEGER")
+                 .setDescription(
+                     "Multiplier of 'max-length' to get window size used to "
+                     "figure out optimal layout of pattern abbreviations for "
+                     "the window"));
 
     ArgsParser::Optional<size_t> MaxAbbreviationsFlag(
         MyCompressionFlags.MaxAbbreviations);
@@ -224,7 +224,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceIntCountsCollectionFlag(
         MyCompressionFlags.TraceIntCountsCollection);
     Args.add(TraceIntCountsCollectionFlag.setLongName(
-                                              "verbose=int-counts-collection")
+                                             "verbose=int-counts-collection")
                  .setDescription("Show how int counts were selected"));
 
     ArgsParser::Optional<bool> TraceSequenceCountsFlag(
@@ -238,7 +238,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceSequenceCountsCollection);
     Args.add(
         TraceSequenceCountsCollectionFlag.setLongName(
-                                              "verbose=seq-counts-collection")
+                                             "verbose=seq-counts-collection")
             .setDescription(
                 "Show how frequency of integer sequences were "
                 "selected"));

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -74,7 +74,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> UseHuffmanEncodingFlag(
         MyCompressionFlags.UseHuffmanEncoding);
     Args.add(UseHuffmanEncodingFlag.setLongName("Huffman").setDescription(
-        "Usage Huffman encoding for abbreviations instead "
+        "Usage Huffman encoding for pattern abbreviations instead"
         "of a simple weighted ordering (experimental)"));
 
     ArgsParser::Optional<bool> TraceHuffmanAssignmentsFlag(
@@ -83,7 +83,7 @@ int main(int Argc, const char* Argv[]) {
         TraceHuffmanAssignmentsFlag.setLongName("verbose=Huffman-assignments")
             .setDescription(
                 "Show defined Huffman encoding assignments for "
-                "to use for abbreviations"));
+                "to use for pattern abbreviations"));
 
     ArgsParser::Optional<size_t> CountCutoffFlag(
         MyCompressionFlags.CountCutoff);
@@ -121,12 +121,13 @@ int main(int Argc, const char* Argv[]) {
              .setOptionName("INTEGER")
              .setDescription(
                  "Multiplier of 'max-length' to get window size used to "
-                 "figure out optimal layout of abbreviations for the window"));
+                 "figure out optimal layout of pattern abbreviations for "
+                 "the window"));
 
     ArgsParser::Optional<size_t> MaxAbbreviationsFlag(
         MyCompressionFlags.MaxAbbreviations);
     Args.add(
-        MaxAbbreviationsFlag.setLongName("max-abbreviations")
+        MaxAbbreviationsFlag.setLongName("max-patterns")
             .setOptionName("INTEGER")
             .setDescription(
                 "Maximum number of abbreviations allowed in compressed file"));
@@ -138,7 +139,7 @@ int main(int Argc, const char* Argv[]) {
             .setOptionName("INTEGER")
             .setDescription(
                 "Maximum value that should be considered a small value when "
-                "applying small abbreviation counts"));
+                "applying small pattern abbreviations"));
 
     ArgsParser::Optional<size_t> SmallValueCountCutoffFlag(
         MyCompressionFlags.SmallValueCountCutoff);
@@ -146,7 +147,7 @@ int main(int Argc, const char* Argv[]) {
                  .setLongName("small-min-count")
                  .setDescription(
                      "Mimimum number of uses of a small value before "
-                     "it is considered for abbreviating"));
+                     "it is considered an abbreviation pattern"));
 
     ArgsParser::Toggle TrimOverriddenPatternsFlag(
         MyCompressionFlags.TrimOverriddenPatterns);
@@ -157,7 +158,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.MyAbbrevAssignFlags.CheckOverlapping);
     Args.add(CheckOverlappingPatternsFlag.setLongName("overlapping")
                  .setDescription(
-                     "Overlap close abbreviation patterns to find better "
+                     "Overlap patterns to find better "
                      "fit of abbreviations"));
 
     ArgsParser::Optional<bool> TraceReadingInputFlag(

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -104,9 +104,9 @@ int main(int Argc, const char* Argv[]) {
                      "number of integer constants in pattern) before it is "
                      "considered for abbreviating"));
 
-    ArgsParser::Optional<size_t> LengthLimitFlag(
-        MyCompressionFlags.LengthLimit);
-    Args.add(LengthLimitFlag.setDefault(5)
+    ArgsParser::Optional<size_t> PatternLengthLimitFlag(
+        MyCompressionFlags.PatternLengthLimit);
+    Args.add(PatternLengthLimitFlag.setDefault(5)
                  .setLongName("max-length")
                  .setOptionName("INTEGER")
                  .setDescription(
@@ -114,6 +114,14 @@ int main(int Argc, const char* Argv[]) {
                      "considered for compression patterns ("
                      "execution time grows non-linearly when this value "
                      " is increased)"));
+
+    ArgsParser::Optional<size_t> PatternLengthMultiplierFlag(
+        MyCompressionFlags.PatternLengthMultiplier);
+    Args.add(PatternLengthMultiplierFlag.setLongName("window-mulitplier")
+             .setOptionName("INTEGER")
+             .setDescription(
+                 "Multiplier of 'max-length' to get window size used to "
+                 "figure out optimal layout of abbreviations for the window"));
 
     ArgsParser::Optional<size_t> MaxAbbreviationsFlag(
         MyCompressionFlags.MaxAbbreviations);

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -50,7 +50,8 @@ struct AbbrevAssignFlags {
 struct CompressionFlags {
   size_t CountCutoff;
   size_t WeightCutoff;
-  size_t LengthLimit;
+  size_t PatternLengthLimit;
+  size_t PatternLengthMultiplier;
   size_t MaxAbbreviations;
   decode::IntType SmallValueMax;
   size_t SmallValueCountCutoff;

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -278,8 +278,8 @@ bool IntCompressor::generateIntOutput() {
   auto Writer = std::make_shared<AbbrevAssignWriter>(
       Root, IntOutput,
       MyFlags.PatternLengthLimit * MyFlags.PatternLengthMultiplier,
-      MyFlags.AbbrevFormat,
-      !MyFlags.UseHuffmanEncoding, MyFlags.MyAbbrevAssignFlags);
+      MyFlags.AbbrevFormat, !MyFlags.UseHuffmanEncoding,
+      MyFlags.MyAbbrevAssignFlags);
   IntInterperter Interp(std::make_shared<IntReader>(Contents), Writer,
                         MyFlags.MyInterpFlags, Symtab);
   if (MyFlags.TraceIntStreamGeneration)

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -57,7 +57,8 @@ charstring getName(CollectionFlags Flags) {
 CompressionFlags::CompressionFlags()
     : CountCutoff(0),
       WeightCutoff(0),
-      LengthLimit(10),
+      PatternLengthLimit(10),
+      PatternLengthMultiplier(3),
       MaxAbbreviations(4096),
       SmallValueMax(std::numeric_limits<uint8_t>::max()),
       SmallValueCountCutoff(2),
@@ -213,8 +214,8 @@ void IntCompressor::compress() {
     describeCutoff(stderr, MyFlags.CountCutoff,
                    makeFlags(CollectionFlag::TopLevel),
                    MyFlags.TraceIntCountsCollection);
-  if (MyFlags.LengthLimit > 1) {
-    if (!compressUpToSize(MyFlags.LengthLimit))
+  if (MyFlags.PatternLengthLimit > 1) {
+    if (!compressUpToSize(MyFlags.PatternLengthLimit))
       return;
     removeAllSmallUsageCounts();
     if (MyFlags.TraceSequenceCounts)
@@ -275,7 +276,9 @@ void IntCompressor::assignInitialAbbreviations(CountNode::PtrSet& Assignments) {
 
 bool IntCompressor::generateIntOutput() {
   auto Writer = std::make_shared<AbbrevAssignWriter>(
-      Root, IntOutput, MyFlags.LengthLimit, MyFlags.AbbrevFormat,
+      Root, IntOutput,
+      MyFlags.PatternLengthLimit * MyFlags.PatternLengthMultiplier,
+      MyFlags.AbbrevFormat,
       !MyFlags.UseHuffmanEncoding, MyFlags.MyAbbrevAssignFlags);
   IntInterperter Interp(std::make_shared<IntReader>(Contents), Writer,
                         MyFlags.MyInterpFlags, Symtab);


### PR DESCRIPTION
This is in preparation of adding code that tries to find the best pattern fit for the window size, and then
a) Selects the first abbreviation of the best pattern fit, and
b) Moves window forward over integers absorbed by the first abbreviation pattern.