### PR TITLE
Implement an abbreviation selector for the contents of a buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ INTCOMP_SRCS = \
 	AbbrevAssignWriter.cpp \
 	AbbreviationCodegen.cpp \
 	AbbreviationsCollector.cpp \
+	AbbrevSelector.cpp \
 	CountNodeCollector.cpp \
 	CountWriter.cpp \
 	IntCompress.cpp \

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -16,7 +16,6 @@
 
 // Converts textual algorithm into binary file form.
 
-
 #include <cstdlib>
 #include <cctype>
 #include <set>

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -142,10 +142,11 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<size_t> SmallValueCountCutoffFlag(
         MyCompressionFlags.SmallValueCountCutoff);
     Args.add(SmallValueCountCutoffFlag.setDefault(5)
-                 .setLongName("small-min-count")
-                 .setDescription(
-                     "Mimimum number of uses of a small value before "
-                     "it is considered an abbreviation pattern"));
+             .setLongName("small-min-count")
+             .setOptionName("INTEGER")
+             .setDescription(
+                 "Mimimum number of uses of a small value before "
+                 "it is considered an abbreviation pattern"));
 
     ArgsParser::Toggle TrimOverriddenPatternsFlag(
         MyCompressionFlags.TrimOverriddenPatterns);

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -142,11 +142,11 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<size_t> SmallValueCountCutoffFlag(
         MyCompressionFlags.SmallValueCountCutoff);
     Args.add(SmallValueCountCutoffFlag.setDefault(5)
-             .setLongName("small-min-count")
-             .setOptionName("INTEGER")
-             .setDescription(
-                 "Mimimum number of uses of a small value before "
-                 "it is considered an abbreviation pattern"));
+                 .setLongName("small-min-count")
+                 .setOptionName("INTEGER")
+                 .setDescription(
+                     "Mimimum number of uses of a small value before "
+                     "it is considered an abbreviation pattern"));
 
     ArgsParser::Toggle TrimOverriddenPatternsFlag(
         MyCompressionFlags.TrimOverriddenPatterns);
@@ -223,7 +223,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceIntCountsCollectionFlag(
         MyCompressionFlags.TraceIntCountsCollection);
     Args.add(TraceIntCountsCollectionFlag.setLongName(
-                                             "verbose=int-counts-collection")
+                                              "verbose=int-counts-collection")
                  .setDescription("Show how int counts were selected"));
 
     ArgsParser::Optional<bool> TraceSequenceCountsFlag(
@@ -237,7 +237,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceSequenceCountsCollection);
     Args.add(
         TraceSequenceCountsCollectionFlag.setLongName(
-                                             "verbose=seq-counts-collection")
+                                              "verbose=seq-counts-collection")
             .setDescription(
                 "Show how frequency of integer sequences were "
                 "selected"));
@@ -269,11 +269,38 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Optional<bool> TraceIntStreamGenerationFlag(
         MyCompressionFlags.TraceIntStreamGeneration);
-    Args.add(TraceIntStreamGenerationFlag.setLongName("verbose=gen-int-output")
+    Args.add(TraceIntStreamGenerationFlag.setLongName("verbose=select-abbrevs")
                  .setDescription(
                      "Trace the generation of the compressed integer "
-                     "stream. In particular, show how abbreviations "
-                     "are inserted"));
+                     "stream. and show how abbreviations are selected"));
+
+    ArgsParser::Optional<bool> TraceAbbrevSelectionSelectFlag(
+        MyCompressionFlags.MyAbbrevAssignFlags.TraceAbbrevSelectionSelect);
+    Args.add(TraceAbbrevSelectionSelectFlag.setLongName(
+                                                "verbose=select-abbrevs-select")
+                 .setDescription(
+                     "Show selected pattern sequences, as they apply. "
+                     "Only appiles when --verbose=select-abbrevs is "
+                     "also true"));
+
+    ArgsParser::Optional<bool> TraceAbbrevSelectionCreateFlag(
+        MyCompressionFlags.MyAbbrevAssignFlags.TraceAbbrevSelectionCreate);
+    Args.add(
+        TraceAbbrevSelectionCreateFlag.setLongName(
+                                           "verbose=select-abbrevs-create")
+            .setDescription(
+                "Show each created pattern sequence that is tried (not just "
+                "the selected ones). Only applies when "
+                "--verbose=select-abbrevs is also true"));
+
+    ArgsParser::Optional<bool> TraceAbbrevSelectionDetailFlag(
+        MyCompressionFlags.MyAbbrevAssignFlags.TraceAbbrevSelectionDetail);
+    Args.add(TraceAbbrevSelectionDetailFlag.setLongName(
+                                                "verbose=select-abbrev-details")
+                 .setDescription(
+                     "Show additional detail (besides creating and selecting) "
+                     "when creating the applied pattern sequence. Only applies "
+                     "when --verbose=select-abbrevs is also true"));
 
     switch (Args.parse(Argc, Argv)) {
       case ArgsParser::State::Good:

--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -212,10 +212,10 @@ void AbbrevAssignWriter::writeFromBuffer() {
     fprintf(Out, "************\n");
   });
 #if 1
