### PR TITLE
Simplify interpretation writers to use varuint64 by default.

### DIFF
--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -73,36 +73,6 @@ StreamType AbbrevAssignWriter::getStreamType() const {
   return StreamType::Int;
 }
 
-bool AbbrevAssignWriter::writeUint8(uint8_t Value) {
-  bufferValue(Value);
-  return true;
-}
-
-bool AbbrevAssignWriter::writeUint32(uint32_t Value) {
-  bufferValue(Value);
-  return true;
-}
-
-bool AbbrevAssignWriter::writeUint64(uint64_t Value) {
-  bufferValue(Value);
-  return true;
-}
-
-bool AbbrevAssignWriter::writeVarint32(int32_t Value) {
-  bufferValue(Value);
-  return true;
-}
-
-bool AbbrevAssignWriter::writeVarint64(int64_t Value) {
-  bufferValue(Value);
-  return true;
-}
-
-bool AbbrevAssignWriter::writeVaruint32(uint32_t Value) {
-  bufferValue(Value);
-  return true;
-}
-
 bool AbbrevAssignWriter::writeVaruint64(uint64_t Value) {
   bufferValue(Value);
   return true;
@@ -120,11 +90,6 @@ bool AbbrevAssignWriter::writeFreezeEof() {
   flushDefaultValues();
   alignIfNecessary();
   return Writer.writeFreezeEof();
-}
-
-bool AbbrevAssignWriter::writeValue(decode::IntType Value, const filt::Node*) {
-  bufferValue(Value);
-  return true;
 }
 
 bool AbbrevAssignWriter::writeHeaderValue(decode::IntType Value,

--- a/src/intcomp/AbbrevAssignWriter.h
+++ b/src/intcomp/AbbrevAssignWriter.h
@@ -46,15 +46,8 @@ class AbbrevAssignWriter : public interp::Writer {
   ~AbbrevAssignWriter() OVERRIDE;
 
   decode::StreamType getStreamType() const OVERRIDE;
-  bool writeUint8(uint8_t Value) OVERRIDE;
-  bool writeUint32(uint32_t Value) OVERRIDE;
-  bool writeUint64(uint64_t Value) OVERRIDE;
-  bool writeVarint32(int32_t Value) OVERRIDE;
-  bool writeVarint64(int64_t Value) OVERRIDE;
-  bool writeVaruint32(uint32_t Value) OVERRIDE;
   bool writeVaruint64(uint64_t Value) OVERRIDE;
   bool writeFreezeEof() OVERRIDE;
-  bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
   bool writeHeaderValue(decode::IntType Value,
                         interp::IntTypeFormat Format) OVERRIDE;
   bool writeAction(const filt::SymbolNode* Action) OVERRIDE;

--- a/src/intcomp/CountWriter.cpp
+++ b/src/intcomp/CountWriter.cpp
@@ -53,42 +53,7 @@ void CountWriter::addToUsageMap(IntType Value) {
     Frontier.push_back(TopNd);
 }
 
-bool CountWriter::writeUint8(uint8_t Value) {
-  addToUsageMap(Value);
-  return true;
-}
-
-bool CountWriter::writeUint32(uint32_t Value) {
-  addToUsageMap(Value);
-  return true;
-}
-
-bool CountWriter::writeUint64(uint64_t Value) {
-  addToUsageMap(Value);
-  return true;
-}
-
-bool CountWriter::writeVarint32(int32_t Value) {
-  addToUsageMap(Value);
-  return true;
-}
-
-bool CountWriter::writeVarint64(int64_t Value) {
-  addToUsageMap(Value);
-  return true;
-}
-
-bool CountWriter::writeVaruint32(uint32_t Value) {
-  addToUsageMap(Value);
-  return true;
-}
-
 bool CountWriter::writeVaruint64(uint64_t Value) {
-  addToUsageMap(Value);
-  return true;
-}
-
-bool CountWriter::writeValue(decode::IntType Value, const filt::Node*) {
   addToUsageMap(Value);
   return true;
 }

--- a/src/intcomp/CountWriter.h
+++ b/src/intcomp/CountWriter.h
@@ -59,14 +59,7 @@ class CountWriter : public interp::Writer {
   void addToUsageMap(decode::IntType Value);
 
   decode::StreamType getStreamType() const OVERRIDE;
-  bool writeUint8(uint8_t Value) OVERRIDE;
-  bool writeUint32(uint32_t Value) OVERRIDE;
-  bool writeUint64(uint64_t Value) OVERRIDE;
-  bool writeVarint32(int32_t Value) OVERRIDE;
-  bool writeVarint64(int64_t Value) OVERRIDE;
-  bool writeVaruint32(uint32_t Value) OVERRIDE;
   bool writeVaruint64(uint64_t Value) OVERRIDE;
-  bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
   bool writeHeaderValue(decode::IntType Value,
                         interp::IntTypeFormat Format) OVERRIDE;
   bool writeAction(const filt::SymbolNode* Action) OVERRIDE;

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -48,30 +48,6 @@ StreamType IntWriter::getStreamType() const {
   return StreamType::Int;
 }
 
-bool IntWriter::writeUint8(uint8_t Value) {
-  return write(Value);
-}
-
-bool IntWriter::writeUint32(uint32_t Value) {
-  return write(Value);
-}
-
-bool IntWriter::writeUint64(uint64_t Value) {
-  return write(Value);
-}
-
-bool IntWriter::writeVarint32(int32_t Value) {
-  return write(Value);
-}
-
-bool IntWriter::writeVarint64(int64_t Value) {
-  return write(Value);
-}
-
-bool IntWriter::writeVaruint32(uint32_t Value) {
-  return write(Value);
-}
-
 bool IntWriter::writeVaruint64(uint64_t Value) {
   return write(Value);
 }

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -40,12 +40,6 @@ class IntWriter : public Writer {
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
   bool write(decode::IntType Value) { return Pos.write(Value); }
-  bool writeUint8(uint8_t Value) OVERRIDE;
-  bool writeUint32(uint32_t Value) OVERRIDE;
-  bool writeUint64(uint64_t Value) OVERRIDE;
-  bool writeVarint32(int32_t Value) OVERRIDE;
-  bool writeVarint64(int64_t Value) OVERRIDE;
-  bool writeVaruint32(uint32_t Value) OVERRIDE;
   bool writeVaruint64(uint64_t Value) OVERRIDE;
   bool writeFreezeEof() OVERRIDE;
   bool writeHeaderValue(decode::IntType Value,

--- a/src/interp/Writer.cpp
+++ b/src/interp/Writer.cpp
@@ -29,6 +29,30 @@ namespace interp {
 Writer::~Writer() {
 }
 
+bool Writer::writeUint8(uint8_t Value) {
+  return writeVaruint64(Value);
+}
+
+bool Writer::writeUint32(uint32_t Value) {
+  return writeVaruint64(Value);
+}
+
+bool Writer::writeUint64(uint64_t Value) {
+  return writeVaruint64(Value);
+}
+
+bool Writer::writeVarint32(int32_t Value) {
+  return writeVaruint64(Value);
+}
+
+bool Writer::writeVarint64(int64_t Value) {
+  return writeVaruint64(Value);
+}
+
+bool Writer::writeVaruint32(uint32_t Value) {
+  return writeVaruint64(Value);
+}
+
 void Writer::setMinimizeBlockSize(bool NewValue) {
   MinimizeBlockSize = NewValue;
 }

--- a/src/interp/Writer.h
+++ b/src/interp/Writer.h
@@ -41,12 +41,12 @@ class Writer {
   virtual decode::StreamType getStreamType() const = 0;
   // Override the following as needed. These methods return false if the writes
   // failed. Default actions are to do nothing and return true.
-  virtual bool writeUint8(uint8_t Value) = 0;
-  virtual bool writeUint32(uint32_t Value) = 0;
-  virtual bool writeUint64(uint64_t Value) = 0;
-  virtual bool writeVarint32(int32_t Value) = 0;
-  virtual bool writeVarint64(int64_t Value) = 0;
-  virtual bool writeVaruint32(uint32_t Value) = 0;
+  virtual bool writeUint8(uint8_t Value);
+  virtual bool writeUint32(uint32_t Value);
+  virtual bool writeUint64(uint64_t Value);
+  virtual bool writeVarint32(int32_t Value);
+  virtual bool writeVarint64(int64_t Value);
+  virtual bool writeVaruint32(uint32_t Value);
   virtual bool writeVaruint64(uint64_t Value) = 0;
   virtual bool writeFreezeEof();
   virtual bool writeBinary(decode::IntType Value, const filt::Node* Encoding);


### PR DESCRIPTION
This removes a lot of repeated code for writers that don't need to byte format (which is all writers except the byte writer).