### PR TITLE
Apply abbreviations as defined by the selector.

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -154,7 +154,7 @@ int main(int Argc, const char* Argv[]) {
         "Remove patterns if already implied by previous patterns"));
 
     ArgsParser::Toggle CheckOverlappingPatternsFlag(
-        MyCompressionFlags.MyAbbrevAssignFlags.CheckOverlapping);
+        MyCompressionFlags.CheckOverlapping);
     Args.add(CheckOverlappingPatternsFlag.setLongName("overlapping")
                  .setDescription(
                      "Overlap patterns to find better "
@@ -274,8 +274,20 @@ int main(int Argc, const char* Argv[]) {
                      "Trace the generation of the compressed integer "
                      "stream. and show how abbreviations are selected"));
 
+    ArgsParser::Optional<size_t> TraceAbbrevSelectionProgressFlag(
+        MyCompressionFlags.TraceAbbrevSelectionProgress);
+    Args.add(
+        TraceAbbrevSelectionProgressFlag.setLongName(
+                                             "verbose=select-abbrevs-progress")
+            .setOptionName("INTEGER")
+            .setDescription(
+                "For every INTEGER values generated in the output integer "
+                "stream, generate a progress message. Use this to show "
+                "progress is being made, especially with large "
+                "command line overrides (INTEGER=0 turns off)"));
+
     ArgsParser::Optional<bool> TraceAbbrevSelectionSelectFlag(
-        MyCompressionFlags.MyAbbrevAssignFlags.TraceAbbrevSelectionSelect);
+        MyCompressionFlags.TraceAbbrevSelectionSelect);
     Args.add(TraceAbbrevSelectionSelectFlag.setLongName(
                                                 "verbose=select-abbrevs-select")
                  .setDescription(
@@ -284,7 +296,7 @@ int main(int Argc, const char* Argv[]) {
                      "also true"));
 
     ArgsParser::Optional<bool> TraceAbbrevSelectionCreateFlag(
-        MyCompressionFlags.MyAbbrevAssignFlags.TraceAbbrevSelectionCreate);
+        MyCompressionFlags.TraceAbbrevSelectionCreate);
     Args.add(
         TraceAbbrevSelectionCreateFlag.setLongName(
                                            "verbose=select-abbrevs-create")
@@ -294,7 +306,7 @@ int main(int Argc, const char* Argv[]) {
                 "--verbose=select-abbrevs is also true"));
 
     ArgsParser::Optional<bool> TraceAbbrevSelectionDetailFlag(
-        MyCompressionFlags.MyAbbrevAssignFlags.TraceAbbrevSelectionDetail);
+        MyCompressionFlags.TraceAbbrevSelectionDetail);
     Args.add(TraceAbbrevSelectionDetailFlag.setLongName(
                                                 "verbose=select-abbrev-details")
                  .setDescription(

--- a/src/intcomp/AbbrevAssignWriter.h
+++ b/src/intcomp/AbbrevAssignWriter.h
@@ -42,7 +42,7 @@ class AbbrevAssignWriter : public interp::Writer {
                      size_t BufSize,
                      interp::IntTypeFormat AbbrevFormat,
                      bool AssumeByteAlignment,
-                     const AbbrevAssignFlags& MyFlags);
+                     const CompressionFlags& MyFlags);
   ~AbbrevAssignWriter() OVERRIDE;
 
   decode::StreamType getStreamType() const OVERRIDE;
@@ -62,23 +62,18 @@ class AbbrevAssignWriter : public interp::Writer {
   void setTrace(std::shared_ptr<utils::TraceClass> Trace) OVERRIDE;
 
  private:
-  const AbbrevAssignFlags& MyFlags;
+  const CompressionFlags& MyFlags;
   CountNode::RootPtr Root;
   interp::IntWriter Writer;
-  size_t BufSize;
   utils::circular_vector<decode::IntType> Buffer;
   interp::IntTypeFormat AbbrevFormat;
   std::vector<decode::IntType> DefaultValues;
   bool AssumeByteAlignment;
-  static constexpr interp::IntTypeFormat DefaultFormat =
-      interp::IntTypeFormat::Varint64;
-  static constexpr interp::IntTypeFormat LoopSizeFormat =
-      interp::IntTypeFormat::Varuint64;
+  size_t ProgressCount;
 
   void bufferValue(decode::IntType Value);
   void forwardAbbrevValue(decode::IntType Value);
   void forwardOtherValue(decode::IntType Value);
-  CountNode::IntPtr extractMaxPattern(size_t StartIndex);
   void writeFromBuffer();
   void writeUntilBufferEmpty();
   void popValuesFromBuffer(size_t size);

--- a/src/intcomp/AbbrevSelector.cpp
+++ b/src/intcomp/AbbrevSelector.cpp
@@ -145,12 +145,10 @@ void AbbrevSelection::describe(FILE* Out, bool Summary) {
 AbbrevSelector::AbbrevSelector(BufferType Buffer,
                                CountNode::RootPtr Root,
                                size_t NumLeadingDefaultValues,
-                               IntTypeFormat AbbrevFormat,
-                               const AbbrevAssignFlags& Flags)
+                               const CompressionFlags& Flags)
     : Buffer(Buffer),
       Root(Root),
       NumLeadingDefaultValues(NumLeadingDefaultValues),
-      AbbrevFormat(AbbrevFormat),
       NextCreationIndex(0),
       Flags(Flags),
       Heap(std::make_shared<HeapType>(isHillclimbLT)) {
@@ -173,7 +171,7 @@ size_t AbbrevSelector::computeAbbrevWeight(CountNode::Ptr) {
 
 size_t AbbrevSelector::computeValueWeight(IntType Value) {
   IntTypeFormats Formatter(Value);
-  return Formatter.getByteSize(AbbrevFormat);
+  return Formatter.getByteSize(Flags.DefaultFormat);
 }
 
 AbbrevSelection::Ptr AbbrevSelector::create(CountNode::Ptr Abbreviation,

--- a/src/intcomp/AbbrevSelector.h
+++ b/src/intcomp/AbbrevSelector.h
@@ -92,8 +92,7 @@ class AbbrevSelector {
   AbbrevSelector(BufferType Buffer,
                  CountNode::RootPtr Root,
                  size_t NumLeadingDefaultValues,
-                 interp::IntTypeFormat AbbrevFormat,
-                 const AbbrevAssignFlags& Flags);
+                 const CompressionFlags& Flags);
   // Heuristically finds the best (measured by weight) abberviation selection
   // for the contents of the buffer.
   AbbrevSelection::Ptr select();
@@ -108,12 +107,8 @@ class AbbrevSelector {
   BufferType Buffer;
   CountNode::RootPtr Root;
   size_t NumLeadingDefaultValues;
-#if 1
-// Remove, use flags.
-#endif
-  interp::IntTypeFormat AbbrevFormat;
   size_t NextCreationIndex;
-  const AbbrevAssignFlags& Flags;
+  const CompressionFlags& Flags;
   std::shared_ptr<HeapType> Heap;
   std::map<decode::IntType, interp::IntTypeFormats*> FormatMap;
   utils::TraceClass::Ptr Trace;

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -42,14 +42,6 @@ inline bool hasFlag(CollectionFlag F, CollectionFlags Flags) {
   return makeFlags(F) & Flags;
 }
 
-struct AbbrevAssignFlags {
-  bool CheckOverlapping;
-  bool TraceAbbrevSelectionSelect;
-  bool TraceAbbrevSelectionCreate;
-  bool TraceAbbrevSelectionDetail;
-  AbbrevAssignFlags();
-};
-
 struct CompressionFlags {
   size_t CountCutoff;
   size_t WeightCutoff;
@@ -62,6 +54,12 @@ struct CompressionFlags {
   bool MinimizeCodeSize;
   bool UseHuffmanEncoding;
   bool TrimOverriddenPatterns;
+  bool CheckOverlapping;
+  interp::IntTypeFormat DefaultFormat;
+  interp::IntTypeFormat LoopSizeFormat;
+
+  interp::InterpreterFlags MyInterpFlags;
+
   bool TraceHuffmanAssignments;
   bool TraceReadingInput;
   bool TraceReadingIntStream;
@@ -80,8 +78,10 @@ struct CompressionFlags {
   bool TraceAbbreviationAssignmentsCollection;
   bool TraceAssigningAbbreviations;
   bool TraceCompressedIntOutput;
-  interp::InterpreterFlags MyInterpFlags;
-  AbbrevAssignFlags MyAbbrevAssignFlags;
+  bool TraceAbbrevSelectionSelect;
+  bool TraceAbbrevSelectionCreate;
+  bool TraceAbbrevSelectionDetail;
+  size_t TraceAbbrevSelectionProgress;
   CompressionFlags();
 };
 

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -66,7 +66,7 @@ class IntCompressor FINAL {
   void setTrace(std::shared_ptr<utils::TraceClass> Trace);
   utils::TraceClass& getTrace() { return *getTracePtr(); }
   std::shared_ptr<utils::TraceClass> getTracePtr();
-  bool hasTrace() { return bool(Trace); }
+  bool hasTrace() { return bool(Trace) && Trace->getTraceProgress(); }
 
   void describe(FILE* Out,
                 CollectionFlags Flags = makeFlags(CollectionFlag::All),

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -56,6 +56,8 @@ class IntWriter : public Writer {
 
   virtual void describeState(FILE* File);
 
+  size_t getIndex() const { return Pos.getIndex(); }
+
  private:
   std::shared_ptr<IntStream> Output;
   IntStream::WriteCursor Pos;

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -43,6 +43,7 @@ class Reader : public std::enable_shared_from_this<Reader> {
   virtual ~Reader() {}
   virtual utils::TraceClass::ContextPtr getTraceContext();
   void setTraceProgress(bool NewValue);
+  bool hasTrace() { return bool(Trace); }
   void setTrace(std::shared_ptr<utils::TraceClass> Trace);
   std::shared_ptr<utils::TraceClass> getTracePtr();
   utils::TraceClass& getTrace() { return *getTracePtr(); }

--- a/src/interp/Writer.h
+++ b/src/interp/Writer.h
@@ -61,6 +61,7 @@ class Writer {
   virtual void describeState(FILE* File);
 
   virtual utils::TraceClass::ContextPtr getTraceContext();
+  bool hasTrace() { return bool(Trace) && Trace->getTraceProgress(); }
   virtual void setTrace(std::shared_ptr<utils::TraceClass> Trace);
   std::shared_ptr<utils::TraceClass> getTracePtr();
   utils::TraceClass& getTrace() { return *getTracePtr(); }

--- a/src/utils/ArgsParse.h
+++ b/src/utils/ArgsParse.h
@@ -45,7 +45,7 @@ class ArgsParser {
 
    public:
     void describe(FILE* Out, size_t TabSize) const;
-    virtual bool select(charstring OptionValue) = 0;
+    virtual bool select(ArgsParser* Parser, charstring OptionValue) = 0;
     virtual int compare(const Arg& A) const;
     char getShortName() const { return ShortName; }
     Arg& setShortName(char Name) {
@@ -68,6 +68,7 @@ class ArgsParser {
     }
     bool getOptionFound() const { return OptionFound; }
     void setOptionFound(bool Value) { OptionFound = Value; }
+    bool validOptionValue(ArgsParser* Parser, charstring OptionValue);
     size_t getAddIndex() const { return AddIndex; }
     void setAddIndex(size_t Value) { AddIndex = Value; }
     ArgKind getRtClassId() const { return Kind; }
@@ -179,7 +180,7 @@ class ArgsParser {
       Value = DefaultValue = NewDefault;
       return *this;
     }
-    bool select(charstring NewDefault) OVERRIDE;
+    bool select(ArgsParser* Parser, charstring NewDefault) OVERRIDE;
     void describeDefault(FILE* Out,
                          size_t TabSize,
                          size_t& Indent) const OVERRIDE;
@@ -199,7 +200,7 @@ class ArgsParser {
    public:
     explicit Toggle(bool& Value, charstring Description = nullptr)
         : Optional<bool>(Value, Description) {}
-    bool select(charstring OptionValue) OVERRIDE;
+    bool select(ArgsParser* Parser, charstring OptionValue) OVERRIDE;
     void describeDefault(FILE* Out,
                          size_t TabSize,
                          size_t& Indent) const OVERRIDE;
@@ -217,7 +218,7 @@ class ArgsParser {
     SetValue(T& Value, T SelectValue, charstring Description = nullptr)
         : Optional<T>(Value, Description) {}
 
-    bool select(charstring OptionValue) OVERRIDE;
+    bool select(ArgsParser* Parser, charstring OptionValue) OVERRIDE;
     void describeDefault(FILE* Out,
                          size_t TabSize,
                          size_t& Indent) const OVERRIDE;
@@ -239,7 +240,7 @@ class ArgsParser {
     explicit RepeatableSet(set_type& Values, charstring Description = nullptr)
         : OptionalArg(Description), Values(Values) {}
 
-    bool select(charstring Add) OVERRIDE;
+    bool select(ArgsParser* Parser, charstring Add) OVERRIDE;
     void describeDefault(FILE* Out,
                          size_t TabSize,
                          size_t& Indent) const OVERRIDE;
@@ -275,7 +276,7 @@ class ArgsParser {
    public:
     explicit Required(T& Value, charstring Description = nullptr)
         : RequiredArg(Description), Value(Value) {}
-    bool select(charstring OptionValue) OVERRIDE;
+    bool select(ArgsParser* Parser, charstring OptionValue) OVERRIDE;
 
     ~Required() OVERRIDE {}
 
@@ -320,6 +321,10 @@ class ArgsParser {
   Arg* parseNextShort(charstring Argument, charstring& Leftover);
   Arg* parseNextLong(charstring Argument, charstring& Leftover);
   void showUsage();
+
+  // Records that there was an error, and then returns stream to print
+  // error message to.
+  FILE* error();
 
   friend class Arg;
 

--- a/src/utils/ArgsParseBool.cpp
+++ b/src/utils/ArgsParseBool.cpp
@@ -23,7 +23,7 @@ namespace wasm {
 namespace utils {
 
 template <>
-bool ArgsParser::Optional<bool>::select(charstring OptionValue) {
+bool ArgsParser::Optional<bool>::select(ArgsParser*, charstring OptionValue) {
   Value = !DefaultValue;
   return false;
 }
@@ -38,7 +38,7 @@ void ArgsParser::Optional<bool>::describeDefault(FILE* Out,
   printDescriptionContinue(Out, TabSize, Indent, ")");
 }
 
-bool ArgsParser::Toggle::select(charstring OptionValue) {
+bool ArgsParser::Toggle::select(ArgsParser*, charstring OptionValue) {
   Value = !Value;
   return false;
 }

--- a/src/utils/ArgsParseCharstring.cpp
+++ b/src/utils/ArgsParseCharstring.cpp
@@ -25,7 +25,10 @@ namespace wasm {
 namespace utils {
 
 template <>
-bool ArgsParser::Optional<charstring>::select(charstring OptionValue) {
+bool ArgsParser::Optional<charstring>::select(ArgsParser* Parser,
+                                              charstring OptionValue) {
+  if (!validOptionValue(Parser, OptionValue))
+    return false;
   Value = OptionValue;
   return true;
 }
@@ -44,7 +47,10 @@ void ArgsParser::Optional<charstring>::describeDefault(FILE* Out,
 }
 
 template <>
-bool ArgsParser::Required<charstring>::select(charstring OptionValue) {
+bool ArgsParser::Required<charstring>::select(ArgsParser* Parser,
+                                              charstring OptionValue) {
+  if (!validOptionValue(Parser, OptionValue))
+    return false;
   Value = OptionValue;
   return true;
 }

--- a/src/utils/ArgsParseInt32_t.cpp
+++ b/src/utils/ArgsParseInt32_t.cpp
@@ -26,7 +26,10 @@ namespace wasm {
 namespace utils {
 
 template <>
-bool ArgsParser::SetValue<int32_t>::select(charstring OptionValue) {
+bool ArgsParser::SetValue<int32_t>::select(ArgsParser* Parser,
+                                           charstring OptionValue) {
+  if (!validOptionValue(Parser, OptionValue))
+    return false;
   Value = int32_t(atoll(OptionValue));
   return false;
 }

--- a/src/utils/ArgsParseInt64_t.cpp
+++ b/src/utils/ArgsParseInt64_t.cpp
@@ -26,7 +26,10 @@ namespace wasm {
 namespace utils {
 
 template <>
-bool ArgsParser::Optional<int64_t>::select(charstring OptionValue) {
+bool ArgsParser::Optional<int64_t>::select(ArgsParser* Parser,
+                                           charstring OptionValue) {
+  if (!validOptionValue(Parser, OptionValue))
+    return false;
   Value = int64_t(atoll(OptionValue));
   return true;
 }

--- a/src/utils/ArgsParseSize_t.cpp
+++ b/src/utils/ArgsParseSize_t.cpp
@@ -26,7 +26,10 @@ namespace wasm {
 namespace utils {
 
 template <>
-bool ArgsParser::Optional<size_t>::select(charstring OptionValue) {
+bool ArgsParser::Optional<size_t>::select(ArgsParser* Parser,
+                                          charstring OptionValue) {
+  if (!validOptionValue(Parser, OptionValue))
+    return false;
   Value = size_t(atoll(OptionValue));
   return true;
 }

--- a/src/utils/ArgsParseString.cpp
+++ b/src/utils/ArgsParseString.cpp
@@ -23,7 +23,10 @@ namespace wasm {
 namespace utils {
 
 template <>
-bool ArgsParser::RepeatableSet<std::string>::select(charstring Add) {
+bool ArgsParser::RepeatableSet<std::string>::select(ArgsParser* Parser,
+                                                    charstring Add) {
+  if (!validOptionValue(Parser, Add))
+    return false;
   Values.insert(Add);
   return true;
 }

--- a/src/utils/ArgsParseUint32_t.cpp
+++ b/src/utils/ArgsParseUint32_t.cpp
@@ -26,7 +26,10 @@ namespace wasm {
 namespace utils {
 
 template <>
-bool ArgsParser::Optional<uint32_t>::select(charstring OptionValue) {
+bool ArgsParser::Optional<uint32_t>::select(ArgsParser* Parser,
+                                            charstring OptionValue) {
+  if (!validOptionValue(Parser, OptionValue))
+    return false;
   Value = uint32_t(atoll(OptionValue));
   return true;
 }

--- a/src/utils/ArgsParseUint64_t.cpp
+++ b/src/utils/ArgsParseUint64_t.cpp
@@ -26,7 +26,10 @@ namespace wasm {
 namespace utils {
 
 template <>
-bool ArgsParser::Optional<uint64_t>::select(charstring OptionValue) {
+bool ArgsParser::Optional<uint64_t>::select(ArgsParser* Parser,
+                                            charstring OptionValue) {
+  if (!validOptionValue(Parser, OptionValue))
+    return false;
   Value = uint64_t(atoll(OptionValue));
   return true;
 }


### PR DESCRIPTION
Uses the results of the abbreviation selector to determine how abbreviations are applied.

Also fixes bug in command-line parser when the last command line argument expects an argument, but none was provided.