-  AbbrevSelector Selector(Buffer, Root, DefaultValues.size(),
-                          DefaultFormat, MyFlags);
+  AbbrevSelector Selector(Buffer, Root, DefaultValues.size(), DefaultFormat,
+                          MyFlags);
 #if 1
-  Selector.getTrace().setTraceProgress(getTrace().getTraceProgress());
+  Selector.setTrace(getTracePtr());
 #endif
   AbbrevSelection::Ptr Sel = Selector.select();
 #endif

--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -17,6 +17,7 @@
 // Implements a writer that injects abbreviations into the input stream.
 
 #include "intcomp/AbbrevAssignWriter.h"
+#include "intcomp/AbbrevSelector.h"
 
 namespace wasm {
 
@@ -210,6 +211,14 @@ void AbbrevAssignWriter::writeFromBuffer() {
       fprintf(Out, "  %" PRIuMAX "\n", Value);
     fprintf(Out, "************\n");
   });
+#if 1
+  AbbrevSelector Selector(Buffer, Root, DefaultValues.size(),
+                          DefaultFormat, MyFlags);
+#if 1
+  Selector.getTrace().setTraceProgress(getTrace().getTraceProgress());
+#endif
+  AbbrevSelection::Ptr Sel = Selector.select();
+#endif
   // Collect abbreviations available for value sequences in buffer.
   CountNode::IntPtr Max = extractMaxPattern(0);
   // Before committing to Max, see if would be cheaper to just add

