### PR TITLE
Turn on compressing Huffman-encoded opcodes.

### DIFF
--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -127,6 +127,7 @@
     (=> 'binary.bit')
   )
   (=> 'binary.end')
+  (=> 'align')
 )
 
 (define 'node' (params)

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -584,7 +584,7 @@ int main(int Argc, charstring Argv[]) {
   bool StripActions = false;
   bool StripLiterals = false;
   bool ShowSavedCast = false;
-  bool BitCompress = false;
+  bool BitCompress = true;
   std::set<std::string> KeepActions;
   {
     ArgsParser Args("Converts compression algorithm from text to binary");


### PR DESCRIPTION
Updates cast2casm to do bit compression of binary (i.e. Huffman-encoded) opcodes. In this model, the binary AST of the encoding is encoded as:
  0 => create leaf
  1 => create internal node.
