### PR TITLE
Add bit operator to algorithms

### DIFF
--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -48,9 +48,8 @@
 (literal 'varuint64'      (u8.const 0x26))
 (literal 'opcode'         (u8.const 0x27))
 (literal 'accept'         (u8.const 0x28))
-(literal 'reject'         (u8.const 0x29))
-(literal 'binary'         (u8.const 0x2a))
-(literal 'bin.eval'       (u8.const 0x2b))
+(literal 'binary'         (u8.const 0x29))
+(literal 'bin.eval'       (u8.const 0x2a))
 
 # Boolean expressions
 (literal 'and'            (u8.const 0x30))
@@ -158,7 +157,6 @@
     (case 'params'              (eval 'int.value' (varuint32)))
     (case 'peek'                (=> 'postorder.inst'))
     (case 'read'                (=> 'postorder.inst'))
-    (case 'reject'              (=> 'postorder.inst'))
     (case 'rename'              (=> 'postorder.inst'))
     (case 'section'             (=> 'postorder.inst'))
     (case 'sequence'            (eval 'nary.node'))

--- a/src/interp/ByteReadStream.cpp
+++ b/src/interp/ByteReadStream.cpp
@@ -33,6 +33,8 @@ ByteReadStream::~ByteReadStream() {
 
 IntType ByteReadStream::readValue(ReadCursor& Pos, const filt::Node* Format) {
   switch (Format->getType()) {
+    case OpBit:
+      return readBit(Pos);
     case OpUint32:
       return readUint32(Pos);
     case OpUint64:

--- a/src/interp/ByteReader.cpp
+++ b/src/interp/ByteReader.cpp
@@ -164,6 +164,10 @@ void ByteReader::readFillMoreInput() {
   FillCursor.advance(PageSize);
 }
 
+uint8_t ByteReader::readBit() {
+  return ReadPos.readBit();
+}
+
 uint8_t ByteReader::readUint8() {
   return Input->readUint8(ReadPos);
 }

--- a/src/interp/ByteReader.cpp
+++ b/src/interp/ByteReader.cpp
@@ -165,7 +165,7 @@ void ByteReader::readFillMoreInput() {
 }
 
 uint8_t ByteReader::readBit() {
-  return ReadPos.readBit();
+  return Input->readBit(ReadPos);
 }
 
 uint8_t ByteReader::readUint8() {

--- a/src/interp/ByteReader.h
+++ b/src/interp/ByteReader.h
@@ -53,6 +53,7 @@ class ByteReader : public Reader {
   virtual bool readAction(const filt::SymbolNode* Action) OVERRIDE;
   void readFillStart() OVERRIDE;
   void readFillMoreInput() OVERRIDE;
+  uint8_t readBit() OVERRIDE;
   uint8_t readUint8() OVERRIDE;
   uint32_t readUint32() OVERRIDE;
   uint64_t readUint64() OVERRIDE;

--- a/src/interp/ByteWriter.cpp
+++ b/src/interp/ByteWriter.cpp
@@ -66,6 +66,11 @@ decode::StreamType ByteWriter::getStreamType() const {
   return Stream->getType();
 }
 
+bool ByteWriter::writeBit(uint8_t Value) {
+  WritePos.writeBit(uint8_t(Value & 0x1));
+  return WritePos.isQueueGood();
+}
+
 bool ByteWriter::writeUint8(uint8_t Value) {
   Stream->writeUint8(Value, WritePos);
   return WritePos.isQueueGood();

--- a/src/interp/ByteWriter.cpp
+++ b/src/interp/ByteWriter.cpp
@@ -67,7 +67,7 @@ decode::StreamType ByteWriter::getStreamType() const {
 }
 
 bool ByteWriter::writeBit(uint8_t Value) {
-  WritePos.writeBit(uint8_t(Value & 0x1));
+  Stream->writeBit(Value, WritePos);
   return WritePos.isQueueGood();
 }
 

--- a/src/interp/ByteWriter.h
+++ b/src/interp/ByteWriter.h
@@ -43,6 +43,7 @@ class ByteWriter : public Writer {
   void setPos(const decode::BitWriteCursor& NewPos);
   void reset() OVERRIDE;
   decode::StreamType getStreamType() const OVERRIDE;
+  bool writeBit(uint8_t Value) OVERRIDE;
   bool writeUint8(uint8_t Value) OVERRIDE;
   bool writeUint32(uint32_t Value) OVERRIDE;
   bool writeUint64(uint64_t Value) OVERRIDE;

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -632,7 +632,6 @@ void Interpreter::algorithmResume() {
         switch (Frame.Nd->getType()) {
           case NO_SUCH_NODETYPE:
           case OpBinaryAccept:
-          case OpBinaryReject:
           case OpBinarySelect:
           case OpParams:
           case OpLastSymbolIs:

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -851,6 +851,7 @@ void Interpreter::algorithmResume() {
                 return failBadState();
             }
             break;
+          case OpBit:
           case OpUint32:
           case OpUint64:
           case OpUint8:

--- a/src/interp/ReadStream.cpp
+++ b/src/interp/ReadStream.cpp
@@ -32,6 +32,10 @@ namespace interp {
 ReadStream::~ReadStream() {
 }
 
+uint8_t ReadStream::readBit(ReadCursor& Pos) {
+  return Pos.readBit();
+}
+
 uint8_t ReadStream::readUint8(ReadCursor& Pos) {
   return fmt::readUint8(Pos);
 }

--- a/src/interp/ReadStream.h
+++ b/src/interp/ReadStream.h
@@ -43,6 +43,7 @@ class ReadStream : public std::enable_shared_from_this<ReadStream> {
   virtual ~ReadStream();
 
   // Hard coded reads.
+  uint8_t readBit(decode::ReadCursor& Pos);
   uint8_t readUint8(decode::ReadCursor& Pos);
   uint32_t readUint32(decode::ReadCursor& Pos);
   uint64_t readUint64(decode::ReadCursor& Pos);

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -95,6 +95,9 @@ bool Reader::readBinary(const Node*, IntType& Value) {
 
 bool Reader::readValue(const filt::Node* Format, IntType& Value) {
   switch (Format->getType()) {
+    case OpBit:
+      Value = readBit();
+      return true;
     case OpUint8:
       Value = readUint8();
       return true;

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -60,28 +60,32 @@ std::shared_ptr<TraceClass> Reader::getTracePtr() {
 void Reader::reset() {
 }
 
+uint8_t Reader::readBit() {
+  return readVaruint64() & 0x1;
+}
+
 uint8_t Reader::readUint8() {
-  return readVaruint64();
+  return uint8_t(readVaruint64());
 }
 
 uint32_t Reader::readUint32() {
-  return readVaruint64();
+  return uint32_t(readVaruint64());
 }
 
 uint64_t Reader::readUint64() {
-  return readVaruint64();
+  return uint64_t(readVaruint64());
 }
 
 int32_t Reader::readVarint32() {
-  return readVaruint64();
+  return int32_t(readVaruint64());
 }
 
 int64_t Reader::readVarint64() {
-  return readVaruint64();
+  return int64_t(readVaruint64());
 }
 
 uint32_t Reader::readVaruint32() {
-  return readVaruint64();
+  return uint32_t(readVaruint64());
 }
 
 bool Reader::readBinary(const Node*, IntType& Value) {

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -66,6 +66,7 @@ class Reader : public std::enable_shared_from_this<Reader> {
   virtual void readFillStart() = 0;
   virtual void readFillMoreInput() = 0;
   // Hard coded reads.
+  virtual uint8_t readBit();
   virtual uint8_t readUint8();
   virtual uint32_t readUint32();
   virtual uint64_t readUint64();

--- a/src/interp/WriteStream.cpp
+++ b/src/interp/WriteStream.cpp
@@ -36,6 +36,10 @@ WriteStream::WriteStream(decode::StreamType Type) : Type(Type) {
 WriteStream::~WriteStream() {
 }
 
+void WriteStream::writeBit(uint8_t Value, WriteCursor& Pos) {
+  Pos.writeBit(Value);
+}
+
 void WriteStream::writeUint8(uint8_t Value, WriteCursor& Pos) {
   fmt::writeUint8(Value, Pos);
 }

--- a/src/interp/WriteStream.h
+++ b/src/interp/WriteStream.h
@@ -41,6 +41,7 @@ class WriteStream : public std::enable_shared_from_this<WriteStream> {
 
  public:
   virtual ~WriteStream();
+  void writeBit(uint8_t Value, decode::WriteCursor& Pos);
   void writeUint8(uint8_t Value, decode::WriteCursor& Pos);
   void writeUint32(uint32_t Value, decode::WriteCursor& Pos);
   void writeInt32(int32_t Value, decode::WriteCursor& Pos) {

--- a/src/interp/Writer.cpp
+++ b/src/interp/Writer.cpp
@@ -123,6 +123,9 @@ bool Writer::writeValue(decode::IntType Value, const filt::Node* Format) {
   // Note: We pass through virtual functions to force any applicable cast
   // conversions.
   switch (Format->getType()) {
+    case OpBit:
+      writeBit(Value);
+      return true;
     case OpUint8:
       writeUint8(Value);
       return true;

--- a/src/interp/Writer.cpp
+++ b/src/interp/Writer.cpp
@@ -31,6 +31,10 @@ namespace interp {
 Writer::~Writer() {
 }
 
+bool Writer::writeBit(uint8_t Value) {
+  return writeVaruint64(Value & 0x1);
+}
+
 bool Writer::writeUint8(uint8_t Value) {
   return writeVaruint64(Value);
 }

--- a/src/interp/Writer.h
+++ b/src/interp/Writer.h
@@ -44,6 +44,7 @@ class Writer {
   virtual decode::StreamType getStreamType() const = 0;
   // Override the following as needed. These methods return false if the writes
   // failed. Default actions are to do nothing and return true.
+  virtual bool writeBit(uint8_t Value);
   virtual bool writeUint8(uint8_t Value);
   virtual bool writeUint32(uint32_t Value);
   virtual bool writeUint64(uint64_t Value);

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -64,10 +64,6 @@ class Driver {
                                        unsigned NumBits) {
     return Table->createBinaryAccept(Value, NumBits);
   }
-  BinaryRejectNode* createBinaryReject(decode::IntType Value,
-                                       unsigned NumBits) {
-    return Table->createBinaryReject(Value, NumBits);
-  }
 
 #define X(tag, format, defval, mergable, NODE_DECLS)               \
   tag##Node* get##tag##Definition(                                 \

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -239,7 +239,6 @@ letter	[a-zA-Z]
 "params"          return Parser::make_PARAMS(Driver.getLoc());
 "peek"            return Parser::make_PEEK(Driver.getLoc());
 "read"            return Parser::make_READ(Driver.getLoc());
-"reject"          return Parser::make_REJECT(Driver.getLoc());
 "rename"          return Parser::make_RENAME(Driver.getLoc());
 "seq"             return Parser::make_SEQ(Driver.getLoc());
 "set"             return Parser::make_SET(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -111,7 +111,6 @@ struct IntValue {
 %token PARAMS        "params"
 %token PEEK          "peek"
 %token READ          "read"
-%token REJECT        "reject"
 %token RENAME        "rename"
 %token SEQ           "seq"
 %token SET           "set"
@@ -452,16 +451,6 @@ format_binary
                 || $5.Value >= std::numeric_limits<unsigned>::max())
               Driver.error("Malformed accept arguments");
             $$ = Driver.createBinaryAccept($3.Value, unsigned($5.Value));
-          }
-        | "(" "reject" ")" {
-            $$ = Driver.create<BinaryRejectNode>();
-          }
-        | "(" "reject" INTEGER ":" INTEGER ")" {
-            if ($3.Format != decode::ValueFormat::Hexidecimal
-                || $5.Format != decode::ValueFormat::Decimal
-                || $5.Value >= std::numeric_limits<unsigned>::max())
-              Driver.error("Malformed reject arguments");
-            $$ = Driver.createBinaryReject($3.Value, unsigned($5.Value));
           }
         | "(" "binary" format_binary format_binary ")" {
             $$ = Driver.create<BinarySelectNode>($3, $4);

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -953,27 +953,28 @@ bool ParamNode::validateNode(NodeVectorType& Parents) {
   return false;
 }
 
-BinaryLeafNode::BinaryLeafNode(SymbolTable& Symtab, NodeType Type)
-    : IntegerNode(Symtab, Type, 0, decode::ValueFormat::Hexidecimal, true),
-      NumBits(0) {
+BinaryAcceptNode::BinaryAcceptNode(SymbolTable& Symtab)
+    : IntegerNode(Symtab,
+                  OpBinaryAccept,
+                  0,
+                  decode::ValueFormat::Hexidecimal,
+                  true) {
 }
 
-BinaryLeafNode::BinaryLeafNode(SymbolTable& Symtab,
-                               NodeType Type,
-                               decode::IntType Value,
-                               unsigned NumBits)
-    : IntegerNode(Symtab, Type, Value, decode::ValueFormat::Hexidecimal, false),
-      NumBits(NumBits) {
+BinaryAcceptNode::BinaryAcceptNode(SymbolTable& Symtab,
+                                   decode::IntType Value,
+                                   unsigned NumBits)
+    : IntegerNode(Symtab,
+                  OpBinaryAccept,
+                  Value,
+                  decode::ValueFormat::Hexidecimal,
+                  NumBits) {
 }
 
-BinaryLeafNode::~BinaryLeafNode() {
+BinaryAcceptNode::~BinaryAcceptNode() {
 }
 
-bool BinaryLeafNode::implementsClass(NodeType Type) {
-  return Type == OpBinaryAccept;
-}
-
-bool BinaryLeafNode::validateNode(NodeVectorType& Parents) {
+bool BinaryAcceptNode::validateNode(NodeVectorType& Parents) {
   // Defines path (value) from leaf to (binary) root node, guaranteeing each
   // accept node has a unique value that can be case selected.
   TRACE_METHOD("validateNode");
@@ -1034,19 +1035,6 @@ bool BinaryLeafNode::validateNode(NodeVectorType& Parents) {
   fprintf(getTrace().getFile(), "Error: %s can't appear at top level\n",
           getName());
   return false;
-}
-
-BinaryAcceptNode::BinaryAcceptNode(SymbolTable& Symtab)
-    : BinaryLeafNode(Symtab, OpBinaryAccept) {
-}
-
-BinaryAcceptNode::BinaryAcceptNode(SymbolTable& Symtab,
-                                   decode::IntType Value,
-                                   unsigned NumBits)
-    : BinaryLeafNode(Symtab, OpBinaryAccept, Value, NumBits) {
-}
-
-BinaryAcceptNode::~BinaryAcceptNode() {
 }
 
 BinaryNode::BinaryNode(SymbolTable& Symtab,
@@ -1554,9 +1542,7 @@ const Node* BinaryEvalNode::getEncoding(IntType Value) const {
   return NotFound;
 }
 
-bool BinaryEvalNode::addEncoding(BinaryLeafNode* Encoding) {
-  if (!isa<BinaryAcceptNode>(Encoding))
-    return true;
+bool BinaryEvalNode::addEncoding(BinaryAcceptNode* Encoding) {
   IntType Value = Encoding->getValue();
   if (LookupMap.count(Value))
     return false;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -67,20 +67,6 @@ BinaryEvalNode* SymbolTable::create<BinaryEvalNode>(Node* Kid) {
   return Nd;
 }
 
-template <>
-BinaryRejectNode* SymbolTable::create<BinaryRejectNode>() {
-  BinaryRejectNode* Nd = new BinaryRejectNode(*this);
-  Allocated->push_back(Nd);
-  return Nd;
-}
-
-BinaryRejectNode* SymbolTable::createBinaryReject(IntType Value,
-                                                  unsigned NumBits) {
-  BinaryRejectNode* Nd = new BinaryRejectNode(*this, Value, NumBits);
-  Allocated->push_back(Nd);
-  return Nd;
-}
-
 #define X(tag, NODE_DECLS)                      \
   template <>                                   \
   tag##Node* SymbolTable::create<tag##Node>() { \
@@ -917,7 +903,6 @@ bool IntegerNode::implementsClass(NodeType Type) {
     default:
       return false;
     case OpBinaryAccept:
-    case OpBinaryReject:
 #define X(tag, format, defval, mergable, NODE_DECLS) case Op##tag:
       AST_INTEGERNODE_TABLE
 #undef X
@@ -985,7 +970,7 @@ BinaryLeafNode::~BinaryLeafNode() {
 }
 
 bool BinaryLeafNode::implementsClass(NodeType Type) {
-  return Type == OpBinaryAccept || Type == OpBinaryReject;
+  return Type == OpBinaryAccept;
 }
 
 bool BinaryLeafNode::validateNode(NodeVectorType& Parents) {
@@ -1062,19 +1047,6 @@ BinaryAcceptNode::BinaryAcceptNode(SymbolTable& Symtab,
 }
 
 BinaryAcceptNode::~BinaryAcceptNode() {
-}
-
-BinaryRejectNode::BinaryRejectNode(SymbolTable& Symtab)
-    : BinaryLeafNode(Symtab, OpBinaryReject) {
-}
-
-BinaryRejectNode::BinaryRejectNode(SymbolTable& Symtab,
-                                   decode::IntType Value,
-                                   unsigned NumBits)
-    : BinaryLeafNode(Symtab, OpBinaryReject, Value, NumBits) {
-}
-
-BinaryRejectNode::~BinaryRejectNode() {
 }
 
 BinaryNode::BinaryNode(SymbolTable& Symtab,
@@ -1562,7 +1534,7 @@ utils::TraceClass& OpcodeNode::WriteRange::getTrace() const {
 
 BinaryEvalNode::BinaryEvalNode(SymbolTable& Symtab, Node* Encoding)
     : UnaryNode(Symtab, OpBinaryEval, Encoding),
-      NotFound(Symtab.create<BinaryRejectNode>()) {
+      NotFound(Symtab.create<ErrorNode>()) {
 }
 
 BinaryEvalNode::~BinaryEvalNode() {

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -64,6 +64,7 @@
   X(BinaryAccept,      0x28, "accept",           nullptr,           0, 0)      \
   X(BinarySelect,      0x29, "binary",           nullptr,           0, 0)      \
   X(BinaryEval,        0x2a, "opcode",           "BinaryEval",      1, 0)      \
+  X(Bit,               0x2b, "bit",              nullptr,           0, 0 )     \
                                                                                \
   /* Boolean Expressions */                                                    \
   X(And,               0x30, "and",              nullptr,           2, 0)      \
@@ -105,6 +106,7 @@
 
 //#define X(tag, NODE_DECLS)
 #define AST_NULLARYNODE_TABLE                                                  \
+  X(Bit,)                                                                      \
   X(Error,)                                                                    \
   X(LastRead,)                                                                 \
   X(Uint32,)                                                                   \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -62,9 +62,8 @@
   X(Varuint64,         0x26, "varuint64",        nullptr,           0, 0)      \
   X(Opcode,            0x27, "opcode",           nullptr,           0, 0)      \
   X(BinaryAccept,      0x28, "accept",           nullptr,           0, 0)      \
-  X(BinaryReject,      0x29, "reject",           nullptr,           0, 0)      \
-  X(BinarySelect,      0x2a, "binary",           nullptr,           0, 0)      \
-  X(BinaryEval,        0x2b, "opcode",           "BinaryEval",      1, 0)      \
+  X(BinarySelect,      0x29, "binary",           nullptr,           0, 0)      \
+  X(BinaryEval,        0x2a, "opcode",           "BinaryEval",      1, 0)      \
                                                                                \
   /* Boolean Expressions */                                                    \
   X(And,               0x30, "and",              nullptr,           2, 0)      \

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -422,21 +422,6 @@ class BinaryAcceptNode FINAL : public BinaryLeafNode {
   static bool implementsClass(NodeType Type) { return Type == OpBinaryAccept; }
 };
 
-class BinaryRejectNode FINAL : public BinaryLeafNode {
-  BinaryRejectNode() = delete;
-  BinaryRejectNode(const BinaryRejectNode&) = delete;
-  BinaryRejectNode& operator=(const BinaryRejectNode&) = delete;
-
- public:
-  BinaryRejectNode(SymbolTable& Symtab);
-  BinaryRejectNode(SymbolTable& Symtab,
-                   decode::IntType Value,
-                   unsigned NumBits);
-  ~BinaryRejectNode() OVERRIDE;
-
-  static bool implementsClass(NodeType Type) { return Type == OpBinaryReject; }
-};
-
 class SymbolNode FINAL : public NullaryNode {
   SymbolNode() = delete;
   SymbolNode(const SymbolNode&) = delete;
@@ -710,7 +695,7 @@ class BinaryEvalNode : public UnaryNode {
 
  private:
   std::unordered_map<decode::IntType, const Node*> LookupMap;
-  BinaryRejectNode* NotFound;
+  Node* NotFound;
 };
 
 }  // end of namespace filt

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -40,7 +40,6 @@ class TraceClass;
 namespace filt {
 
 class BinaryAcceptNode;
-class BinaryRejectNode;
 class FileHeaderNode;
 class IntegerNode;
 class Node;
@@ -175,7 +174,6 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   template <typename T>
   T* create(Node* Nd1, Node* Nd2, Node* Nd3);
   BinaryAcceptNode* createBinaryAccept(decode::IntType Value, unsigned NumBits);
-  BinaryRejectNode* createBinaryReject(decode::IntType Value, unsigned NumBits);
 
   // Strips all callback actions from the algorithm, except for the names
   // specified. Returns the updated tree.
@@ -386,28 +384,7 @@ AST_INTEGERNODE_TABLE
 // bits used to reach this accept, and Value encodes the path (from leaf to
 // root) for the accept node. Note: The Value is unique for each accept, and
 // therefore is used as the (case) selector value.
-class BinaryLeafNode : public IntegerNode {
-  BinaryLeafNode() = delete;
-  BinaryLeafNode(const BinaryLeafNode&) = delete;
-  BinaryLeafNode& operator=(const BinaryLeafNode&) = delete;
-
- public:
-  BinaryLeafNode(SymbolTable& Symtab, NodeType Type);
-  BinaryLeafNode(SymbolTable& Symtab,
-                 NodeType Type,
-                 decode::IntType Value,
-                 unsigned NumBits);
-  ~BinaryLeafNode() OVERRIDE;
-  bool validateNode(NodeVectorType& Parents) OVERRIDE;
-  unsigned getNumBits() const { return NumBits; }
-
-  static bool implementsClass(NodeType Type);
-
- protected:
-  unsigned NumBits;
-};
-
-class BinaryAcceptNode FINAL : public BinaryLeafNode {
+class BinaryAcceptNode FINAL : public IntegerNode {
   BinaryAcceptNode() = delete;
   BinaryAcceptNode(const BinaryAcceptNode&) = delete;
   BinaryAcceptNode& operator=(const BinaryAcceptNode&) = delete;
@@ -418,8 +395,13 @@ class BinaryAcceptNode FINAL : public BinaryLeafNode {
                    decode::IntType Value,
                    unsigned NumBits);
   ~BinaryAcceptNode() OVERRIDE;
+  bool validateNode(NodeVectorType& Parents) OVERRIDE;
+  unsigned getNumBits() const { return NumBits; }
 
   static bool implementsClass(NodeType Type) { return Type == OpBinaryAccept; }
+
+ protected:
+  unsigned NumBits;
 };
 
 class SymbolNode FINAL : public NullaryNode {
@@ -689,7 +671,7 @@ class BinaryEvalNode : public UnaryNode {
   bool validateNode(NodeVectorType& Parents) OVERRIDE;
 
   const Node* getEncoding(decode::IntType Value) const;
-  bool addEncoding(BinaryLeafNode* Encoding);
+  bool addEncoding(BinaryAcceptNode* Encoding);
 
   static bool implementsClass(NodeType Type) { return OpBinaryEval == Type; }
 

--- a/src/sexp/FlattenAst.cpp
+++ b/src/sexp/FlattenAst.cpp
@@ -125,7 +125,6 @@ void FlattenAst::flattenNode(const Node* Nd) {
     // TODO(karlschimpf): Compress BinaryAccept/Select into bitsequence?
     case OpBinaryAccept:
     case OpBinaryEval:
-    case OpBinaryReject:
     case OpBinarySelect:
     case OpBitwiseAnd:
     case OpBitwiseNegate:

--- a/src/sexp/FlattenAst.cpp
+++ b/src/sexp/FlattenAst.cpp
@@ -150,6 +150,7 @@ void FlattenAst::flattenNode(const Node* Nd) {
     case OpLiteralUse:
     case OpUint32:
     case OpUint64:
+    case OpBit:
     case OpUint8:
     case OpVarint32:
     case OpVarint64:

--- a/src/sexp/InflateAst.cpp
+++ b/src/sexp/InflateAst.cpp
@@ -201,8 +201,6 @@ bool InflateAst::applyOp(IntType Op) {
       return buildNullary<BinaryAcceptNode>();
     case OpBinaryEval:
       return buildUnary<BinaryEvalNode>();
-    case OpBinaryReject:
-      return buildNullary<BinaryRejectNode>();
     case OpBinarySelect:
       return buildBinary<BinarySelectNode>();
     case OpBitwiseAnd:

--- a/src/sexp/InflateAst.cpp
+++ b/src/sexp/InflateAst.cpp
@@ -161,10 +161,6 @@ bool InflateAst::writeVaruint64(uint64_t Value) {
   return write(Value);
 }
 
-bool InflateAst::writeValue(decode::IntType Value, const filt::Node*) {
-  return write(Value);
-}
-
 bool InflateAst::writeTypedValue(decode::IntType Value, interp::IntTypeFormat) {
   return write(Value);
 }
@@ -203,6 +199,8 @@ bool InflateAst::applyOp(IntType Op) {
       return buildUnary<BinaryEvalNode>();
     case OpBinarySelect:
       return buildBinary<BinarySelectNode>();
+    case OpBit:
+      return buildNullary<BitNode>();
     case OpBitwiseAnd:
       return buildBinary<BitwiseAndNode>();
     case OpBitwiseOr:

--- a/src/sexp/InflateAst.h
+++ b/src/sexp/InflateAst.h
@@ -56,7 +56,6 @@ class InflateAst : public interp::Writer {
   bool writeVarint64(int64_t Value) OVERRIDE;
   bool writeVaruint32(uint32_t Value) OVERRIDE;
   bool writeVaruint64(uint64_t Value) OVERRIDE;
-  bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;
   bool writeTypedValue(decode::IntType Value,
                        interp::IntTypeFormat Format) OVERRIDE;
   bool writeHeaderValue(decode::IntType Value,

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -185,7 +185,7 @@ void TextWriter::writeNode(const Node* Nd,
     if (!Int->isDefaultValue()) {
       fputc(' ', File);
       writeInt(File, Int->getValue(), Int->getFormat());
-      if (const auto* Accept = dyn_cast<BinaryLeafNode>(Int)) {
+      if (const auto* Accept = dyn_cast<BinaryAcceptNode>(Int)) {
         fputc(':', File);
         fprintf(File, "%u", Accept->getNumBits());
       }

--- a/src/stream/BitReadCursor.h
+++ b/src/stream/BitReadCursor.h
@@ -47,7 +47,7 @@ class BitReadCursor : public ReadCursor {
 
   bool atEob() OVERRIDE;
   ByteType readByte() OVERRIDE;
-  ByteType readBit();
+  ByteType readBit() OVERRIDE;
   void alignToByte();
 
   void describeDerivedExtensions(FILE* File, bool IncludeDetail) OVERRIDE;

--- a/src/stream/BitWriteCursor.h
+++ b/src/stream/BitWriteCursor.h
@@ -39,7 +39,7 @@ class BitWriteCursor : public WriteCursor {
   void assign(const BitWriteCursor& C);
   void swap(BitWriteCursor& C);
   void writeByte(ByteType Byte) OVERRIDE;
-  void writeBit(ByteType Bit);
+  void writeBit(ByteType Bit) OVERRIDE;
   void alignToByte();
 
   BitWriteCursor& operator=(const BitWriteCursor& C) {

--- a/src/stream/ReadCursor.cpp
+++ b/src/stream/ReadCursor.cpp
@@ -65,12 +65,17 @@ void ReadCursor::popEobAddress() {
   updateGuaranteedBeforeEob();
 }
 
-uint8_t ReadCursor::readByteAfterReadFill() {
+ByteType ReadCursor::readByteAfterReadFill() {
   bool atEof = isIndexAtEndOfPage() && !readFillBuffer();
   updateGuaranteedBeforeEob();
   if (atEof)
     return 0;
   return readOneByte();
+}
+
+ByteType ReadCursor::readBit() {
+  fail();
+  return 0;
 }
 
 size_t ReadCursor::advance(size_t Distance) {
@@ -87,14 +92,14 @@ size_t ReadCursor::advance(size_t Distance) {
   return DistanceMoved;
 }
 
-uint8_t ReadCursor::readByte() {
+ByteType ReadCursor::readByte() {
   return (CurAddress < GuaranteedBeforeEob) ? readOneByte()
                                             : readByteAfterReadFill();
 }
 
-uint8_t ReadCursor::readOneByte() {
+ByteType ReadCursor::readOneByte() {
   assert(CurPage);
-  uint8_t Byte = *getBufferPtr();
+  ByteType Byte = *getBufferPtr();
   ++CurAddress;
   return Byte;
 }

--- a/src/stream/ReadCursor.h
+++ b/src/stream/ReadCursor.h
@@ -49,7 +49,8 @@ class ReadCursor : public Cursor {
   void popEobAddress();
 
   // Reads next byte. Returns zero if at end of file.
-  virtual uint8_t readByte();
+  virtual ByteType readByte();
+  virtual ByteType readBit();
 
   // Try to advance Distance bytes. Returns actual number of bytes advanced.  If
   // zero is returned (and Distance > 0), no more bytes are available to advance

--- a/src/stream/WriteCursorBase.cpp
+++ b/src/stream/WriteCursorBase.cpp
@@ -48,6 +48,10 @@ void WriteCursorBase::writeByte(ByteType Byte) {
     writeFillWriteByte(Byte);
 }
 
+void WriteCursorBase::writeBit(ByteType Bit) {
+  fail();
+}
+
 void WriteCursorBase::writeOneByte(ByteType Byte) {
   *getBufferPtr() = Byte;
   ++CurAddress;

--- a/src/stream/WriteCursorBase.h
+++ b/src/stream/WriteCursorBase.h
@@ -37,6 +37,7 @@ class WriteCursorBase : public Cursor {
   ~WriteCursorBase() OVERRIDE;
   // Writes next byte. Fails if at end of file.
   virtual void writeByte(ByteType Byte);
+  virtual void writeBit(ByteType Bit);
 
   WriteCursorBase& operator=(const WriteCursorBase& C) {
     assign(C);


### PR DESCRIPTION
This is in preparation to compress (Huffman encoded) opcode expressions in the binary form of algorithms.

That is a bit can be used to encode the expression (via a postorder walk) by encoding if the next node is a leaf/internal node.

This can be done because the validator automatically recomputes the Huffman encodings of the opcode when these nodes are processed.