### PR TITLE
Reassign abbreviation indices once usage is known.

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -246,7 +246,23 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbreviationAssignments);
     Args.add(
         TraceAbbreviationAssignmentsFlag.setLongName("verbose=abbreviations")
-            .setDescription("Show (initial) abbreviation assignments"));
+            .setDescription("Show (final) abbreviation assignments"));
+
+    ArgsParser::Optional<bool> TraceInitialAbbreviationAssignmentsFlag(
+        MyCompressionFlags.TraceInitialAbbreviationAssignments);
+    Args.add(TraceInitialAbbreviationAssignmentsFlag
+                 .setLongName("verbose=initial-abbreviations")
+                 .setDescription(
+                     "Show initial abbreviation assignments before selecting "
+                     "patterns"));
+
+    ArgsParser::Toggle ReassignAbbreviationsFlag(
+        MyCompressionFlags.ReassignAbbreviations);
+    Args.add(ReassignAbbreviationsFlag.setShortName('r')
+                 .setLongName("reassign")
+                 .setDescription(
+                     "Toggle whether abbrevation are reassigned after "
+                     "selecting patterns"));
 
     ArgsParser::Optional<bool> TraceAbbreviationAssignmentsCollectionFlag(
         MyCompressionFlags.TraceAbbreviationAssignmentsCollection);

