### PR TITLE
Abstract alignment and block enter/exit.

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -212,7 +212,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceIntCountsCollectionFlag(
         MyCompressionFlags.TraceIntCountsCollection);
     Args.add(TraceIntCountsCollectionFlag.setLongName(
-                                              "verbose=int-counts-collection")
+                                             "verbose=int-counts-collection")
                  .setDescription("Show how int counts were selected"));
 
     ArgsParser::Optional<bool> TraceSequenceCountsFlag(
@@ -226,7 +226,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceSequenceCountsCollection);
     Args.add(
         TraceSequenceCountsCollectionFlag.setLongName(
-                                              "verbose=seq-counts-collection")
+                                             "verbose=seq-counts-collection")
             .setDescription(
                 "Show how frequency of integer sequences were "
                 "selected"));
@@ -283,7 +283,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbrevSelectionProgress);
     Args.add(
         TraceAbbrevSelectionProgressFlag.setLongName(
-                                             "verbose=select-abbrevs-progress")
+                                            "verbose=select-abbrevs-progress")
             .setOptionName("INTEGER")
             .setDescription(
                 "For every INTEGER values generated in the output integer "
@@ -294,7 +294,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceAbbrevSelectionSelectFlag(
         MyCompressionFlags.TraceAbbrevSelectionSelect);
     Args.add(TraceAbbrevSelectionSelectFlag.setLongName(
-                                                "verbose=select-abbrevs-select")
+                                               "verbose=select-abbrevs-select")
                  .setDescription(
                      "Show selected pattern sequences, as they apply. "
                      "Only appiles when --verbose=select-abbrevs is "
@@ -304,7 +304,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbrevSelectionCreate);
     Args.add(
         TraceAbbrevSelectionCreateFlag.setLongName(
-                                           "verbose=select-abbrevs-create")
+                                          "verbose=select-abbrevs-create")
             .setDescription(
                 "Show each created pattern sequence that is tried (not just "
                 "the selected ones). Only applies when "
@@ -313,7 +313,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceAbbrevSelectionDetailFlag(
         MyCompressionFlags.TraceAbbrevSelectionDetail);
     Args.add(TraceAbbrevSelectionDetailFlag.setLongName(
-                                                "verbose=select-abbrev-details")
+                                               "verbose=select-abbrev-details")
                  .setDescription(
                      "Show additional detail (besides creating and selecting) "
                      "when creating the applied pattern sequence. Only applies "

--- a/src/intcomp/AbbrevAssignWriter.h
+++ b/src/intcomp/AbbrevAssignWriter.h
@@ -53,7 +53,8 @@ class AbbrevAssignWriter : public interp::Writer {
   bool writeFreezeEof() OVERRIDE;
   bool writeHeaderValue(decode::IntType Value,
                         interp::IntTypeFormat Format) OVERRIDE;
-  bool writeAction(const filt::SymbolNode* Action) OVERRIDE;
+  bool writeBlockEnter() OVERRIDE;
+  bool writeBlockExit() OVERRIDE;
 
   void setTrace(std::shared_ptr<utils::TraceClass> Trace) OVERRIDE;
 
@@ -62,7 +63,7 @@ class AbbrevAssignWriter : public interp::Writer {
   CountNode::RootPtr Root;
   CountNode::PtrSet& Assignments;
   utils::HuffmanEncoder::NodePtr& EncodingRoot;
-  interp::IntWriter Writer;
+  interp::IntWriter OutWriter;
   utils::circular_vector<decode::IntType> Buffer;
   std::vector<decode::IntType> DefaultValues;
   // Intermediate structure. Allows us to change encoding of

--- a/src/intcomp/CountWriter.cpp
+++ b/src/intcomp/CountWriter.cpp
@@ -26,6 +26,10 @@ namespace intcomp {
 using namespace decode;
 using namespace filt;
 
+CountWriter::CountWriter(CountNode::RootPtr Root)
+    : Writer(true), Root(Root), CountCutoff(1), UpToSize(0) {
+}
+
 CountWriter::~CountWriter() {
 }
 
@@ -59,19 +63,16 @@ bool CountWriter::writeVaruint64(uint64_t Value) {
   return true;
 }
 
-bool CountWriter::writeAction(const filt::SymbolNode* Action) {
-  switch (Action->getPredefinedSymbol()) {
-    case PredefinedSymbol::Block_enter:
-      Frontier.clear();
-      Root->getBlockEnter()->increment();
-      return true;
-    case PredefinedSymbol::Block_exit:
-      Frontier.clear();
-      Root->getBlockExit()->increment();
-      return true;
-    default:
-      return true;
-  }
+bool CountWriter::writeBlockEnter() {
+  Frontier.clear();
+  Root->getBlockEnter()->increment();
+  return true;
+}
+
+bool CountWriter::writeBlockExit() {
+  Frontier.clear();
+  Root->getBlockExit()->increment();
+  return true;
 }
 
 bool CountWriter::writeHeaderValue(decode::IntType Value,

--- a/src/intcomp/CountWriter.h
+++ b/src/intcomp/CountWriter.h
@@ -43,8 +43,7 @@ class CountWriter : public interp::Writer {
  public:
   typedef std::vector<CountNode::IntPtr> IntFrontier;
   typedef std::set<CountNode::IntPtr> CountNodeIntSet;
-  CountWriter(CountNode::RootPtr Root)
-      : Root(Root), CountCutoff(1), UpToSize(0) {}
+  CountWriter(CountNode::RootPtr Root);
 
   ~CountWriter() OVERRIDE;
 
@@ -62,7 +61,8 @@ class CountWriter : public interp::Writer {
   bool writeVaruint64(uint64_t Value) OVERRIDE;
   bool writeHeaderValue(decode::IntType Value,
                         interp::IntTypeFormat Format) OVERRIDE;
-  bool writeAction(const filt::SymbolNode* Action) OVERRIDE;
+  bool writeBlockEnter() OVERRIDE;
+  bool writeBlockExit() OVERRIDE;
 
  private:
   CountNode::RootPtr Root;

--- a/src/interp/ByteReader.h
+++ b/src/interp/ByteReader.h
@@ -50,7 +50,6 @@ class ByteReader : public Reader {
   size_t sizePeekPosStack() OVERRIDE;
   decode::StreamType getStreamType() OVERRIDE;
   bool processedInputCorrectly() OVERRIDE;
-  virtual bool readAction(const filt::SymbolNode* Action) OVERRIDE;
   void readFillStart() OVERRIDE;
   void readFillMoreInput() OVERRIDE;
   uint8_t readBit() OVERRIDE;
@@ -61,6 +60,9 @@ class ByteReader : public Reader {
   int64_t readVarint64() OVERRIDE;
   uint32_t readVaruint32() OVERRIDE;
   uint64_t readVaruint64() OVERRIDE;
+  bool alignToByte() OVERRIDE;
+  bool readBlockEnter() OVERRIDE;
+  bool readBlockExit() OVERRIDE;
   bool readBinary(const filt::Node* Encoding, decode::IntType& Value) OVERRIDE;
   utils::TraceContextPtr getTraceContext() OVERRIDE;
 

--- a/src/interp/ByteWriter.h
+++ b/src/interp/ByteWriter.h
@@ -51,9 +51,11 @@ class ByteWriter : public Writer {
   bool writeVarint64(int64_t Value) OVERRIDE;
   bool writeVaruint32(uint32_t Value) OVERRIDE;
   bool writeVaruint64(uint64_t Value) OVERRIDE;
+  bool alignToByte() OVERRIDE;
+  bool writeBlockEnter() OVERRIDE;
+  bool writeBlockExit() OVERRIDE;
   bool writeFreezeEof() OVERRIDE;
   bool writeBinary(decode::IntType, const filt::Node* Encoding) OVERRIDE;
-  bool writeAction(const filt::SymbolNode* Action) OVERRIDE;
 
   void describeState(FILE* File) OVERRIDE;
 

--- a/src/interp/IntReader.cpp
+++ b/src/interp/IntReader.cpp
@@ -30,7 +30,8 @@ using namespace utils;
 namespace interp {
 
 IntReader::IntReader(std::shared_ptr<IntStream> Input)
-    : Pos(Input),
+    : Reader(true),
+      Pos(Input),
       Input(Input),
       HeaderIndex(0),
       StillAvailable(0),
@@ -100,17 +101,12 @@ bool IntReader::processedInputCorrectly() {
   return Pos.atEnd();
 }
 
-bool IntReader::readAction(const SymbolNode* Action) {
-  switch (Action->getPredefinedSymbol()) {
-    case PredefinedSymbol::Block_enter:
-    case PredefinedSymbol::Block_enter_readonly:
-      return Pos.openBlock();
-    case PredefinedSymbol::Block_exit:
-    case PredefinedSymbol::Block_exit_readonly:
-      return Pos.closeBlock();
-    default:
-      return true;
-  }
+bool IntReader::readBlockEnter() {
+  return Pos.openBlock();
+}
+
+bool IntReader::readBlockExit() {
+  return Pos.closeBlock();
 }
 
 void IntReader::readFillStart() {

--- a/src/interp/IntReader.h
+++ b/src/interp/IntReader.h
@@ -52,10 +52,11 @@ class IntReader : public Reader {
   size_t sizePeekPosStack() OVERRIDE;
   decode::StreamType getStreamType() OVERRIDE;
   bool processedInputCorrectly() OVERRIDE;
-  bool readAction(const filt::SymbolNode* Action) OVERRIDE;
   void readFillStart() OVERRIDE;
   void readFillMoreInput() OVERRIDE;
   uint64_t readVaruint64() OVERRIDE;
+  bool readBlockEnter() OVERRIDE;
+  bool readBlockExit() OVERRIDE;
   bool readHeaderValue(interp::IntTypeFormat Format,
                        decode::IntType& Value) OVERRIDE;
   utils::TraceContextPtr getTraceContext() OVERRIDE;

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -29,7 +29,7 @@ using namespace utils;
 namespace interp {
 
 IntWriter::IntWriter(std::shared_ptr<IntStream> Output)
-    : Output(Output), Pos(Output) {
+    : Writer(true), Output(Output), Pos(Output) {
 }
 
 void IntWriter::reset() {
@@ -54,6 +54,14 @@ bool IntWriter::writeVaruint64(uint64_t Value) {
   return write(Value);
 }
 
+bool IntWriter::writeBlockEnter() {
+  return Pos.openBlock();
+}
+
+bool IntWriter::writeBlockExit() {
+  return Pos.closeBlock();
+}
+
 bool IntWriter::writeFreezeEof() {
   return Pos.freezeEof();
 }
@@ -61,21 +69,6 @@ bool IntWriter::writeFreezeEof() {
 bool IntWriter::writeHeaderValue(IntType Value, IntTypeFormat Format) {
   Output->appendHeader(Value, Format);
   return true;
-}
-
-bool IntWriter::writeAction(const filt::SymbolNode* Action) {
-  switch (Action->getPredefinedSymbol()) {
-    case PredefinedSymbol::Block_enter:
-    case PredefinedSymbol::Block_enter_writeonly:
-      return Pos.openBlock();
-    case PredefinedSymbol::Block_exit:
-    case PredefinedSymbol::Block_exit_writeonly:
-      return Pos.closeBlock();
-    default:
-      // Ignore all other actions, since they do not involve
-      // changing the integer sequence.
-      return true;
-  }
 }
 
 void IntWriter::describeState(FILE* File) {

--- a/src/interp/IntWriter.h
+++ b/src/interp/IntWriter.h
@@ -38,10 +38,11 @@ class IntWriter : public Writer {
   decode::StreamType getStreamType() const OVERRIDE;
   bool write(decode::IntType Value) { return Pos.write(Value); }
   bool writeVaruint64(uint64_t Value) OVERRIDE;
+  bool writeBlockEnter() OVERRIDE;
+  bool writeBlockExit() OVERRIDE;
   bool writeFreezeEof() OVERRIDE;
   bool writeHeaderValue(decode::IntType Value,
                         interp::IntTypeFormat Format) OVERRIDE;
-  bool writeAction(const filt::SymbolNode* Action) OVERRIDE;
   utils::TraceContextPtr getTraceContext() OVERRIDE;
   void describeState(FILE* File) OVERRIDE;
   size_t getIndex() const { return Pos.getIndex(); }

--- a/src/interp/Reader.cpp
+++ b/src/interp/Reader.cpp
@@ -60,6 +60,18 @@ std::shared_ptr<TraceClass> Reader::getTracePtr() {
 void Reader::reset() {
 }
 
+bool Reader::alignToByte() {
+  return true;
+}
+
+bool Reader::readBlockEnter() {
+  return true;
+}
+
+bool Reader::readBlockExit() {
+  return true;
+}
+
 uint8_t Reader::readBit() {
   return readVaruint64() & 0x1;
 }
@@ -139,6 +151,21 @@ bool Reader::readHeaderValue(IntTypeFormat Format, IntType& Value) {
     default:
       Value = 0;
       return false;
+  }
+}
+
+bool Reader::readAction(const SymbolNode* Action) {
+  switch (Action->getPredefinedSymbol()) {
+    case PredefinedSymbol::Block_enter:
+    case PredefinedSymbol::Block_enter_readonly:
+      return readBlockEnter();
+    case PredefinedSymbol::Block_exit:
+    case PredefinedSymbol::Block_exit_readonly:
+      return readBlockExit();
+    case PredefinedSymbol::Align:
+      return alignToByte();
+    default:
+      return DefaultReadAction;
   }
 }
 

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -40,7 +40,6 @@ class Reader : public std::enable_shared_from_this<Reader> {
   Reader& operator=(const Reader&) = delete;
 
  public:
-  Reader() {}
   virtual ~Reader() {}
   virtual utils::TraceContextPtr getTraceContext();
   void setTraceProgress(bool NewValue);
@@ -62,7 +61,7 @@ class Reader : public std::enable_shared_from_this<Reader> {
   virtual size_t sizePeekPosStack() = 0;
   virtual decode::StreamType getStreamType() = 0;
   virtual bool processedInputCorrectly() = 0;
-  virtual bool readAction(const filt::SymbolNode* Action) = 0;
+  virtual bool readAction(const filt::SymbolNode* Action);
   virtual void readFillStart() = 0;
   virtual void readFillMoreInput() = 0;
   // Hard coded reads.
@@ -74,6 +73,9 @@ class Reader : public std::enable_shared_from_this<Reader> {
   virtual int64_t readVarint64();
   virtual uint32_t readVaruint32();
   virtual uint64_t readVaruint64() = 0;
+  virtual bool alignToByte();
+  virtual bool readBlockEnter();
+  virtual bool readBlockExit();
   virtual bool readBinary(const filt::Node* Encoding, decode::IntType& Value);
   virtual bool readValue(const filt::Node* Format, decode::IntType& Value);
   virtual bool readHeaderValue(interp::IntTypeFormat Format,
@@ -81,6 +83,9 @@ class Reader : public std::enable_shared_from_this<Reader> {
 
  protected:
   std::shared_ptr<utils::TraceClass> Trace;
+  // Defines value to return if readAction can't handle.
+  const bool DefaultReadAction;
+  Reader(bool DefaultReadAction) : DefaultReadAction(DefaultReadAction) {}
 };
 
 }  // end of namespace interp

--- a/src/interp/TeeWriter.cpp
+++ b/src/interp/TeeWriter.cpp
@@ -25,7 +25,7 @@ using namespace utils;
 
 namespace interp {
 
-TeeWriter::TeeWriter() : Writer() {
+TeeWriter::TeeWriter() : Writer(true) {
 }
 
 TeeWriter::~TeeWriter() {
@@ -117,6 +117,30 @@ bool TeeWriter::writeVaruint64(uint64_t Value) {
     if (!Nd.getWriter()->writeVaruint64(Value))
       return false;
   return true;
+}
+
+bool TeeWriter::alignToByte() {
+  bool Result = true;
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->alignToByte())
+      Result = false;
+  return Result;
+}
+
+bool TeeWriter::writeBlockEnter() {
+  bool Result = true;
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeBlockEnter())
+      Result = false;
+  return Result;
+}
+
+bool TeeWriter::writeBlockExit() {
+  bool Result = true;
+  for (Node& Nd : Writers)
+    if (!Nd.getWriter()->writeBlockExit())
+      Result = false;
+  return Result;
 }
 
 bool TeeWriter::writeFreezeEof() {

--- a/src/interp/TeeWriter.h
+++ b/src/interp/TeeWriter.h
@@ -72,6 +72,9 @@ class TeeWriter : public Writer {
   bool writeVarint64(int64_t Value) OVERRIDE;
   bool writeVaruint32(uint32_t Value) OVERRIDE;
   bool writeVaruint64(uint64_t Value) OVERRIDE;
+  bool alignToByte() OVERRIDE;
+  bool writeBlockEnter() OVERRIDE;
+  bool writeBlockExit() OVERRIDE;
   bool writeFreezeEof() OVERRIDE;
   bool writeBinary(decode::IntType, const filt::Node* Encoding) OVERRIDE;
   bool writeValue(decode::IntType Value, const filt::Node* Format) OVERRIDE;

--- a/src/interp/Writer.cpp
+++ b/src/interp/Writer.cpp
@@ -63,6 +63,10 @@ void Writer::setMinimizeBlockSize(bool NewValue) {
   MinimizeBlockSize = NewValue;
 }
 
+bool Writer::alignToByte() {
+  return true;
+}
+
 TraceContextPtr Writer::getTraceContext() {
   TraceContextPtr Ptr;
   return Ptr;
@@ -149,6 +153,29 @@ bool Writer::writeValue(decode::IntType Value, const filt::Node* Format) {
       return true;
     default:
       return false;
+  }
+}
+
+bool Writer::writeBlockEnter() {
+  return true;
+}
+
+bool Writer::writeBlockExit() {
+  return true;
+}
+
+bool Writer::writeAction(const SymbolNode* Action) {
+  switch (Action->getPredefinedSymbol()) {
+    case PredefinedSymbol::Block_enter:
+    case PredefinedSymbol::Block_enter_writeonly:
+      return writeBlockEnter();
+    case PredefinedSymbol::Block_exit:
+    case PredefinedSymbol::Block_exit_writeonly:
+      return writeBlockExit();
+    case PredefinedSymbol::Align:
+      return alignToByte();
+    default:
+      return DefaultWriteAction;
   }
 }
 

--- a/src/interp/Writer.h
+++ b/src/interp/Writer.h
@@ -37,7 +37,6 @@ class Writer {
   Writer& operator=(const Writer&) = delete;
 
  public:
-  explicit Writer() : MinimizeBlockSize(false) {}
   virtual ~Writer();
 
   virtual void reset();
@@ -52,6 +51,9 @@ class Writer {
   virtual bool writeVarint64(int64_t Value);
   virtual bool writeVaruint32(uint32_t Value);
   virtual bool writeVaruint64(uint64_t Value) = 0;
+  virtual bool alignToByte();
+  virtual bool writeBlockEnter();
+  virtual bool writeBlockExit();
   virtual bool writeFreezeEof();
   virtual bool writeBinary(decode::IntType Value, const filt::Node* Encoding);
   virtual bool writeValue(decode::IntType Value, const filt::Node* Format);
@@ -59,7 +61,7 @@ class Writer {
                                interp::IntTypeFormat Format);
   virtual bool writeHeaderValue(decode::IntType Value,
                                 interp::IntTypeFormat Format);
-  virtual bool writeAction(const filt::SymbolNode* Action) = 0;
+  virtual bool writeAction(const filt::SymbolNode* Action);
 
   virtual void setMinimizeBlockSize(bool NewValue);
   virtual void describeState(FILE* File);
@@ -72,7 +74,11 @@ class Writer {
 
  protected:
   bool MinimizeBlockSize;
+  // Defines value to return if writeAction can't handle.
+  const bool DefaultWriteAction;
   std::shared_ptr<utils::TraceClass> Trace;
+  explicit Writer(bool DefaultWriteAction)
+      : MinimizeBlockSize(false), DefaultWriteAction(DefaultWriteAction) {}
 
   virtual const char* getDefaultTraceName() const;
 };

--- a/src/sexp/InflateAst.cpp
+++ b/src/sexp/InflateAst.cpp
@@ -34,7 +34,8 @@ using namespace utils;
 namespace filt {
 
 InflateAst::InflateAst()
-    : Symtab(std::make_shared<SymbolTable>()),
+    : Writer(false),
+      Symtab(std::make_shared<SymbolTable>()),
       SectionSymtab(utils::make_unique<SectionSymbolTable>(Symtab)),
       ValuesTop(0),
       Values(ValuesTop),
@@ -360,9 +361,6 @@ bool InflateAst::writeAction(const filt::SymbolNode* Action) {
     case PredefinedSymbol::Binary_end:
       Values.push(OpBinaryEval);
       return buildUnary<BinaryEvalNode>();
-    case PredefinedSymbol::Block_enter:
-    case PredefinedSymbol::Block_exit:
-      return true;
     case PredefinedSymbol::Instruction_begin:
       AstMarkers.push(Asts.size());
       return true;
@@ -467,7 +465,7 @@ bool InflateAst::writeAction(const filt::SymbolNode* Action) {
       TRACE(size_t, "nary node size", Values.size());
       return applyOp(Values[Values.size() - 2]);
     default:
-      break;
+      return Writer::writeAction(Action);
   }
   return false;
 }


### PR DESCRIPTION
Moves alignment checks from a bit cursor, to the corresponding Reader/Writer classes, allowing the concept to be applicable independent of the corresponding Reader/Writer (via writeAction()).

Noticed that default actions for block enter/exit (via writeAction()) also needed abstraction. Once these abstractions have been added, a default readAction()/writeAction() methods can also be abstracted out.