--- a/src/intcomp/AbbrevSelector.cpp
+++ b/src/intcomp/AbbrevSelector.cpp
@@ -1,0 +1,279 @@
+/* -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements an API for deciding abbreviation layout for a buffer.
+
+#include "intcomp/AbbrevSelector.h"
+
+#include <cassert>
+
+namespace wasm {
+
+using namespace decode;
+using namespace interp;
+using namespace utils;
+
+namespace intcomp {
+
+size_t AbbrevSelection::NextCreationIndex = 0;
+
+AbbrevSelection::AbbrevSelection(CountNode::Ptr Abbreviation,
+                                 Ptr Previous,
+                                 size_t BufferIndex,
+                                 size_t Weight)
+    : Abbreviation(Abbreviation),
+      Previous(Previous),
+      BufferIndex(BufferIndex),
+      Weight(Weight),
+      CreationIndex(NextCreationIndex++) {}
+
+AbbrevSelection::Ptr AbbrevSelection::create(
+    CountNode::Ptr Abbreviation,
+    Ptr Previous,
+    size_t Weight,
+    size_t BufferIndex) {
+  auto Sel = std::make_shared<AbbrevSelection>(Abbreviation, Previous, BufferIndex, Weight);
+  return Sel;
+}
+
+AbbrevSelection::Ptr AbbrevSelection::create(
+    CountNode::Ptr Abbreviation,
+    size_t Weight,
+    size_t BufferIndex,
+    size_t NumLeadingDefaultValues) {
+  Ptr Previous;
+  auto Sel = std::make_shared<AbbrevSelection>(Abbreviation, Previous, BufferIndex, Weight);
+  // TODO(karlschimpf) Set additional fields.
+  return Sel;
+}
+
+int AbbrevSelection::compare(AbbrevSelection* Sel) const {
+  if (Sel == nullptr)
+    return 1;
+  // Assume the one with the less weight (i.e. bitsize when written), is the
+  // better choice.
+  if (Weight < Sel->Weight)
+    return -1;
+  if (Weight > Sel->Weight)
+    return 1;
+  // Consider the one that has consumed more of the input to be the better
+  // choice.
+  if (BufferIndex > Sel->BufferIndex)
+    return -1;
+  if (BufferIndex < Sel->BufferIndex)
+    return 1;
+  // Both are equally likely.
+  if (CreationIndex < Sel->CreationIndex)
+    return -1;
+  if (CreationIndex > Sel->CreationIndex)
+    return 1;
+  return 0;
+}
+
+namespace {
+
+bool isLT(AbbrevSelection::Ptr S1, AbbrevSelection::Ptr S2) {
+  if (!S1)
+    return bool(S2);
+  if (!S2)
+    return false;
+  return S1->compare(S2.get()) < 0;
+}
+
+bool isGT(AbbrevSelection::Ptr S1, AbbrevSelection::Ptr S2) {
+  if (!S1)
+    return false;
+  if (!S2)
+    return true;
+  return S1->compare(S2.get()) > 0;
+}
+
+} // end of anonymous namespace
+
+AbbrevSelection::CompareFcnType AbbrevSelection::CompareGT =
+    [](Ptr S1, Ptr S2) { return isGT(S1, S2); };
+
+AbbrevSelection::CompareFcnType AbbrevSelection::CompareLT =
+    [](Ptr S1, Ptr S2) { return isLT(S1, S2); };
+
+void AbbrevSelection::trace(TraceClass& TC, charstring Name, AbbrevSelection::Ptr Sel) {
+  TC.indent();
+  FILE* Out = TC.getFile();
+  TC.trace_value_label(Name);
+  fputc('\n', Out);
+  std::vector<AbbrevSelection*> Stack;
+  AbbrevSelection* Next = Sel.get();
+  while (Next) {
+    Stack.push_back(Next);
+    Next = Next->Previous.get();
+  }
+  while (!Stack.empty()) {
+    Stack.back()->describe(TC.indentNewline());
+    Stack.pop_back();
+  }
+}
+
+void AbbrevSelection::describe(FILE* Out, bool Summary) {
+  AbbrevSelection* Next = this;
+  do {
+    fprintf(Out, "[%" PRIuMAX "] ints=%" PRIuMAX " w=%" PRIuMAX ":",
+            uintmax_t(Next->CreationIndex), uintmax_t(Next->BufferIndex),
+            uintmax_t(Next->Weight));
+  if (Next->Abbreviation)
+    Next->Abbreviation->describe(Out);
+  else
+    fprintf(Out, "nullptr\n");
+  Next = Next->Previous.get();
+  } while (Next && !Summary);
+}
+
+AbbrevSelector::AbbrevSelector(BufferType Buffer,
+                               CountNode::RootPtr Root,
+                               size_t NumLeadingDefaultValues,
+                               IntTypeFormat AbbrevFormat,
+                               const AbbrevAssignFlags& Flags)
+    : Buffer(Buffer),
+      Root(Root),
+      NumLeadingDefaultValues(NumLeadingDefaultValues),
+      AbbrevFormat(AbbrevFormat),
+      Flags(Flags),
+      Heap(std::make_shared<HeapType>(AbbrevSelection::CompareLT)) {
+}
+
+void AbbrevSelector::setTrace(TraceClass::Ptr NewTrace) {
+  Trace = NewTrace;
+}
+
+utils::TraceClass::Ptr AbbrevSelector::getTracePtr() {
+  if (!Trace)
+    setTrace(std::make_shared<TraceClass>("AbbrevSelector"));
+  return Trace;
+}
+
+size_t AbbrevSelector::computeAbbrevWeight(CountNode::Ptr) {
+  // For now, assume all abbreviations use one byte.
+  return 1;
+}
+
+size_t AbbrevSelector::computeValueWeight(IntType Value) {
+  IntTypeFormats Formatter(Value);
+  return Formatter.getByteSize(AbbrevFormat);
+}
+
+void AbbrevSelector::installDefaults() {
+  TRACE_METHOD("installlDefaults");
+  AbbrevSelection::Ptr Sel;
+  size_t ValueWeight = computeValueWeight(Buffer[0]);
+  if (NumLeadingDefaultValues == 0) {
+    CountNode::DefaultPtr Default = Root->getDefaultSingle();
+    Sel = AbbrevSelection::create(Default,
+                                  ValueWeight + computeAbbrevWeight(Default),
+                                  1);
+  } else {
+    CountNode::DefaultPtr Default = Root->getDefaultMultiple();
+    Sel = AbbrevSelection::create(Root->getDefaultMultiple(),
+                                  ValueWeight,
+                                  1);
+  }
+  TRACE_ABBREV_SELECTION("install", Sel);
+  Heap->push(Sel);
+}
+
+void AbbrevSelector::installIntSeqMatches() {
+  TRACE_METHOD("installMatches");
+  CountNode::IntPtr Nd;
+  constexpr bool AddIfNotFound = true;
+  for (size_t i = 0; i < Buffer.size(); ++i) {
+    IntType Value = Buffer[i];
+    TRACE(size_t, "i", i);
+    TRACE(IntType, "Value", Value);
+    Nd = Nd ? lookup(Nd, Value, !AddIfNotFound)
+            : lookup(Root, Value, !AddIfNotFound);
+    if (!Nd) {
+      TRACE_MESSAGE("No more patterns found!");
+      return;
+    }
+    if (!Nd->hasAbbrevIndex())
+      continue;
+    auto Sel = AbbrevSelection::create(Nd,
+                                       computeAbbrevWeight(Nd),
+                                       i + 1);
+    TRACE_ABBREV_SELECTION("install", Sel);
+    Heap->push(Sel);
+  }
+}
+
+void AbbrevSelector::installMatches() {
+  installDefaults();
+  installIntSeqMatches();
+}
+
+void AbbrevSelector::installDefaults(AbbrevSelection::Ptr Previous) {
+  // TODO(karlschimpf): Define.
+#if 1
+  (void) Previous;
+#endif
+}
+
+void AbbrevSelector::installIntSeqMatches(AbbrevSelection::Ptr Previous) {
+  // TODO(karlschimpf): Define.
+#if 1
+  (void) Previous;
+#endif
+}
+
+void AbbrevSelector::installMatches(AbbrevSelection::Ptr Previous) {
+  installDefaults(Previous);
+  installIntSeqMatches(Previous);
+}
+
+AbbrevSelection::Ptr AbbrevSelector::popHeap() {
+  assert(Heap);
+  HeapType::entry_ptr Entry = Heap->top();
+  Heap->pop();
+  return Entry->getValue();
+}
+
+AbbrevSelection::Ptr AbbrevSelector::select() {
+  TRACE_METHOD("select");
+  (void) Flags;
+  AbbrevSelection::Ptr Min;
+  if (Buffer.size() == 0)
+    return Min;
+  // Install possible defaults.
+  Heap->clear();
+  installMatches();
+  while (!Heap->empty()) {
+    AbbrevSelection::Ptr Sel = popHeap();
+    TRACE_ABBREV_SELECTION("Select", Sel);
+    assert(bool(Sel));
+    if (Sel->getBufferIndex() == Buffer.size()) {
+      if (!bool(Min) || Min->compare(Sel.get()) > 0) {
+        Min = Sel;
+        TRACE_MESSAGE("Define as minimum");
+      } else {
+        TRACE_MESSAGE("Ignoring: not minimum");
+      }
+      continue;
+    }
+    installMatches(Sel);
+  }
+  return Min;
+}
+
+}  // end of namespace intcomp
+
+}  // end of namespace wasm

--- a/src/intcomp/AbbrevSelector.h
+++ b/src/intcomp/AbbrevSelector.h
@@ -1,0 +1,141 @@
+/* -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Defines an API for deciding abbreviation layout for a buffer.
+
+#ifndef DECOMPRESSOR_SRC_INTCOMP_ABBREVSELECTOR_H_
+#define DECOMPRESSOR_SRC_INTCOMP_ABBREVSELECTOR_H_
+
+#include "intcomp/CompressionFlags.h"
+#include "intcomp/IntCountNode.h"
+#include "interp/IntFormats.h"
+#include "utils/circular-vector.h"
+#include "utils/Trace.h"
+
+#ifdef NDEBUG
+
+#define TRACE_ABBREV_SELECTION_USING(trace, name, value)
+#define TRACE_ABBREV_SELECTION(name, value)
+
+#else
+
+#define TRACE_ABBREV_SELECTION_USING(Trace, name, value) \
+  do {                                                   \
+    auto& tracE = (Trace);                               \
+    if (tracE.getTraceProgress())                        \
+      AbbrevSelection::trace(tracE, name, value)    ;    \
+  } while(false)
+
+#define TRACE_ABBREV_SELECTION(name, value) \
+    TRACE_ABBREV_SELECTION_USING(getTrace(), name, Sel);
+#endif
+
+namespace wasm {
+
+namespace intcomp {
+
+class AbbrevSelection : public std::enable_shared_from_this<AbbrevSelection> {
+  AbbrevSelection() = delete;
+  AbbrevSelection(const AbbrevSelection&) = delete;
+  AbbrevSelection& operator=(const AbbrevSelection&) = delete;
+ public:
+  typedef std::shared_ptr<AbbrevSelection> Ptr;
+  typedef std::function<bool(Ptr, Ptr)> CompareFcnType;
+
+  static CompareFcnType CompareGT;
+  static CompareFcnType CompareLT;
+
+  // Do not use directly! Call create to instantiate.
+  AbbrevSelection(CountNode::Ptr Abbreviation,
+                  Ptr Previous,
+                  size_t BufferIndex,
+                  size_t Weight);
+
+  CountNode::Ptr getAbbreviation() const { return Abbreviation; }
+  Ptr getPrevious() const { return Previous; }
+  size_t getBufferIndex() const { return BufferIndex; }
+  size_t getWeight() const;
+
+  static Ptr create(CountNode::Ptr Abbreviation,
+                    Ptr Previous,
+                    size_t Weight,
+                    size_t BufferIndex);
+
+  static Ptr create(CountNode::Ptr Abbreviation,
+                    size_t Weight,
+                    size_t BufferIndex,
+                    size_t NumLeadingDefaultValues = 0);
+
+  // Returns < 0 if this smaller, > 0 if Sel smaller, and zero if equal.
+  int compare(AbbrevSelection* Sel) const;
+
+  void describe(FILE* Out, bool Summary=true);
+  static void trace(utils::TraceClass& TC, charstring Name, AbbrevSelection::Ptr Sel);
+
+ private:
+  CountNode::Ptr Abbreviation;
+  Ptr Previous;
+  size_t BufferIndex;
+  size_t Weight;
+  // Note: CreationIndex is used to break ties in comparison.
+  size_t CreationIndex;
+  static size_t NextCreationIndex;
+};
+
+class AbbrevSelector {
+ public:
+  typedef utils::circular_vector<decode::IntType> BufferType;
+  AbbrevSelector(BufferType Buffer,
+                 CountNode::RootPtr Root,
+                 size_t NumLeadingDefaultValues,
+                 interp::IntTypeFormat AbbrevFormat,
+                 const AbbrevAssignFlags& Flags);
+  // Heuristically finds the best (measured by weight) abberviation selection
+  // for the contents of the buffer.
+  AbbrevSelection::Ptr select();
+
+  void setTrace(utils::TraceClass::Ptr Trace);
+  utils::TraceClass::Ptr getTracePtr();
+  utils::TraceClass& getTrace() { return *getTracePtr(); }
+  bool hasTrace() { return bool(Trace); }
+
+ private:
+  typedef utils::heap<AbbrevSelection::Ptr> HeapType;
+  BufferType Buffer;
+  CountNode::RootPtr Root;
+  size_t NumLeadingDefaultValues;
+  interp::IntTypeFormat AbbrevFormat;
+  const AbbrevAssignFlags& Flags;
+  std::shared_ptr<HeapType> Heap;
+  std::map<decode::IntType, interp::IntTypeFormats*> FormatMap;
+  utils::TraceClass::Ptr Trace;
+
+  size_t computeAbbrevWeight(CountNode::Ptr Abbev);
+  size_t computeValueWeight(decode::IntType Value);
+  void installDefaults();
+  void installDefaults(AbbrevSelection::Ptr Previous);
+  void installIntSeqMatches();
+  void installIntSeqMatches(AbbrevSelection::Ptr Previous);
+  void installMatches();
+  void installMatches(AbbrevSelection::Ptr Previous);
+  AbbrevSelection::Ptr popHeap();
+};
+
+}  // end of namespace intcomp
+
+}  // end of namespace wasm
+
+#endif  // DECOMPRESSOR_SRC_INTCOMP_ABBREVSELECTOR_H_

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -44,7 +44,10 @@ inline bool hasFlag(CollectionFlag F, CollectionFlags Flags) {
 
 struct AbbrevAssignFlags {
   bool CheckOverlapping;
-  AbbrevAssignFlags() : CheckOverlapping(false) {}
+  bool TraceAbbrevSelectionSelect;
+  bool TraceAbbrevSelectionCreate;
+  bool TraceAbbrevSelectionDetail;
+  AbbrevAssignFlags();
 };
 
 struct CompressionFlags {

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -26,10 +26,6 @@ using namespace utils;
 
 namespace intcomp {
 
-void CountNodeCollector::setTrace(std::shared_ptr<TraceClass> NewTrace) {
-  Trace = NewTrace;
-}
-
 CountNodeCollector::CountNodeCollector(CountNode::RootPtr Root)
     : Root(Root),
       ValuesHeap(std::make_shared<CountNode::HeapType>(CountNode::CompareLt)),
@@ -47,6 +43,10 @@ CountNodeCollector::CountNodeCollector(CountNode::RootPtr Root)
 void CountNodeCollector::setCompareFcn(CountNode::CompareFcnType LtFcn) {
   assert(ValuesHeap->empty());
   ValuesHeap->setLtFcn(LtFcn);
+}
+
+void CountNodeCollector::setTrace(std::shared_ptr<TraceClass> NewTrace) {
+  Trace = NewTrace;
 }
 
 std::shared_ptr<TraceClass> CountNodeCollector::getTracePtr() {

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -54,11 +54,19 @@ charstring getName(CollectionFlags Flags) {
   return "UnknownCollectionFlags";
 }
 
+AbbrevAssignFlags::AbbrevAssignFlags()
+    : CheckOverlapping(false),
+      // TODO(karlschimpf) Make these command-line arguments.
+      TraceAbbrevSelectionSelect(false),
+      TraceAbbrevSelectionCreate(false),
+      TraceAbbrevSelectionDetail(false) {
+}
+
 CompressionFlags::CompressionFlags()
     : CountCutoff(0),
       WeightCutoff(0),
       PatternLengthLimit(10),
-      PatternLengthMultiplier(3),
+      PatternLengthMultiplier(2),
       MaxAbbreviations(4096),
       SmallValueMax(std::numeric_limits<uint8_t>::max()),
       SmallValueCountCutoff(2),

--- a/src/utils/Defs.h
+++ b/src/utils/Defs.h
@@ -38,9 +38,11 @@ namespace wasm {
 #define WASM_IGNORE(V) (void)(V);
 
 #ifdef __GNUC__
-#define WASM_RETURN_UNREACHABLE(V) return (V);
+#define WASM_RETURN_UNREACHABLE(V) \
+  assert(false);                   \
+  return (V)
 #else
-#define WASM_RETURN_UNREACHABLE(V)
+#define WASM_RETURN_UNREACHABLE(V) assert(false)
 #endif
 
 #ifdef NDEBUG

--- a/src/utils/Trace.cpp
+++ b/src/utils/Trace.cpp
@@ -36,7 +36,7 @@ TraceClass::TraceClass() {
   init();
 }
 
-TraceClass::TraceClass(const char* Lbl) {
+TraceClass::TraceClass(charstring Lbl) {
   init();
   Label = Lbl;
 }
@@ -46,7 +46,7 @@ TraceClass::TraceClass(FILE* Fl) {
   File = Fl;
 }
 
-TraceClass::TraceClass(const char* Lbl, FILE* Fl) {
+TraceClass::TraceClass(charstring Lbl, FILE* Fl) {
   init();
   Label = Lbl;
   File = Fl;
@@ -79,14 +79,14 @@ void TraceClass::traceContext() const {
   fputc(' ', File);
 }
 
-void TraceClass::enter(const char* Name) {
+void TraceClass::enter(charstring Name) {
   indent();
   ++IndentLevel;
   CallStack.push_back(Name);
   fprintf(File, "enter %s\n", Name);
 }
 
-void TraceClass::exit(const char* Name) {
+void TraceClass::exit(charstring Name) {
   assert(~CallStack.empty());
   if (Name == nullptr)
     Name = CallStack.back();
@@ -115,7 +115,13 @@ FILE* TraceClass::indent() {
   return File;
 }
 
-void TraceClass::trace_value_label(const char* Label) {
+FILE* TraceClass::indentNewline() {
+  for (int i = 0; i <= IndentLevel; ++i)
+    fputs("  ", File);
+  return File;
+}
+
+void TraceClass::trace_value_label(charstring Label) {
   if (Label == nullptr)
     return;
   fprintf(File, "%s = ", Label);
@@ -126,56 +132,56 @@ void TraceClass::traceMessageInternal(const std::string& Message) {
   fprintf(File, "%s\n", Message.c_str());
 }
 
-void TraceClass::traceBoolInternal(const char* Name, bool Value) {
+void TraceClass::traceBoolInternal(charstring Name, bool Value) {
   indent();
   trace_value_label(Name);
   fprintf(File, "%s\n", Value ? "t" : "f");
 }
 
-void TraceClass::traceCharInternal(const char* Name, char Ch) {
+void TraceClass::traceCharInternal(charstring Name, char Ch) {
   indent();
   trace_value_label(Name);
   fprintf(File, "'%c'\n", Ch);
 }
 
-void TraceClass::traceStringInternal(const char* Name, const char* Value) {
+void TraceClass::traceStringInternal(charstring Name, charstring Value) {
   indent();
   trace_value_label(Name);
   fprintf(File, "'%s'\n", Value);
 }
 
-void TraceClass::traceIntInternal(const char* Name, intmax_t Value) {
+void TraceClass::traceIntInternal(charstring Name, intmax_t Value) {
   indent();
   trace_value_label(Name);
   fprintf(File, "%" PRIiMAX "\n", Value);
 }
 
-void TraceClass::traceUintInternal(const char* Name, uintmax_t Value) {
+void TraceClass::traceUintInternal(charstring Name, uintmax_t Value) {
   indent();
   trace_value_label(Name);
   fprintf(File, "%" PRIuMAX "\n", Value);
 }
 
-void TraceClass::traceIntTypeInternal(const char* Name, IntType Value) {
+void TraceClass::traceIntTypeInternal(charstring Name, IntType Value) {
   indent();
   trace_value_label(Name);
   fprint_IntType(File, Value);
   fputc('\n', File);
 }
 
-void TraceClass::traceHexIntTypeInternal(const char* Name, IntType Value) {
+void TraceClass::traceHexIntTypeInternal(charstring Name, IntType Value) {
   indent();
   trace_value_label(Name);
   fprintf(File, "%" PRIxMAX "\n", uintmax_t(Value));
 }
 
-void TraceClass::traceHexInternal(const char* Name, uintmax_t Value) {
+void TraceClass::traceHexInternal(charstring Name, uintmax_t Value) {
   indent();
   trace_value_label(Name);
   fprintf(File, "%" PRIxMAX "\n", uintmax_t(Value));
 }
 
-void TraceClass::tracePointerInternal(const char* Name, void* Value) {
+void TraceClass::tracePointerInternal(charstring Name, void* Value) {
   indent();
   trace_value_label(Name);
   fprintf(File, "%p\n", Value);

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -100,6 +100,7 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
   TraceClass& operator=(const TraceClass&) = delete;
 
  public:
+  typedef std::shared_ptr<TraceClass> Ptr;
   // Models called methods in traces.
   class Method {
     Method() = delete;
@@ -107,7 +108,7 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
     Method& operator=(const Method&) = delete;
 
    public:
-    Method(const char* Name, TraceClass& Cls) : Cls(Cls) {
+    Method(charstring Name, TraceClass& Cls) : Cls(Cls) {
       if (Cls.getTraceProgress()) {
         Cls.enter(Name);
       }
@@ -136,134 +137,136 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
   typedef std::shared_ptr<Context> ContextPtr;
 
   TraceClass();
-  explicit TraceClass(const char* Label);
+  explicit TraceClass(charstring Label);
   explicit TraceClass(FILE* File);
-  TraceClass(const char* Label, FILE* File);
+  TraceClass(charstring Label, FILE* File);
   virtual ~TraceClass();
-  void enter(const char* Name);
-  void exit(const char* Name = nullptr);
+  void enter(charstring Name);
+  void exit(charstring Name = nullptr);
   virtual void traceContext() const;
   void addContext(ContextPtr Ctx);
   void clearContexts();
 
   // Prints trace prefix only.
   FILE* indent();
-  void trace_value_label(const char* Label);
-  void trace_message(const char* Message) { traceMessageInternal(Message); }
+  FILE* indentNewline();
+  void trace_value_label(charstring Label);
+  void trace_message(charstring Message) { traceMessageInternal(Message); }
   void trace_message(std::string Message) { traceMessageInternal(Message); }
-  void trace_bool(const char* Name, bool Value) {
+  void trace_bool(charstring Name, bool Value) {
     traceBoolInternal(Name, Value);
   }
-  void trace_char(const char* Name, char Ch) { traceCharInternal(Name, Ch); }
-  void trace_signed_char(const char* Name, signed char Ch) {
+  void trace_char(charstring Name, char Ch) { traceCharInternal(Name, Ch); }
+  void trace_signed_char(charstring Name, signed char Ch) {
     traceCharInternal(Name, char(Ch));
   }
-  void trace_unsigned_char(const char* Name, unsigned char Ch) {
+  void trace_unsigned_char(charstring Name, unsigned char Ch) {
     traceCharInternal(Name, char(Ch));
   }
-  void trace_string(const char* Name, const std::string&& Value) {
+  void trace_string(charstring Name, const std::string&& Value) {
     traceStringInternal(Name, Value.c_str());
   }
-  void trace_string(const char* Name, const std::string& Value) {
+  void trace_string(charstring Name, const std::string& Value) {
     traceStringInternal(Name, Value.c_str());
   }
-  void trace_string(const char* Name, const char* Value) {
+  void trace_charstring(charstring Name, charstring Value) {
     traceStringInternal(Name, Value);
   }
-  void trace_short(const char* Name, short Value) {
+  void trace_short(charstring Name, short Value) {
     traceIntInternal(Name, Value);
   }
-  void trace_unsigned_short(const char* Name, unsigned short Value) {
+  void trace_unsigned_short(charstring Name, unsigned short Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_int(const char* Name, int Value) { traceIntInternal(Name, Value); }
-  void trace_unsigned_int(const char* Name, unsigned int Value) {
+  void trace_int(charstring Name, int Value) { traceIntInternal(Name, Value); }
+  void trace_unsigned_int(charstring Name, unsigned int Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_long(const char* Name, long Value) {
+  void trace_long(charstring Name, long Value) {
     traceIntInternal(Name, Value);
   }
-  void trace_unsigned_long(const char* Name, unsigned long Value) {
+  void trace_unsigned_long(charstring Name, unsigned long Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_int8_t(const char* Name, int8_t Value) {
+  void trace_int8_t(charstring Name, int8_t Value) {
     traceIntInternal(Name, Value);
   }
-  void trace_uint8_t(const char* Name, uint8_t Value) {
+  void trace_uint8_t(charstring Name, uint8_t Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_hex_uint8_t(const char* Name, uint8_t Value) {
+  void trace_hex_uint8_t(charstring Name, uint8_t Value) {
     traceHexInternal(Name, Value);
   }
-  void trace_int16_t(const char* Name, int16_t Value) {
+  void trace_int16_t(charstring Name, int16_t Value) {
     traceIntInternal(Name, Value);
   }
-  void trace_uint16_t(const char* Name, uint16_t Value) {
+  void trace_uint16_t(charstring Name, uint16_t Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_int32_t(const char* Name, int32_t Value) {
+  void trace_int32_t(charstring Name, int32_t Value) {
     traceIntInternal(Name, Value);
   }
-  void trace_hex_int32_t(const char* Name, int32_t Value) {
+  void trace_hex_int32_t(charstring Name, int32_t Value) {
     traceHexInternal(Name, Value);
   }
-  void trace_uint32_t(const char* Name, uint32_t Value) {
+  void trace_uint32_t(charstring Name, uint32_t Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_hex_uint32_t(const char* Name, uint32_t Value) {
+  void trace_hex_uint32_t(charstring Name, uint32_t Value) {
     traceHexInternal(Name, Value);
   }
-  void trace_int64_t(const char* Name, int64_t Value) {
+  void trace_int64_t(charstring Name, int64_t Value) {
     traceIntInternal(Name, Value);
   }
-  void trace_intmax_t(const char* Name, intmax_t Value) {
+  void trace_intmax_t(charstring Name, intmax_t Value) {
     traceIntInternal(Name, Value);
   }
-  void trace_uint64_t(const char* Name, uint64_t Value) {
+  void trace_uint64_t(charstring Name, uint64_t Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_uintmax_t(const char* Name, uintmax_t Value) {
+  void trace_uintmax_t(charstring Name, uintmax_t Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_IntType(const char* Name, decode::IntType Value) {
+  void trace_IntType(charstring Name, decode::IntType Value) {
     traceIntTypeInternal(Name, Value);
   }
-  void trace_hex_IntType(const char* Name, decode::IntType Value) {
+  void trace_hex_IntType(charstring Name, decode::IntType Value) {
     traceHexIntTypeInternal(Name, Value);
   }
-  void trace_size_t(const char* Name, size_t Value) {
+  void trace_size_t(charstring Name, size_t Value) {
     traceUintInternal(Name, Value);
   }
-  void trace_hex_size_t(const char* Name, size_t Value) {
+  void trace_hex_size_t(charstring Name, size_t Value) {
     traceHexInternal(Name, Value);
   }
   template <typename T>
-  void trace_void_ptr(const char* Name, T* Ptr) {
+  void trace_void_ptr(charstring Name, T* Ptr) {
     tracePointerInternal(Name, (void*)Ptr);
   }
-  void trace_node_ptr(const char* Name, const filt::Node* Nd);
+  void trace_node_ptr(charstring Name, const filt::Node* Nd);
   bool getTraceProgress() const { return wasm::isDebug() && TraceProgress; }
   void setTraceProgress(bool NewValue) { TraceProgress = NewValue; }
 
   FILE* getFile() const { return File; }
 
  protected:
-  const char* Label;
+  charstring Label;
   FILE* File;
   int IndentLevel;
   bool TraceProgress;
-  std::vector<const char*> CallStack;
+  std::vector<charstring> CallStack;
   std::vector<ContextPtr> ContextList;
+
   void traceMessageInternal(const std::string& Message);
-  void traceBoolInternal(const char* Name, bool Value);
-  void traceCharInternal(const char* Name, char Ch);
-  void traceStringInternal(const char* Name, const char* Value);
-  void traceIntInternal(const char* Name, intmax_t Value);
-  void traceUintInternal(const char* Name, uintmax_t Value);
-  void traceIntTypeInternal(const char* Name, decode::IntType Value);
-  void traceHexInternal(const char* Name, uintmax_t Value);
-  void tracePointerInternal(const char* Name, void* Value);
-  void traceHexIntTypeInternal(const char* Name, decode::IntType Value);
+  void traceBoolInternal(charstring Name, bool Value);
+  void traceCharInternal(charstring Name, char Ch);
+  void traceStringInternal(charstring Name, charstring Value);
+  void traceIntInternal(charstring Name, intmax_t Value);
+  void traceUintInternal(charstring Name, uintmax_t Value);
+  void traceIntTypeInternal(charstring Name, decode::IntType Value);
+  void traceHexInternal(charstring Name, uintmax_t Value);
+  void tracePointerInternal(charstring Name, void* Value);
+  void traceHexIntTypeInternal(charstring Name, decode::IntType Value);
 
  private:
   inline void init();

--- a/src/utils/heap.h
+++ b/src/utils/heap.h
@@ -139,6 +139,11 @@ class heap : public std::enable_shared_from_this<heap<value_type>> {
     return Entry;
   }
 
+  void clear() {
+    while (!empty())
+      pop();
+  }
+
   void pop() { remove(0); }
 
   // Reinsert value since key changed.


### PR DESCRIPTION
Applies a hill-climbing (depth-first) algorithm that attemps to find the best sequence of abbreviations, given the contents of an integer buffer.

Note: This PR doesn't yet take advantage of the selected sequence of abbreviations. This is delayed for a subsequent PR.
