### PR TITLE
Store abstract abbreviation assignments, then insert into stream

### DIFF
--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -30,6 +30,7 @@ namespace intcomp {
 
 AbbrevAssignWriter::AbbrevAssignWriter(
     CountNode::RootPtr Root,
+    CountNode::PtrSet&,
     std::shared_ptr<interp::IntStream> Output,
     size_t BufSize,
     interp::IntTypeFormat AbbrevFormat,
@@ -147,7 +148,8 @@ bool AbbrevAssignWriter::writeAction(const filt::SymbolNode* Action) {
       forwardAbbrevValue(Root->getBlockExit()->getAbbrevIndex());
       return true;
     default:
-      return Writer.writeAction(Action);
+      // There should not be any other actions!!
+      return false;
   }
 }
 

--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -161,7 +161,7 @@ class LoopValue : public IntValue {
 LoopValue::~LoopValue() {
 }
 
-LoopValue* LoopValue::create(IntType Value) {
+LoopValue* LoopValue::create(size_t Value) {
   return new LoopValue(Value);
 }
 

--- a/src/intcomp/AbbrevAssignWriter.h
+++ b/src/intcomp/AbbrevAssignWriter.h
@@ -43,7 +43,6 @@ class AbbrevAssignWriter : public interp::Writer {
                      CountNode::PtrSet& Assignments,
                      std::shared_ptr<interp::IntStream> Output,
                      size_t BufSize,
-                     interp::IntTypeFormat AbbrevFormat,
                      bool AssumeByteAlignment,
                      const CompressionFlags& MyFlags);
   ~AbbrevAssignWriter() OVERRIDE;
@@ -65,9 +64,6 @@ class AbbrevAssignWriter : public interp::Writer {
 #endif
   interp::IntWriter Writer;
   utils::circular_vector<decode::IntType> Buffer;
-#if 0
-  interp::IntTypeFormat AbbrevFormat;
-#endif
   std::vector<decode::IntType> DefaultValues;
   // Intermediate structure. Allows us to change encoding of
   // abbreviations once we know the actually usage counts.

--- a/src/intcomp/AbbrevAssignWriter.h
+++ b/src/intcomp/AbbrevAssignWriter.h
@@ -21,7 +21,6 @@
 
 #include <vector>
 
-#include "intcomp/AbbrevWriter.h"
 #include "intcomp/CompressionFlags.h"
 #include "intcomp/IntCountNode.h"
 #include "interp/IntStream.h"
@@ -31,6 +30,8 @@
 namespace wasm {
 
 namespace intcomp {
+
+class AbbrevAssignValue;
 
 class AbbrevAssignWriter : public interp::Writer {
   AbbrevAssignWriter() = delete;
@@ -59,21 +60,32 @@ class AbbrevAssignWriter : public interp::Writer {
  private:
   const CompressionFlags& MyFlags;
   CountNode::RootPtr Root;
+#if 0
+  CountNode::PtrSet& Assignments;
+#endif
   interp::IntWriter Writer;
   utils::circular_vector<decode::IntType> Buffer;
+#if 0
   interp::IntTypeFormat AbbrevFormat;
+#endif
   std::vector<decode::IntType> DefaultValues;
+  // Intermediate structure. Allows us to change encoding of
+  // abbreviations once we know the actually usage counts.
+  std::vector<AbbrevAssignValue*> Values;
   bool AssumeByteAlignment;
   size_t ProgressCount;
 
   void bufferValue(decode::IntType Value);
-  void forwardAbbrevValue(decode::IntType Value);
+  void forwardAbbrev(CountNode::Ptr Abbrev);
+  void forwardAbbrevAfterFlush(CountNode::Ptr Abbev);
   void forwardOtherValue(decode::IntType Value);
   void writeFromBuffer();
   void writeUntilBufferEmpty();
   void popValuesFromBuffer(size_t size);
   void flushDefaultValues();
   void alignIfNecessary();
+  bool flushValues();
+  void clearValues();
 
   const char* getDefaultTraceName() const OVERRIDE;
 };

--- a/src/intcomp/AbbrevAssignWriter.h
+++ b/src/intcomp/AbbrevAssignWriter.h
@@ -19,13 +19,14 @@
 #ifndef DECOMPRESSOR_SRC_INTCOMP_ABBREVASSIGNWRITER_H
 #define DECOMPRESSOR_SRC_INTCOMP_ABBREVASSIGNWRITER_H
 
+#include <vector>
+
+#include "intcomp/AbbrevWriter.h"
 #include "intcomp/CompressionFlags.h"
 #include "intcomp/IntCountNode.h"
 #include "interp/IntStream.h"
 #include "interp/IntWriter.h"
 #include "utils/circular-vector.h"
-
-#include <vector>
 
 namespace wasm {
 
@@ -38,6 +39,7 @@ class AbbrevAssignWriter : public interp::Writer {
 
  public:
   AbbrevAssignWriter(CountNode::RootPtr Root,
+                     CountNode::PtrSet& Assignments,
                      std::shared_ptr<interp::IntStream> Output,
                      size_t BufSize,
                      interp::IntTypeFormat AbbrevFormat,

--- a/src/intcomp/AbbrevSelector.cpp
+++ b/src/intcomp/AbbrevSelector.cpp
@@ -112,10 +112,14 @@ AbbrevSelection::AbbrevSelection(CountNode::Ptr Abbreviation,
 void AbbrevSelection::trace(TraceClass& TC,
                             charstring Name,
                             AbbrevSelection::Ptr Sel) {
+#if 0
   TC.indent();
   FILE* Out = TC.getFile();
   TC.trace_value_label(Name);
   fputc('\n', Out);
+#else
+  TC.trace_message(Name);
+#endif
   std::vector<AbbrevSelection*> Stack;
   AbbrevSelection* Next = Sel.get();
   while (Next) {
@@ -123,7 +127,11 @@ void AbbrevSelection::trace(TraceClass& TC,
     Next = Next->Previous.get();
   }
   while (!Stack.empty()) {
+#if 0
     Stack.back()->describe(TC.indentNewline());
+#else
+    Stack.back()->describe(TC.trace_prefix(""));
+#endif
     Stack.pop_back();
   }
 }

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -286,7 +286,7 @@ bool IntCompressor::generateIntOutput(CountNode::PtrSet& Assignments) {
   auto Writer = std::make_shared<AbbrevAssignWriter>(
       Root, Assignments, IntOutput,
       MyFlags.PatternLengthLimit * MyFlags.PatternLengthMultiplier,
-      MyFlags.AbbrevFormat, !MyFlags.UseHuffmanEncoding, MyFlags);
+      !MyFlags.UseHuffmanEncoding, MyFlags);
   IntInterperter Interp(std::make_shared<IntReader>(Contents), Writer,
                         MyFlags.MyInterpFlags, Symtab);
   if (MyFlags.TraceIntStreamGeneration)

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -246,7 +246,7 @@ void IntCompressor::compress() {
                           MyFlags.TraceAbbreviationAssignmentsCollection);
   IntOutput = std::make_shared<IntStream>();
   TRACE_MESSAGE("Generating compressed integer stream");
-  if (!generateIntOutput())
+  if (!generateIntOutput(AbbrevAssignments))
     return;
   TRACE(size_t, "Number of integers in compressed output",
         IntOutput->getNumIntegers());
@@ -282,9 +282,9 @@ void IntCompressor::assignInitialAbbreviations(CountNode::PtrSet& Assignments) {
   }
 }
 
-bool IntCompressor::generateIntOutput() {
+bool IntCompressor::generateIntOutput(CountNode::PtrSet& Assignments) {
   auto Writer = std::make_shared<AbbrevAssignWriter>(
-      Root, IntOutput,
+      Root, Assignments, IntOutput,
       MyFlags.PatternLengthLimit * MyFlags.PatternLengthMultiplier,
       MyFlags.AbbrevFormat, !MyFlags.UseHuffmanEncoding, MyFlags);
   IntInterperter Interp(std::make_shared<IntReader>(Contents), Writer,

--- a/src/intcomp/IntCompress.h
+++ b/src/intcomp/IntCompress.h
@@ -115,7 +115,7 @@ class IntCompressor FINAL {
   void removeAllSmallUsageCounts() { removeSmallUsageCounts(false, false); }
   void zeroSmallUsageCounts() { removeSmallUsageCounts(false, true); }
   void assignInitialAbbreviations(CountNode::PtrSet& Assignments);
-  bool generateIntOutput();
+  bool generateIntOutput(CountNode::PtrSet& Assignments);
   std::shared_ptr<filt::SymbolTable>
   generateCode(CountNode::PtrSet& Assignments, bool ToRead, bool Trace);
   std::shared_ptr<filt::SymbolTable> generateCodeForReading(

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -45,11 +45,8 @@ class IntWriter : public Writer {
   bool writeHeaderValue(decode::IntType Value,
                         interp::IntTypeFormat Format) OVERRIDE;
   bool writeAction(const filt::SymbolNode* Action) OVERRIDE;
-
   utils::TraceClass::ContextPtr getTraceContext() OVERRIDE;
-
-  virtual void describeState(FILE* File);
-
+  void describeState(FILE* File) OVERRIDE;
   size_t getIndex() const { return Pos.getIndex(); }
 
  private:

--- a/src/utils/Trace.cpp
+++ b/src/utils/Trace.cpp
@@ -127,6 +127,12 @@ void TraceClass::trace_value_label(charstring Label) {
   fprintf(File, "%s = ", Label);
 }
 
+FILE* TraceClass::tracePrefixInternal(const std::string& Message) {
+  indent();
+  fprintf(File, "%s", Message.c_str());
+  return File;
+}
+
 void TraceClass::traceMessageInternal(const std::string& Message) {
   indent();
   fprintf(File, "%s\n", Message.c_str());

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -51,11 +51,11 @@
       (tracE).trace_##type((name), (value));  \
   } while (false)
 #define TRACE(type, name, value) TRACE_USING(getTrace(), type, name, value)
-#define TRACE_PREFIX_USING(trace, Message)  \
-  do {                                      \
-    auto& tracE = (trace);                  \
-    if (tracE.getTraceProgress())           \
-      tracE.trace_prefix(Message);          \
+#define TRACE_PREFIX_USING(trace, Message) \
+  do {                                     \
+    auto& tracE = (trace);                 \
+    if (tracE.getTraceProgress())          \
+      tracE.trace_prefix(Message);         \
   } while (false)
 #define TRACE_PREFIX(Message) TRACE_PREFIX_USING(getTrace(), Message)
 #define TRACE_MESSAGE_USING(trace, Message) \
@@ -160,8 +160,12 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
   FILE* indent();
   FILE* indentNewline();
   void trace_value_label(charstring Label);
-  FILE* trace_prefix(charstring Message) { return tracePrefixInternal(Message); }
-  FILE* trace_prefix(std::string Message) { return tracePrefixInternal(Message); }
+  FILE* trace_prefix(charstring Message) {
+    return tracePrefixInternal(Message);
+  }
+  FILE* trace_prefix(std::string Message) {
+    return tracePrefixInternal(Message);
+  }
   void trace_message(charstring Message) { traceMessageInternal(Message); }
   void trace_message(std::string Message) { traceMessageInternal(Message); }
   void trace_bool(charstring Name, bool Value) {

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -26,6 +26,8 @@
 #define TRACE_METHOD(Name)
 #define TRACE_USING(trace, type, name, value)
 #define TRACE(type, name, value)
+#define TRACE_PREFIX_USING(trace, Message)
+#define TRACE_PREFIX(Message)
 #define TRACE_MESSAGE_USING(trace, Message)
 #define TRACE_MESSAGE(Message)
 #define TRACE_ENTER_USING(name, trace)
@@ -49,6 +51,13 @@
       (tracE).trace_##type((name), (value));  \
   } while (false)
 #define TRACE(type, name, value) TRACE_USING(getTrace(), type, name, value)
+#define TRACE_PREFIX_USING(trace, Message)  \
+  do {                                      \
+    auto& tracE = (trace);                  \
+    if (tracE.getTraceProgress())           \
+      tracE.trace_prefix(Message);          \
+  } while (false)
+#define TRACE_PREFIX(Message) TRACE_PREFIX_USING(getTrace(), Message)
 #define TRACE_MESSAGE_USING(trace, Message) \
   do {                                      \
     auto& tracE = (trace);                  \
@@ -151,6 +160,8 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
   FILE* indent();
   FILE* indentNewline();
   void trace_value_label(charstring Label);
+  FILE* trace_prefix(charstring Message) { return tracePrefixInternal(Message); }
+  FILE* trace_prefix(std::string Message) { return tracePrefixInternal(Message); }
   void trace_message(charstring Message) { traceMessageInternal(Message); }
   void trace_message(std::string Message) { traceMessageInternal(Message); }
   void trace_bool(charstring Name, bool Value) {
@@ -257,6 +268,7 @@ class TraceClass : public std::enable_shared_from_this<TraceClass> {
   std::vector<charstring> CallStack;
   std::vector<ContextPtr> ContextList;
 
+  FILE* tracePrefixInternal(const std::string& Message);
   void traceMessageInternal(const std::string& Message);
   void traceBoolInternal(charstring Name, bool Value);
   void traceCharInternal(charstring Name, char Ch);


### PR DESCRIPTION
This is a precursor to "reassigning" abbreviation values before inserting into the stream. In particular, we can now base the actual assignments based on usage rather than previous estimates.

Fixing abbreviation values should improve Huffman encoded values for abbreviations.