--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -272,14 +272,17 @@ void AbbrevAssignWriter::reassignAbbreviations() {
   EncodingRoot = CountNode::assignAbbreviations(Assignments, MyFlags);
   if (!MyFlags.TraceAbbreviationAssignments)
     return;
-  fprintf(stderr, "Final abbreviation assignments:\n");
-  CountNode::describeNodes(stderr, Assignments);
 }
 
 bool AbbrevAssignWriter::flushValues() {
   TRACE_MESSAGE("Flushing collected abbreviations");
   if (MyFlags.ReassignAbbreviations)
     reassignAbbreviations();
+  if (MyFlags.TraceAbbreviationAssignments) {
+    fprintf(stderr, "abbreviation assignments:\n");
+    fprintf(stderr, "-------------------------\n");
+    CountNode::describeNodes(stderr, Assignments);
+  }
   for (AbbrevAssignValue* Value : Values) {
     TRACE_BLOCK({
       TRACE_PREFIX("Write ");

--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -174,22 +174,19 @@ void LoopValue::describe(FILE* Out) {
 AbbrevAssignWriter::AbbrevAssignWriter(
     CountNode::RootPtr Root,
     CountNode::PtrSet& Assignments,
+    HuffmanEncoder::NodePtr& EncodingRoot,
     std::shared_ptr<interp::IntStream> Output,
     size_t BufSize,
     bool AssumeByteAlignment,
     const CompressionFlags& MyFlags)
     : MyFlags(MyFlags),
       Root(Root),
-#if 0
       Assignments(Assignments),
-#endif
+      EncodingRoot(EncodingRoot),
       Writer(Output),
       Buffer(BufSize),
       AssumeByteAlignment(AssumeByteAlignment),
       ProgressCount(0) {
-#if 1
-  (void)Assignments;
-#endif
   assert(Root->getDefaultSingle()->hasAbbrevIndex());
   assert(Root->getDefaultMultiple()->hasAbbrevIndex());
 }
@@ -254,8 +251,30 @@ bool AbbrevAssignWriter::writeFreezeEof() {
   return flushValues();
 }
 
+void AbbrevAssignWriter::reassignAbbreviations() {
+  TRACE_METHOD("reassignAbbreviations");
+  // First clear usage counts.
+  CountNode::PtrVector Abbrevs;
+  for (CountNode::Ptr Nd : Assignments) {
+    Nd->setCount(0);
+    Abbrevs.push_back(Nd);
+  }
+  // Recompute usage counts.
+  for (AbbrevAssignValue* Value : Values)
+    if (auto* Val = dyn_cast<AbbrevValue>(Value))
+      Val->getAbbreviation()->increment();
+  // Now do the assignments.
+  Assignments.clear();
+  for (CountNode::Ptr& Nd : Abbrevs)
+    if (Nd->getCount() > 0)
+      Assignments.insert(Nd);
+  EncodingRoot = CountNode::assignAbbreviations(Assignments, MyFlags);
+}
+
 bool AbbrevAssignWriter::flushValues() {
   TRACE_MESSAGE("Flushing collected abbreviations");
+  if (MyFlags.ReassignAbbreviations)
+    reassignAbbreviations();
   for (AbbrevAssignValue* Value : Values) {
     TRACE_BLOCK({
       TRACE_PREFIX("Write ");
@@ -341,7 +360,7 @@ void AbbrevAssignWriter::writeFromBuffer() {
   // TODO(karlschimp): Figure out why TRACE macro can't be used!
   if (MyFlags.TraceAbbrevSelectionProgress != 0) {
     size_t Gap = MyFlags.TraceAbbrevSelectionProgress;
-    size_t Count = Writer.getIndex();
+    size_t Count = Values.size();
     while (Count >= ProgressCount + Gap) {
       ProgressCount += Gap;
       fprintf(stderr, "Progress: %" PRIuMAX "\n", uintmax_t(ProgressCount));

--- a/src/intcomp/AbbrevAssignWriter.cpp
+++ b/src/intcomp/AbbrevAssignWriter.cpp
@@ -257,6 +257,7 @@ void AbbrevAssignWriter::reassignAbbreviations() {
   CountNode::PtrVector Abbrevs;
   for (CountNode::Ptr Nd : Assignments) {
     Nd->setCount(0);
+    Nd->clearAbbrevIndex();
     Abbrevs.push_back(Nd);
   }
   // Recompute usage counts.
@@ -269,6 +270,10 @@ void AbbrevAssignWriter::reassignAbbreviations() {
     if (Nd->getCount() > 0)
       Assignments.insert(Nd);
   EncodingRoot = CountNode::assignAbbreviations(Assignments, MyFlags);
+  if (!MyFlags.TraceAbbreviationAssignments)
+    return;
+  fprintf(stderr, "Final abbreviation assignments:\n");
+  CountNode::describeNodes(stderr, Assignments);
 }
 
 bool AbbrevAssignWriter::flushValues() {

--- a/src/intcomp/AbbrevAssignWriter.h
+++ b/src/intcomp/AbbrevAssignWriter.h
@@ -41,6 +41,7 @@ class AbbrevAssignWriter : public interp::Writer {
  public:
   AbbrevAssignWriter(CountNode::RootPtr Root,
                      CountNode::PtrSet& Assignments,
+                     utils::HuffmanEncoder::NodePtr& EncodingRoot,
                      std::shared_ptr<interp::IntStream> Output,
                      size_t BufSize,
                      bool AssumeByteAlignment,
@@ -59,9 +60,8 @@ class AbbrevAssignWriter : public interp::Writer {
  private:
   const CompressionFlags& MyFlags;
   CountNode::RootPtr Root;
-#if 0
   CountNode::PtrSet& Assignments;
-#endif
+  utils::HuffmanEncoder::NodePtr& EncodingRoot;
   interp::IntWriter Writer;
   utils::circular_vector<decode::IntType> Buffer;
   std::vector<decode::IntType> DefaultValues;
@@ -82,6 +82,7 @@ class AbbrevAssignWriter : public interp::Writer {
   void alignIfNecessary();
   bool flushValues();
   void clearValues();
+  void reassignAbbreviations();
 
   const char* getDefaultTraceName() const OVERRIDE;
 };

--- a/src/intcomp/AbbrevSelector.cpp
+++ b/src/intcomp/AbbrevSelector.cpp
@@ -112,14 +112,7 @@ AbbrevSelection::AbbrevSelection(CountNode::Ptr Abbreviation,
 void AbbrevSelection::trace(TraceClass& TC,
                             charstring Name,
                             AbbrevSelection::Ptr Sel) {
-#if 0
-  TC.indent();
-  FILE* Out = TC.getFile();
-  TC.trace_value_label(Name);
-  fputc('\n', Out);
-#else
   TC.trace_message(Name);
-#endif
   std::vector<AbbrevSelection*> Stack;
   AbbrevSelection* Next = Sel.get();
   while (Next) {
@@ -127,11 +120,7 @@ void AbbrevSelection::trace(TraceClass& TC,
     Next = Next->Previous.get();
   }
   while (!Stack.empty()) {
-#if 0
-    Stack.back()->describe(TC.indentNewline());
-#else
     Stack.back()->describe(TC.trace_prefix(""));
-#endif
     Stack.pop_back();
   }
 }

--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -30,10 +30,7 @@ namespace intcomp {
 AbbreviationsCollector::AbbreviationsCollector(CountNode::RootPtr Root,
                                                CountNode::PtrSet& Assignments,
                                                const CompressionFlags& MyFlags)
-    : CountNodeCollector(Root),
-      Assignments(Assignments),
-      MyFlags(MyFlags),
-      Encoder(std::make_shared<HuffmanEncoder>()) {
+    : CountNodeCollector(Root), Assignments(Assignments), MyFlags(MyFlags) {
 }
 
 AbbreviationsCollector::~AbbreviationsCollector() {
@@ -49,7 +46,7 @@ std::shared_ptr<TraceClass> AbbreviationsCollector::getTracePtr() {
   return Trace;
 }
 
-void AbbreviationsCollector::assignAbbreviations() {
+HuffmanEncoder::NodePtr AbbreviationsCollector::assignAbbreviations() {
   TRACE_METHOD("assignAbbreviations");
   TRACE(uint64_t, "WeightCutoff", MyFlags.WeightCutoff);
   TrimmedNodes.clear();
@@ -102,22 +99,8 @@ void AbbreviationsCollector::assignAbbreviations() {
     addAbbreviation(Nd);
   }
   TrimmedNodes.clear();
-  // Now create abbreviation indices for selected abbreviations.
   clearHeap();
-  for (const CountNode::Ptr& Nd : Assignments)
-    pushHeap(Nd);
-  while (!ValuesHeap->empty()) {
-    CountNode::Ptr Nd = popHeap();
-    Nd->setAbbrevIndex(Encoder->createSymbol(Nd->getCount()));
-  }
-}
-
-HuffmanEncoder::NodePtr AbbreviationsCollector::assignHuffmanAbbreviations() {
-  // Start by extracting out candidates based on weight. Then use resulting
-  // selected patterns as alphabet for Huffman encoding.
-  assignAbbreviations();
-  HuffmanRoot = Encoder->encodeSymbols();
-  return HuffmanRoot;
+  return CountNode::assignAbbreviations(Assignments, MyFlags);
 }
 
 void AbbreviationsCollector::addAbbreviation(CountNode::Ptr Nd) {

--- a/src/intcomp/AbbreviationsCollector.h
+++ b/src/intcomp/AbbreviationsCollector.h
@@ -19,9 +19,7 @@
 #ifndef DECOMPRESSOR_SRC_INTCOMP_ABBREVIATIONSCOLLECTOR_H
 #define DECOMPRESSOR_SRC_INTCOMP_ABBREVIATIONSCOLLECTOR_H
 
-#include "intcomp/CompressionFlags.h"
 #include "intcomp/CountNodeCollector.h"
-#include "utils/HuffmanEncoding.h"
 
 namespace wasm {
 
@@ -36,11 +34,9 @@ class AbbreviationsCollector : public CountNodeCollector {
   ~AbbreviationsCollector();
 
   // Does assignment based on maximizing weight. This will find the set of
-  // candidate patterns to use as abbreviations.
-  void assignAbbreviations();
-
-  // Same as assignAbbreviations, but does this based on Huffman encodings.
-  utils::HuffmanEncoder::NodePtr assignHuffmanAbbreviations();
+  // candidate patterns to use as abbreviations. Returns Huffman encoding
+  // of abbreviations if generated.
+  utils::HuffmanEncoder::NodePtr assignAbbreviations();
 
   utils::TraceClass& getTrace() { return *getTracePtr(); }
   std::shared_ptr<utils::TraceClass> getTracePtr();
@@ -50,9 +46,6 @@ class AbbreviationsCollector : public CountNodeCollector {
  private:
   CountNode::PtrSet& Assignments;
   const CompressionFlags& MyFlags;
-  std::shared_ptr<utils::HuffmanEncoder> Encoder;
-  utils::HuffmanEncoder::NodePtr HuffmanRoot;
-  utils::HuffmanEncoder::NodePtr Encoding;
   std::shared_ptr<utils::TraceClass> Trace;
   CountNode::PtrSet TrimmedNodes;
 

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -75,6 +75,7 @@ struct CompressionFlags {
   bool TraceIntCountsCollection;
   bool TraceSequenceCounts;
   bool TraceSequenceCountsCollection;
+  bool TraceInitialAbbreviationAssignments;
   bool TraceAbbreviationAssignments;
   bool TraceAbbreviationAssignmentsCollection;
   bool TraceAssigningAbbreviations;

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -55,6 +55,7 @@ struct CompressionFlags {
   bool UseHuffmanEncoding;
   bool TrimOverriddenPatterns;
   bool CheckOverlapping;
+  bool ReassignAbbreviations;
   interp::IntTypeFormat DefaultFormat;
   interp::IntTypeFormat LoopSizeFormat;
 

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -207,20 +207,7 @@ void CountNodeCollector::describe(FILE* Out) {
           uintmax_t(NumNodesReported), uintmax_t(WeightTotal),
           uintmax_t(WeightReported), uintmax_t(CountTotal),
           uintmax_t(CountReported));
-#if 0
-  size_t Count = 0;
-  while (!ValuesHeap->empty()) {
-    CountNode::HeapValueType NdPtr = popHeap();
-    ++Count;
-    fprintf(Out, "%8" PRIuMAX ": ", uintmax_t(Count));
-    NdPtr->describe(Out);
-  }
-#else
-  CountNode::PtrSet Nodes;
-  while (!ValuesHeap->empty())
-    Nodes.insert(popHeap());
-  CountNode::describeNodes(Out, Nodes);
-#endif
+  CountNode::describeAndConsumeHeap(Out, ValuesHeap.get());
 }
 
 }  // end of namespace intcomp

--- a/src/intcomp/CountNodeCollector.cpp
+++ b/src/intcomp/CountNodeCollector.cpp
@@ -207,6 +207,7 @@ void CountNodeCollector::describe(FILE* Out) {
           uintmax_t(NumNodesReported), uintmax_t(WeightTotal),
           uintmax_t(WeightReported), uintmax_t(CountTotal),
           uintmax_t(CountReported));
+#if 0
   size_t Count = 0;
   while (!ValuesHeap->empty()) {
     CountNode::HeapValueType NdPtr = popHeap();
@@ -214,6 +215,12 @@ void CountNodeCollector::describe(FILE* Out) {
     fprintf(Out, "%8" PRIuMAX ": ", uintmax_t(Count));
     NdPtr->describe(Out);
   }
+#else
+  CountNode::PtrSet Nodes;
+  while (!ValuesHeap->empty())
+    Nodes.insert(popHeap());
+  CountNode::describeNodes(Out, Nodes);
+#endif
 }
 
 }  // end of namespace intcomp

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -84,6 +84,7 @@ CompressionFlags::CompressionFlags()
       TraceIntCountsCollection(false),
       TraceSequenceCounts(false),
       TraceSequenceCountsCollection(false),
+      TraceInitialAbbreviationAssignments(false),
       TraceAbbreviationAssignments(false),
       TraceAbbreviationAssignmentsCollection(false),
       TraceAssigningAbbreviations(false),
@@ -242,7 +243,7 @@ void IntCompressor::compress() {
   CountNode::PtrSet AbbrevAssignments;
   assignInitialAbbreviations(AbbrevAssignments);
   zeroSmallUsageCounts();
-  if (MyFlags.TraceAbbreviationAssignments)
+  if (MyFlags.TraceInitialAbbreviationAssignments)
     describeAbbreviations(stderr,
                           MyFlags.TraceAbbreviationAssignmentsCollection);
   IntOutput = std::make_shared<IntStream>();

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -67,6 +67,7 @@ CompressionFlags::CompressionFlags()
       UseHuffmanEncoding(false),
       TrimOverriddenPatterns(false),
       CheckOverlapping(false),
+      ReassignAbbreviations(true),
       DefaultFormat(IntTypeFormat::Varint64),
       LoopSizeFormat(IntTypeFormat::Varuint64),
       TraceHuffmanAssignments(false),
@@ -272,19 +273,12 @@ void IntCompressor::assignInitialAbbreviations(CountNode::PtrSet& Assignments) {
   AbbreviationsCollector Collector(getRoot(), Assignments, MyFlags);
   if (MyFlags.TraceAssigningAbbreviations && hasTrace())
     Collector.setTrace(getTracePtr());
-  if (!MyFlags.UseHuffmanEncoding)
-    return Collector.assignAbbreviations();
-  EncodingRoot = Collector.assignHuffmanAbbreviations();
-  if (MyFlags.TraceHuffmanAssignments) {
-    fprintf(stderr, "Huffman assignments:\n");
-    constexpr bool Brief = false;
-    EncodingRoot->describe(stderr, Brief);
-  }
+  EncodingRoot = Collector.assignAbbreviations();
 }
 
 bool IntCompressor::generateIntOutput(CountNode::PtrSet& Assignments) {
   auto Writer = std::make_shared<AbbrevAssignWriter>(
-      Root, Assignments, IntOutput,
+      Root, Assignments, EncodingRoot, IntOutput,
       MyFlags.PatternLengthLimit * MyFlags.PatternLengthMultiplier,
       !MyFlags.UseHuffmanEncoding, MyFlags);
   IntInterperter Interp(std::make_shared<IntReader>(Contents), Writer,

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -55,6 +55,24 @@ using namespace utils;
 
 namespace intcomp {
 
+HuffmanEncoder::NodePtr CountNode::assignAbbreviations(
+    PtrSet& Assignments,
+    const CompressionFlags& Flags) {
+  HuffmanEncoder Encoder;
+  auto Heap = std::make_shared<CountNode::HeapType>(CompareLt);
+  for (CountNode::Ptr Nd : Assignments)
+    Nd->associateWithHeap(Heap->push(Nd));
+
+  while (!Heap->empty()) {
+    CountNode::Ptr Nd = Heap->top()->getValue();
+    Heap->pop();
+    Nd->setAbbrevIndex(Encoder.createSymbol(Nd->getCount()));
+  }
+  if (!Flags.UseHuffmanEncoding)
+    return HuffmanEncoder::NodePtr();
+  return Encoder.encodeSymbols();
+}
+
 // NOTE(karlschimpf): Created here because g++ version on Travis not happy
 // when used in initializer to heap.
 std::function<bool(CountNode::Ptr, CountNode::Ptr)> CountNode::CompareLt =

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -74,8 +74,20 @@ HuffmanEncoder::NodePtr CountNode::assignAbbreviations(
 }
 
 void CountNode::describeNodes(FILE* Out, PtrSet& Nodes) {
+  fprintf(Out, "Describe nodes:\n");
   size_t Count = 0;
   for (CountNode::Ptr Nd : Nodes) {
+    ++Count;
+    fprintf(Out, "%8" PRIuMAX ": ", uintmax_t(Count));
+    Nd->describe(Out);
+  }
+}
+
+void CountNode::describeAndConsumeHeap(FILE* Out, HeapType* Heap) {
+  size_t Count = 0;
+  while (!Heap->empty()) {
+    CountNode::Ptr Nd = Heap->top()->getValue();
+    Heap->pop();
     ++Count;
     fprintf(Out, "%8" PRIuMAX ": ", uintmax_t(Count));
     Nd->describe(Out);

--- a/src/intcomp/IntCountNode.cpp
+++ b/src/intcomp/IntCountNode.cpp
@@ -73,6 +73,15 @@ HuffmanEncoder::NodePtr CountNode::assignAbbreviations(
   return Encoder.encodeSymbols();
 }
 
+void CountNode::describeNodes(FILE* Out, PtrSet& Nodes) {
+  size_t Count = 0;
+  for (CountNode::Ptr Nd : Nodes) {
+    ++Count;
+    fprintf(Out, "%8" PRIuMAX ": ", uintmax_t(Count));
+    Nd->describe(Out);
+  }
+}
+
 // NOTE(karlschimpf): Created here because g++ version on Travis not happy
 // when used in initializer to heap.
 std::function<bool(CountNode::Ptr, CountNode::Ptr)> CountNode::CompareLt =

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -83,6 +83,8 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
       const CompressionFlags& Flags);
 
   static void describeNodes(FILE* Out, PtrSet& Nodes);
+  // Consumes the heap, printing out each node as it is consumed.
+  static void describeAndConsumeHeap(FILE* Out, HeapType* Heap);
 
   enum class Kind { Root, Block, Default, Align, Singleton, IntSequence };
   Kind getKind() const { return NodeKind; }
@@ -101,6 +103,10 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
     return Abbrev != BAD_ABBREV_INDEX;
   }
   decode::IntType getAbbrevIndex() const;
+  utils::HuffmanEncoder::SymbolPtr getAbbrevSymbol() const {
+    return AbbrevSymbol;
+  }
+  size_t getAbbrevNumBits() const;
   bool hasAbbrevIndex() const;
   void clearAbbrevIndex();
   void setAbbrevIndex(utils::HuffmanEncoder::SymbolPtr Symbol);

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -78,6 +78,10 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
 
   virtual ~CountNode();
 
+  static utils::HuffmanEncoder::NodePtr assignAbbreviations(
+      PtrSet& Assignments,
+      const CompressionFlags& Flags);
+
   enum class Kind { Root, Block, Default, Align, Singleton, IntSequence };
   Kind getKind() const { return NodeKind; }
   size_t getCount() const { return Count; }

--- a/src/intcomp/IntCountNode.h
+++ b/src/intcomp/IntCountNode.h
@@ -82,6 +82,8 @@ class CountNode : public std::enable_shared_from_this<CountNode> {
       PtrSet& Assignments,
       const CompressionFlags& Flags);
 
+  static void describeNodes(FILE* Out, PtrSet& Nodes);
+
   enum class Kind { Root, Block, Default, Align, Singleton, IntSequence };
   Kind getKind() const { return NodeKind; }
   size_t getCount() const { return Count; }


### PR DESCRIPTION
The initial assignment of abbreviations is based on collected pattern usage. These indices are based on an approximation because we don't yet know which patterns will be chosen (depends on how selection works in the sliding window).

To fix this, keep track of the actual pattern selections to use, and then recompute the assignments based on the selection. For banana bread, this results in an additional 7% shrinkage in the compressed file.
