### PR TITLE
Some cleanup in class SymbolTable, and introduce notion of enclosing scope

### DIFF
--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -609,10 +609,9 @@ int main(int Argc, charstring Argv[]) {
                  .setDescription("Succeed on failure/fail on success"));
 
     ArgsParser::Optional<bool> BitCompressFlag(BitCompress);
-    Args.add(
-        BitCompressFlag.setLongName("bit-compress")
-        .setDescription(
-            "Perform bit compresssion on binary opcode expressions"));
+    Args.add(BitCompressFlag.setLongName("bit-compress")
+                 .setDescription(
+                     "Perform bit compresssion on binary opcode expressions"));
 
     ArgsParser::Toggle MinimizeBlockFlag(MinimizeBlockSize);
     Args.add(MinimizeBlockFlag.setDefault(true)

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -609,10 +609,10 @@ int main(int Argc, charstring Argv[]) {
                  .setDescription("Succeed on failure/fail on success"));
 
     ArgsParser::Optional<bool> BitCompressFlag(BitCompress);
-    Args.add(BitCompressFlag.setLongName("bit-compress")
-                 .setDescription(
-                     "Perform bit compresssion on binary opcode "
-                     "expressions"));
+    Args.add(
+        BitCompressFlag.setLongName("bit-compress")
+        .setDescription(
+            "Perform bit compresssion on binary opcode expressions"));
 
     ArgsParser::Toggle MinimizeBlockFlag(MinimizeBlockSize);
     Args.add(MinimizeBlockFlag.setDefault(true)

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -74,10 +74,21 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceHuffmanAssignmentsFlag(
         MyCompressionFlags.TraceHuffmanAssignments);
     Args.add(
-        TraceHuffmanAssignmentsFlag.setLongName("verbose=Huffman-assignments")
+        TraceHuffmanAssignmentsFlag
+        .setDefault(true)
+            .setLongName("verbose=Huffman-assignments")
             .setDescription(
                 "Show defined Huffman encoding assignments for "
                 "to use for pattern abbreviations"));
+
+    ArgsParser::Optional<bool> TraceBitCompressOpcodesFlag(
+        MyCompressionFlags.BitCompressOpcodes);
+    Args.add(
+        TraceBitCompressOpcodesFlag
+        .setDefault(true)
+        .setLongName("bit-compress")
+        .setDescription(
+            "Perform bit compresssion on binary opcode expressions"));
 
     ArgsParser::Optional<size_t> CountCutoffFlag(
         MyCompressionFlags.CountCutoff);
@@ -146,7 +157,9 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Toggle TrimOverriddenPatternsFlag(
         MyCompressionFlags.TrimOverriddenPatterns);
-    Args.add(TrimOverriddenPatternsFlag.setLongName("trim").setDescription(
+    Args.add(TrimOverriddenPatternsFlag
+             .setDefault(true)
+             .setLongName("trim").setDescription(
         "Toggles removing patterns if already implied by previous patterns"));
 
     ArgsParser::Optional<bool> TraceReadingInputFlag(

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -73,22 +73,18 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Optional<bool> TraceHuffmanAssignmentsFlag(
         MyCompressionFlags.TraceHuffmanAssignments);
-    Args.add(
-        TraceHuffmanAssignmentsFlag
-        .setDefault(true)
-            .setLongName("verbose=Huffman-assignments")
-            .setDescription(
-                "Show defined Huffman encoding assignments for "
-                "to use for pattern abbreviations"));
+    Args.add(TraceHuffmanAssignmentsFlag.setDefault(true)
+                 .setLongName("verbose=Huffman-assignments")
+                 .setDescription(
+                     "Show defined Huffman encoding assignments for "
+                     "to use for pattern abbreviations"));
 
     ArgsParser::Optional<bool> TraceBitCompressOpcodesFlag(
         MyCompressionFlags.BitCompressOpcodes);
-    Args.add(
-        TraceBitCompressOpcodesFlag
-        .setDefault(true)
-        .setLongName("bit-compress")
-        .setDescription(
-            "Perform bit compresssion on binary opcode expressions"));
+    Args.add(TraceBitCompressOpcodesFlag.setDefault(true)
+                 .setLongName("bit-compress")
+                 .setDescription(
+                     "Perform bit compresssion on binary opcode expressions"));
 
     ArgsParser::Optional<size_t> CountCutoffFlag(
         MyCompressionFlags.CountCutoff);
@@ -157,10 +153,11 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Toggle TrimOverriddenPatternsFlag(
         MyCompressionFlags.TrimOverriddenPatterns);
-    Args.add(TrimOverriddenPatternsFlag
-             .setDefault(true)
-             .setLongName("trim").setDescription(
-        "Toggles removing patterns if already implied by previous patterns"));
+    Args.add(TrimOverriddenPatternsFlag.setDefault(true)
+                 .setLongName("trim")
+                 .setDescription(
+                     "Toggles removing patterns if already implied by previous "
+                     "patterns"));
 
     ArgsParser::Optional<bool> TraceReadingInputFlag(
         MyCompressionFlags.TraceReadingInput);

--- a/src/intcomp/CompressionFlags.cpp
+++ b/src/intcomp/CompressionFlags.cpp
@@ -46,6 +46,7 @@ CompressionFlags::CompressionFlags()
       MinimizeCodeSize(true),
       UseHuffmanEncoding(false),
       TrimOverriddenPatterns(false),
+      BitCompressOpcodes(false),
       ReassignAbbreviations(true),
       DefaultFormat(IntTypeFormat::Varint64),
       LoopSizeFormat(IntTypeFormat::Varuint64),

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -56,6 +56,7 @@ struct CompressionFlags {
   bool MinimizeCodeSize;
   bool UseHuffmanEncoding;
   bool TrimOverriddenPatterns;
+  bool BitCompressOpcodes;
   bool ReassignAbbreviations;
   interp::IntTypeFormat DefaultFormat;
   interp::IntTypeFormat LoopSizeFormat;

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -94,6 +94,7 @@ const BitWriteCursor IntCompressor::writeCodeOutput(
       .setTraceTree(MyFlags.TraceWritingCodeOutput)
       .setMinimizeBlockSize(MyFlags.MinimizeCodeSize)
       .setFreezeEofAtExit(false)
+      .setBitCompress(MyFlags.BitCompressOpcodes)
       .writeBinary(Symtab, Output);
 }
 

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -456,16 +456,24 @@ void SymbolNode::installCaches(NodeVectorType& AdditionalNodes) {
     AdditionalNodes.push_back(LiteralDefinition);
 }
 
+SymbolTable::SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope)
+    : EnclosingScope(EnclosingScope) {
+}
+
 SymbolTable::SymbolTable()
-    // TODO(karlschimpf) Switch Alloc to an ArenaAllocator once working.
+#if 0
     // TODO(karlschimpf) Figure out why we can't deallocate Allocated!
     : Allocated(new std::vector<Node*>()),
       Root(nullptr),
       TargetHeader(nullptr),
       Error(nullptr),
       NextCreationIndex(0),
-      Predefined(new std::vector<SymbolNode*>()) {
+      Predefined(new std::vector<SymbolNode*>())
+#endif
+{
+#if 0
   Error = create<ErrorNode>();
+#endif
   init();
 }
 
@@ -504,6 +512,14 @@ void SymbolTable::deallocateNodes() {
 }
 
 void SymbolTable::init() {
+#if 1
+  Allocated = new std::vector<Node*>();
+  Root = nullptr;
+  TargetHeader = nullptr;
+  NextCreationIndex = 0;
+  Predefined = new std::vector<SymbolNode*>();
+  Error = create<ErrorNode>();
+#endif
   Predefined->reserve(NumPredefinedSymbols);
   for (size_t i = 0; i < NumPredefinedSymbols; ++i) {
     SymbolNode* Nd = getSymbolDefinition(PredefinedName[i]);

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -50,21 +50,21 @@ namespace filt {
 template <>
 BinaryAcceptNode* SymbolTable::create<BinaryAcceptNode>() {
   BinaryAcceptNode* Nd = new BinaryAcceptNode(*this);
-  Allocated->push_back(Nd);
+  Allocated.push_back(Nd);
   return Nd;
 }
 
 BinaryAcceptNode* SymbolTable::createBinaryAccept(IntType Value,
                                                   unsigned NumBits) {
   BinaryAcceptNode* Nd = new BinaryAcceptNode(*this, Value, NumBits);
-  Allocated->push_back(Nd);
+  Allocated.push_back(Nd);
   return Nd;
 }
 
 template <>
 BinaryEvalNode* SymbolTable::create<BinaryEvalNode>(Node* Kid) {
   BinaryEvalNode* Nd = new BinaryEvalNode(*this, Kid);
-  Allocated->push_back(Nd);
+  Allocated.push_back(Nd);
   return Nd;
 }
 
@@ -72,7 +72,7 @@ BinaryEvalNode* SymbolTable::create<BinaryEvalNode>(Node* Kid) {
   template <>                                   \
   tag##Node* SymbolTable::create<tag##Node>() { \
     tag##Node* tag##Nd = new tag##Node(*this);  \
-    Allocated->push_back(tag##Nd);              \
+    Allocated.push_back(tag##Nd);               \
     return tag##Nd;                             \
   }
 AST_NULLARYNODE_TABLE
@@ -82,7 +82,7 @@ AST_NULLARYNODE_TABLE
   template <>                                            \
   tag##Node* SymbolTable::create<tag##Node>(Node * Nd) { \
     tag##Node* tag##Nd = new tag##Node(*this, Nd);       \
-    Allocated->push_back(tag##Nd);                       \
+    Allocated.push_back(tag##Nd);                        \
     return tag##Nd;                                      \
   }
 AST_UNARYNODE_TABLE
@@ -92,7 +92,7 @@ AST_UNARYNODE_TABLE
   template <>                                                         \
   tag##Node* SymbolTable::create<tag##Node>(Node * Nd1, Node * Nd2) { \
     tag##Node* tag##Nd = new tag##Node(*this, Nd1, Nd2);              \
-    Allocated->push_back(tag##Nd);                                    \
+    Allocated.push_back(tag##Nd);                                     \
     return tag##Nd;                                                   \
   }
 AST_BINARYNODE_TABLE
@@ -103,7 +103,7 @@ AST_BINARYNODE_TABLE
   tag##Node* SymbolTable::create<tag##Node>(Node * Nd1, Node * Nd2, \
                                             Node * Nd3) {           \
     tag##Node* tag##Nd = new tag##Node(*this, Nd1, Nd2, Nd3);       \
-    Allocated->push_back(tag##Nd);                                  \
+    Allocated.push_back(tag##Nd);                                   \
     return tag##Nd;                                                 \
   }
 AST_TERNARYNODE_TABLE
@@ -113,7 +113,7 @@ AST_TERNARYNODE_TABLE
   template <>                                   \
   tag##Node* SymbolTable::create<tag##Node>() { \
     tag##Node* tag##Nd = new tag##Node(*this);  \
-    Allocated->push_back(tag##Nd);              \
+    Allocated.push_back(tag##Nd);               \
     return tag##Nd;                             \
   }
 AST_NARYNODE_TABLE
@@ -123,7 +123,7 @@ AST_NARYNODE_TABLE
   template <>                                   \
   tag##Node* SymbolTable::create<tag##Node>() { \
     tag##Node* tag##Nd = new tag##Node(*this);  \
-    Allocated->push_back(tag##Nd);              \
+    Allocated.push_back(tag##Nd);               \
     return tag##Nd;                             \
   }
 AST_SELECTNODE_TABLE
@@ -132,7 +132,7 @@ AST_SELECTNODE_TABLE
 template <>
 OpcodeNode* SymbolTable::create<OpcodeNode>() {
   OpcodeNode* Nd = new OpcodeNode(*this);
-  Allocated->push_back(Nd);
+  Allocated.push_back(Nd);
   return Nd;
 }
 
@@ -460,20 +460,7 @@ SymbolTable::SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope)
     : EnclosingScope(EnclosingScope) {
 }
 
-SymbolTable::SymbolTable()
-#if 0
-    // TODO(karlschimpf) Figure out why we can't deallocate Allocated!
-    : Allocated(new std::vector<Node*>()),
-      Root(nullptr),
-      TargetHeader(nullptr),
-      Error(nullptr),
-      NextCreationIndex(0),
-      Predefined(new std::vector<SymbolNode*>())
-#endif
-{
-#if 0
-  Error = create<ErrorNode>();
-#endif
+SymbolTable::SymbolTable() {
   init();
 }
 
@@ -507,36 +494,32 @@ std::shared_ptr<TraceClass> SymbolTable::getTracePtr() {
 }
 
 void SymbolTable::deallocateNodes() {
-  for (Node* Nd : *Allocated)
+  for (Node* Nd : Allocated)
     delete Nd;
 }
 
 void SymbolTable::init() {
-#if 1
-  Allocated = new std::vector<Node*>();
   Root = nullptr;
   TargetHeader = nullptr;
   NextCreationIndex = 0;
-  Predefined = new std::vector<SymbolNode*>();
   Error = create<ErrorNode>();
-#endif
-  Predefined->reserve(NumPredefinedSymbols);
+  Predefined.reserve(NumPredefinedSymbols);
   for (size_t i = 0; i < NumPredefinedSymbols; ++i) {
     SymbolNode* Nd = getSymbolDefinition(PredefinedName[i]);
-    Predefined->push_back(Nd);
+    Predefined.push_back(Nd);
     Nd->setPredefinedSymbol(toPredefinedSymbol(i));
   }
-  BlockEnterCallback = create<CallbackNode>(
-      (*Predefined)[uint32_t(PredefinedSymbol::Block_enter)]);
-  BlockExitCallback = create<CallbackNode>(
-      (*Predefined)[uint32_t(PredefinedSymbol::Block_exit)]);
+  BlockEnterCallback =
+      create<CallbackNode>(Predefined[uint32_t(PredefinedSymbol::Block_enter)]);
+  BlockExitCallback =
+      create<CallbackNode>(Predefined[uint32_t(PredefinedSymbol::Block_exit)]);
 }
 
 SymbolNode* SymbolTable::getSymbolDefinition(const std::string& Name) {
   SymbolNode* Node = SymbolMap[Name];
   if (Node == nullptr) {
     Node = new SymbolNode(*this, Name);
-    Allocated->push_back(Node);
+    Allocated.push_back(Node);
     SymbolMap[Name] = Node;
   }
   return Node;
@@ -550,13 +533,13 @@ SymbolNode* SymbolTable::getSymbolDefinition(const std::string& Name) {
       IntegerNode* Node = IntMap[I];                                 \
       if (Node == nullptr) {                                         \
         Node = new tag##Node(*this, Value, Format);                  \
-        Allocated->push_back(Node);                                  \
+        Allocated.push_back(Node);                                   \
         IntMap[I] = Node;                                            \
       }                                                              \
       return dyn_cast<tag##Node>(Node);                              \
     }                                                                \
     tag##Node* Node = new tag##Node(*this, Value, Format);           \
-    Allocated->push_back(Node);                                      \
+    Allocated.push_back(Node);                                       \
     return Node;                                                     \
   }                                                                  \
   tag##Node* SymbolTable::get##tag##Definition() {                   \
@@ -565,13 +548,13 @@ SymbolNode* SymbolTable::getSymbolDefinition(const std::string& Name) {
       IntegerNode* Node = IntMap[I];                                 \
       if (Node == nullptr) {                                         \
         Node = new tag##Node(*this);                                 \
-        Allocated->push_back(Node);                                  \
+        Allocated.push_back(Node);                                   \
         IntMap[I] = Node;                                            \
       }                                                              \
       return dyn_cast<tag##Node>(Node);                              \
     }                                                                \
     tag##Node* Node = new tag##Node(*this);                          \
-    Allocated->push_back(Node);                                      \
+    Allocated.push_back(Node);                                       \
     return Node;                                                     \
   }
 AST_INTEGERNODE_TABLE

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -140,7 +140,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   // Gets existing symbol if known. Otherwise returns nullptr.
   SymbolNode* getSymbol(const std::string& Name);
   SymbolNode* getPredefined(PredefinedSymbol Sym) {
-    return (*Predefined)[uint32_t(Sym)];
+    return Predefined[uint32_t(Sym)];
   }
   // Gets existing symbol if known. Otherwise returns newly created symbol.
   // Used to keep symbols unique within filter s-expressions.
@@ -194,7 +194,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
 
  private:
   std::shared_ptr<SymbolTable> EnclosingScope;
-  std::vector<Node*>* Allocated;
+  std::vector<Node*> Allocated;
   std::shared_ptr<utils::TraceClass> Trace;
   Node* Root;
   const FileHeaderNode* TargetHeader;
@@ -202,8 +202,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   int NextCreationIndex;
   std::map<std::string, SymbolNode*> SymbolMap;
   std::map<IntegerValue, IntegerNode*> IntMap;
-  // TODO(karlschimpf) Figure out why vector destroy not working.
-  std::vector<SymbolNode*>* Predefined;
+  std::vector<SymbolNode*> Predefined;
   CallbackNode* BlockEnterCallback;
   CallbackNode* BlockExitCallback;
 

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -133,7 +133,9 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   SymbolTable& operator=(const SymbolTable&) = delete;
 
  public:
+  // Use std::make_shared() to build.
   explicit SymbolTable();
+  explicit SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope);
   ~SymbolTable();
   // Gets existing symbol if known. Otherwise returns nullptr.
   SymbolNode* getSymbol(const std::string& Name);
@@ -191,6 +193,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   void describe(FILE* Out);
 
  private:
+  std::shared_ptr<SymbolTable> EnclosingScope;
   std::vector<Node*>* Allocated;
   std::shared_ptr<utils::TraceClass> Trace;
   Node* Root;


### PR DESCRIPTION
This is the beginning of a rewrite of ASTs that does 3 significant changes:

1 - Look up defaults using enclosing scope.
2 - Cache data on enclosing symbol table rather than ast nodes (thereby allowing enclosing scope to be used in multiple algorithms)
3 - When installing, only delete cached data in symbol table, and use a single "validateNode()" method to install changes.

