### PR TITLE
Remove old complex scheme for caching information on Ast nodes.

### DIFF
--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -172,7 +172,6 @@
     (case 'rename'              (=> 'postorder.inst'))
     (case 'section'             (=> 'postorder.inst'))
     (case 'sequence'            (eval 'nary.node'))
-    (case 'sequence'            (eval 'nary.node'))
     (case 'set'                 (=> 'postorder.inst'))
     (case 'switch'              (eval 'nary.node'))
     (case 'symbol'              (eval 'symbol.lookup'))      

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -222,7 +222,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceIntCountsCollectionFlag(
         MyCompressionFlags.TraceIntCountsCollection);
     Args.add(TraceIntCountsCollectionFlag.setLongName(
-                                             "verbose=int-counts-collection")
+                                              "verbose=int-counts-collection")
                  .setDescription("Show how int counts were selected"));
 
     ArgsParser::Optional<bool> TraceSequenceCountsFlag(
@@ -236,7 +236,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceSequenceCountsCollection);
     Args.add(
         TraceSequenceCountsCollectionFlag.setLongName(
-                                             "verbose=seq-counts-collection")
+                                              "verbose=seq-counts-collection")
             .setDescription(
                 "Show how frequency of integer sequences were "
                 "selected"));
@@ -293,7 +293,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbrevSelectionProgress);
     Args.add(
         TraceAbbrevSelectionProgressFlag.setLongName(
-                                            "verbose=select-abbrevs-progress")
+                                             "verbose=select-abbrevs-progress")
             .setOptionName("INTEGER")
             .setDescription(
                 "For every INTEGER values generated in the output integer "
@@ -304,7 +304,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceAbbrevSelectionSelectFlag(
         MyCompressionFlags.TraceAbbrevSelectionSelect);
     Args.add(TraceAbbrevSelectionSelectFlag.setLongName(
-                                               "verbose=select-abbrevs-select")
+                                                "verbose=select-abbrevs-select")
                  .setDescription(
                      "Show selected pattern sequences, as they apply. "
                      "Only appiles when --verbose=select-abbrevs is "
@@ -314,7 +314,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbrevSelectionCreate);
     Args.add(
         TraceAbbrevSelectionCreateFlag.setLongName(
-                                          "verbose=select-abbrevs-create")
+                                           "verbose=select-abbrevs-create")
             .setDescription(
                 "Show each created pattern sequence that is tried (not just "
                 "the selected ones). Only applies when "
@@ -323,7 +323,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceAbbrevSelectionDetailFlag(
         MyCompressionFlags.TraceAbbrevSelectionDetail);
     Args.add(TraceAbbrevSelectionDetailFlag.setLongName(
-                                               "verbose=select-abbrev-details")
+                                                "verbose=select-abbrev-details")
                  .setDescription(
                      "Show additional detail (besides creating and selecting) "
                      "when creating the applied pattern sequence. Only applies "

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1199,6 +1199,12 @@ void Interpreter::algorithmResume() {
               case State::Enter: {
                 auto* Sym = dyn_cast<SymbolNode>(Frame.Nd->getKid(0));
                 assert(Sym);
+                // Note: To handle local algorithm overrides (when processing
+                // code in an enclosing scope) we need to get the definition
+                // from the current algorithm, not the algorithm the symbol was
+                // defined in.
+                Sym = Symtab->getSymbol(Sym->getName());
+                assert(Sym);
                 auto* Defn = dyn_cast<DefineNode>(Sym->getDefineDefinition());
                 assert(Defn);
                 auto* NumParams = dyn_cast<ParamsNode>(Defn->getKid(1));

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -631,6 +631,7 @@ void Interpreter::algorithmResume() {
       case Method::Eval:
         switch (Frame.Nd->getType()) {
           case NO_SUCH_NODETYPE:
+          case OpSymbolDefn:
           case OpBinaryEvalBits:
           case OpBinaryAccept:
           case OpBinarySelect:

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -632,6 +632,7 @@ void Interpreter::algorithmResume() {
         switch (Frame.Nd->getType()) {
           case NO_SUCH_NODETYPE:
           case OpSymbolDefn:
+          case OpIntLookup:
           case OpBinaryEvalBits:
           case OpBinaryAccept:
           case OpBinarySelect:

--- a/src/sexp/Ast-templates.h
+++ b/src/sexp/Ast-templates.h
@@ -1,0 +1,59 @@
+// -*- C++ -*- */
+//
+// Copyright 2016 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Define template bodies used by Ast.h
+
+#ifndef DECOMPRESSOR_SRC_SEXP_AST_TEMPLATES_H_
+#define DECOMPRESSOR_SRC_SEXP_AST_TEMPLATES_H_
+
+namespace wasm {
+
+namespace filt {
+
+template <typename T>
+T* SymbolTable::create() {
+  T* Nd = new T(*this);
+  Allocated.push_back(Nd);
+  return Nd;
+}
+
+template <typename T>
+T* SymbolTable::create(Node* Kid) {
+  T* Nd = new T(*this, Kid);
+  Allocated.push_back(Nd);
+  return Nd;
+}
+
+template <typename T>
+T* SymbolTable::create(Node* Kid1, Node* Kid2) {
+  T* Nd = new T(*this, Kid1, Kid2);
+  Allocated.push_back(Nd);
+  return Nd;
+}
+
+template <typename T>
+T* SymbolTable::create(Node* Kid1, Node* Kid2, Node* Kid3) {
+  T* Nd = new T(*this, Kid1, Kid2, Kid3);
+  Allocated.push_back(Nd);
+  return Nd;
+}
+
+}  // end of namespace filt
+
+}  // end of namespace wasm
+
+
+#endif // DECOMPRESSOR_SRC_SEXP_AST_TEMPLATES_H_

--- a/src/sexp/Ast-templates.h
+++ b/src/sexp/Ast-templates.h
@@ -55,5 +55,4 @@ T* SymbolTable::create(Node* Kid1, Node* Kid2, Node* Kid3) {
 
 }  // end of namespace wasm
 
-
-#endif // DECOMPRESSOR_SRC_SEXP_AST_TEMPLATES_H_
+#endif  // DECOMPRESSOR_SRC_SEXP_AST_TEMPLATES_H_

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -440,15 +440,19 @@ void SymbolNode::setPredefinedSymbol(PredefinedSymbol NewValue) {
 // a node type is not defined with the correct template class.
 
 void SymbolNode::clearCaches(NodeVectorType& AdditionalNodes) {
+#if 0
   const Node* DefineDefinition = getDefineDefinition();
   if (DefineDefinition)
     AdditionalNodes.push_back(const_cast<Node*>(DefineDefinition));
+#endif
 }
 
 void SymbolNode::installCaches(NodeVectorType& AdditionalNodes) {
+#if 0
   const Node* DefineDefinition = getDefineDefinition();
   if (DefineDefinition)
     AdditionalNodes.push_back(const_cast<Node*>(DefineDefinition));
+#endif
 }
 
 SymbolTable::SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope)

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -68,6 +68,13 @@ BinaryEvalNode* SymbolTable::create<BinaryEvalNode>(Node* Kid) {
   return Nd;
 }
 
+template<>
+SymbolDefnNode* SymbolTable::create<SymbolDefnNode>() {
+  SymbolDefnNode* Nd = new SymbolDefnNode(*this);
+  Allocated.push_back(Nd);
+  return Nd;
+}
+
 #define X(tag, NODE_DECLS)                      \
   template <>                                   \
   tag##Node* SymbolTable::create<tag##Node>() { \
@@ -416,6 +423,17 @@ bool Node::validateNode(NodeVectorType& Scope) {
   return true;
 }
 
+SymbolDefnNode::SymbolDefnNode(SymbolTable& Symab)
+    : NullaryNode(Symtab, OpSymbolDefn),
+      Symbol(nullptr),
+      DefineDefinition(nullptr),
+      LiteralDefinition(nullptr) {
+}
+
+const std::string& SymbolDefnNode::getName() const {
+  return Symbol->getName();
+}
+
 SymbolNode::SymbolNode(SymbolTable& Symtab, const std::string& Name)
     : NullaryNode(Symtab, OpSymbol), Name(Name) {
   init();
@@ -426,8 +444,20 @@ SymbolNode::~SymbolNode() {
 
 void SymbolNode::init() {
   DefineDefinition = nullptr;
+#if 0
   LiteralDefinition = nullptr;
+#endif
   PredefinedValue = PredefinedSymbol::Unknown;
+}
+
+SymbolDefnNode* SymbolNode::getSymbolDefn() const {
+  SymbolDefnNode* Defn = cast<SymbolDefnNode>(Symtab.getCachedValue(this));
+  if (Defn == nullptr) {
+    Defn = Symtab.create<SymbolDefnNode>();
+    Defn->setSymbol(this);
+    Symtab.setCachedValue(this, Defn);
+  }
+  return Defn;
 }
 
 void SymbolNode::setPredefinedSymbol(PredefinedSymbol NewValue) {
@@ -445,15 +475,19 @@ void SymbolNode::setPredefinedSymbol(PredefinedSymbol NewValue) {
 void SymbolNode::clearCaches(NodeVectorType& AdditionalNodes) {
   if (DefineDefinition)
     AdditionalNodes.push_back(DefineDefinition);
+#if 0
   if (LiteralDefinition)
     AdditionalNodes.push_back(LiteralDefinition);
+#endif
 }
 
 void SymbolNode::installCaches(NodeVectorType& AdditionalNodes) {
   if (DefineDefinition)
     AdditionalNodes.push_back(DefineDefinition);
+#if 0
   if (LiteralDefinition)
     AdditionalNodes.push_back(LiteralDefinition);
+#endif
 }
 
 SymbolTable::SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope)
@@ -1242,9 +1276,11 @@ bool EvalNode::validateNode(NodeVectorType& Parents) {
   return true;
 }
 
+#if 0
 SymbolNode* SectionNode::getSymbol() const {
   return dyn_cast<SymbolNode>(getKid(0));
 }
+#endif
 
 SelectBaseNode::~SelectBaseNode() {
 }

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -857,10 +857,7 @@ IntegerNode::IntegerNode(SymbolTable& Symtab,
                          decode::IntType Value,
                          decode::ValueFormat Format,
                          bool isDefault)
-    : NullaryNode(Symtab, Type),
-      Value(Value),
-      Format(Format),
-      isDefault(isDefault) {
+    : NullaryNode(Symtab, Type), Value(Type, Value, Format, isDefault) {
 }
 
 IntegerNode::~IntegerNode() {
@@ -964,7 +961,8 @@ bool BinaryAcceptNode::validateNode(NodeVectorType& Parents) {
     switch (Nd->getType()) {
       case OpBinaryEval: {
         bool Success = true;
-        if (!isDefault && (MyValue != Value || MyNumBits != NumBits)) {
+        if (!Value.isDefault &&
+            (MyValue != Value.Value || MyNumBits != NumBits)) {
           describeNode("Malformed", this);
           fprintf(stderr, "Expected (%s ", getName());
           writeInt(stderr, MyValue, ValueFormat::Hexidecimal);
@@ -973,10 +971,10 @@ bool BinaryAcceptNode::validateNode(NodeVectorType& Parents) {
         }
         TRACE(IntType, "Value", MyValue);
         TRACE(unsigned_int, "Bits", MyNumBits);
-        Value = MyValue;
+        Value.Value = MyValue;
         NumBits = MyNumBits;
-        isDefault = false;
-        Format = ValueFormat::Hexidecimal;
+        Value.isDefault = false;
+        Value.Format = ValueFormat::Hexidecimal;
         if (!cast<BinaryEvalNode>(Nd)->addEncoding(this)) {
           fprintf(error(), "Can't install opcode, malformed: %s\n", getName());
           Success = false;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -562,6 +562,7 @@ AST_INTEGERNODE_TABLE
 
 void SymbolTable::install(Node* Root) {
   TRACE_METHOD("install");
+  CachedValue.clear();
   this->Root = Root;
   // Before starting, clear all known caches.
   VisitedNodesType VisitedNodes;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -440,19 +440,9 @@ void SymbolNode::setPredefinedSymbol(PredefinedSymbol NewValue) {
 // a node type is not defined with the correct template class.
 
 void SymbolNode::clearCaches(NodeVectorType& AdditionalNodes) {
-#if 0
-  const Node* DefineDefinition = getDefineDefinition();
-  if (DefineDefinition)
-    AdditionalNodes.push_back(const_cast<Node*>(DefineDefinition));
-#endif
 }
 
 void SymbolNode::installCaches(NodeVectorType& AdditionalNodes) {
-#if 0
-  const Node* DefineDefinition = getDefineDefinition();
-  if (DefineDefinition)
-    AdditionalNodes.push_back(const_cast<Node*>(DefineDefinition));
-#endif
 }
 
 SymbolTable::SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope)
@@ -481,6 +471,16 @@ FILE* SymbolTable::error() const {
 SymbolNode* SymbolTable::getSymbol(const std::string& Name) {
   // TODO(karlschimpf) -- Dont overfill.
   return SymbolMap[Name];
+}
+
+SymbolDefnNode* SymbolTable::getSymbolDefn(const SymbolNode* Sym) {
+  SymbolDefnNode* Defn = cast<SymbolDefnNode>(getCachedValue(Sym));
+  if (Defn == nullptr) {
+    Defn = create<SymbolDefnNode>();
+    Defn->setSymbol(Sym);
+    setCachedValue(Sym, Defn);
+  }
+  return Defn;
 }
 
 void SymbolTable::clear() {

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -68,7 +68,7 @@ BinaryEvalNode* SymbolTable::create<BinaryEvalNode>(Node* Kid) {
   return Nd;
 }
 
-template<>
+template <>
 SymbolDefnNode* SymbolTable::create<SymbolDefnNode>() {
   SymbolDefnNode* Nd = new SymbolDefnNode(*this);
   Allocated.push_back(Nd);

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -443,10 +443,6 @@ SymbolNode::~SymbolNode() {
 }
 
 void SymbolNode::init() {
-  DefineDefinition = nullptr;
-#if 0
-  LiteralDefinition = nullptr;
-#endif
   PredefinedValue = PredefinedSymbol::Unknown;
 }
 
@@ -473,21 +469,15 @@ void SymbolNode::setPredefinedSymbol(PredefinedSymbol NewValue) {
 // a node type is not defined with the correct template class.
 
 void SymbolNode::clearCaches(NodeVectorType& AdditionalNodes) {
+  const Node* DefineDefinition = getDefineDefinition();
   if (DefineDefinition)
-    AdditionalNodes.push_back(DefineDefinition);
-#if 0
-  if (LiteralDefinition)
-    AdditionalNodes.push_back(LiteralDefinition);
-#endif
+    AdditionalNodes.push_back(const_cast<Node*>(DefineDefinition));
 }
 
 void SymbolNode::installCaches(NodeVectorType& AdditionalNodes) {
+  const Node* DefineDefinition = getDefineDefinition();
   if (DefineDefinition)
-    AdditionalNodes.push_back(DefineDefinition);
-#if 0
-  if (LiteralDefinition)
-    AdditionalNodes.push_back(LiteralDefinition);
-#endif
+    AdditionalNodes.push_back(const_cast<Node*>(DefineDefinition));
 }
 
 SymbolTable::SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope)
@@ -1275,12 +1265,6 @@ bool EvalNode::validateNode(NodeVectorType& Parents) {
   }
   return true;
 }
-
-#if 0
-SymbolNode* SectionNode::getSymbol() const {
-  return dyn_cast<SymbolNode>(getKid(0));
-}
-#endif
 
 SelectBaseNode::~SelectBaseNode() {
 }

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -165,13 +165,19 @@
   X(BitwiseAnd,)                                                               \
   X(BitwiseOr,)                                                                \
   X(BitwiseXor,)                                                               \
-  X(Case,)                                                                     \
+  X(Case, CASE_DECLS)                                                          \
   X(IfThen,)                                                                   \
   X(Loop,)                                                                     \
   X(Or,)                                                                       \
   X(Rename,)                                                                   \
   X(Set,)                                                                      \
   X(LiteralDef,)                                                               \
+
+#define CASE_DECLS                                                             \
+  decode::IntType getValue() const { return Value; }                           \
+  bool validateNode(NodeVectorType &Parents) OVERRIDE;                         \
+ private:                                                                      \
+  decode::IntType Value;                                                       \
 
 //#define X(tag, NODE_DECLS)
 #define AST_SELECTNODE_TABLE                                                   \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -106,6 +106,7 @@
   /* Internal (not opcodes in compressed file) */                              \
   X(UnknownSection,    0xFF, "unknown.section", nullptr,           1, 0)       \
   X(SymbolDefn,        0x100, "symbol.defn",    nullptr,           0, 0)       \
+  X(IntLookup,         0x101, "int.lookup",     nullptr,           0, 0)       \
 
 //#define X(tag, NODE_DECLS)
 #define AST_NULLARYNODE_TABLE                                                  \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -105,6 +105,7 @@
                                                                                \
   /* Internal (not opcodes in compressed file) */                              \
   X(UnknownSection,    0xFF, "unknown.section", nullptr,           1, 0)       \
+  X(SymbolDefn,        0x100, "symbol.defn",    nullptr,           0, 0)       \
 
 //#define X(tag, NODE_DECLS)
 #define AST_NULLARYNODE_TABLE                                                  \
@@ -198,7 +199,7 @@
 
 #define SECTION_DECLS                                                          \
  public:                                                                       \
-  SymbolNode* getSymbol() const;                                               \
+  /* SymbolNode* getSymbol() const; */                                               \
 
 //#define X(tag, NODE_DECLS)
 #define AST_TERNARYNODE_TABLE                                                  \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -182,7 +182,7 @@
   X(Define, DEFINE_DECLS)                                                      \
   X(Eval, EVAL_DECLS)                                                          \
   X(FileHeader,)                                                               \
-  X(Section, SECTION_DECLS)                                                    \
+  X(Section,)                                                                  \
   X(Sequence,)                                                                 \
   X(Write,)                                                                    \
 
@@ -196,10 +196,6 @@
  public:                                                                       \
   SymbolNode* getCallName() const;                                             \
   bool validateNode(NodeVectorType &Parents) OVERRIDE;                         \
-
-#define SECTION_DECLS                                                          \
- public:                                                                       \
-  /* SymbolNode* getSymbol() const; */                                               \
 
 //#define X(tag, NODE_DECLS)
 #define AST_TERNARYNODE_TABLE                                                  \

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -341,15 +341,19 @@ class IntegerNode : public NullaryNode {
 
  public:
   ~IntegerNode() OVERRIDE;
-  decode::ValueFormat getFormat() const { return Format; }
-  decode::IntType getValue() const { return Value; }
+  decode::ValueFormat getFormat() const { return Value.Format; }
+  decode::IntType getValue() const { return Value.Value; }
+  bool isDefaultValue() const { return Value.isDefault; }
   static bool implementsClass(NodeType Type);
-  bool isDefaultValue() const { return isDefault; }
 
  protected:
+#if 0
   decode::IntType Value;
   decode::ValueFormat Format;
   bool isDefault;
+#else
+  IntegerValue Value;
+#endif
   // Note: ValueFormat provided so that we can echo back out same
   // representation as when lexing s-expressions.
   IntegerNode(SymbolTable& Symtab,

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -495,7 +495,8 @@ class SymbolDefnNode FINAL : public NullaryNode {
   SymbolDefnNode() = delete;
   SymbolDefnNode(const SymbolDefnNode&) = delete;
   SymbolDefnNode& operator=(const SymbolDefnNode&) = delete;
-public:
+
+ public:
   SymbolDefnNode(SymbolTable& Symtab);
   const SymbolNode* getSymbol() const { return Symbol; }
   void setSymbol(const SymbolNode* Nd) { Symbol = Nd; }
@@ -507,7 +508,7 @@ public:
 
   static bool implementsClass(NodeType Type) { return Type == OpSymbolDefn; }
 
-private:
+ private:
   const SymbolNode* Symbol;
   const Node* DefineDefinition;
   const Node* LiteralDefinition;

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -193,6 +193,8 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   virtual void setTrace(std::shared_ptr<utils::TraceClass> Trace);
   std::shared_ptr<utils::TraceClass> getTracePtr();
 
+  FILE* error();
+
   // For debugging.
   utils::TraceClass& getTrace();
   void describe(FILE* Out);
@@ -301,6 +303,8 @@ class Node {
   bool definesIntTypeFormat() const;
   // Gets the corresponding format if definesIntTypeFormat() returns true.
   interp::IntTypeFormat getIntTypeFormat() const;
+
+  FILE* error() { return Symtab.error(); }
 
   static bool implementsClass(NodeType /*Type*/) { return true; }
 
@@ -634,14 +638,11 @@ class SelectBaseNode : public NaryNode {
 
  public:
   ~SelectBaseNode() OVERRIDE;
-  void clearCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
-  void installCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
   const CaseNode* getCase(decode::IntType Key) const;
+  bool addCase(const CaseNode* Case);
+  static bool implementsClass(NodeType Type);
 
  protected:
-#if 0
-  std::unordered_map<decode::IntType, const CaseNode*> LookupMap;
-#endif
   SelectBaseNode(SymbolTable& Symtab, NodeType Type);
   IntLookupNode* getIntLookup() const;
 };

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -45,6 +45,7 @@ class FileHeaderNode;
 class IntegerNode;
 class LiteralDefNode;
 class Node;
+class SymbolDefnNode;
 class SymbolNode;
 class SymbolTable;
 class CallbackNode;
@@ -142,6 +143,10 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   SymbolTable* getEnclosingScope() { return EnclosingScope.get(); }
   // Gets existing symbol if known. Otherwise returns nullptr.
   SymbolNode* getSymbol(const std::string& Name);
+  // Returns local version of symbol definitions associated with the
+  // symbol. Used to get local cached symbol definitions when interpreting
+  // nodes with a symbol lookup, such as EvalNode.
+  SymbolDefnNode* getSymbolDefn(const SymbolNode* Symbol);
   SymbolNode* getPredefined(PredefinedSymbol Sym) {
     return Predefined[uint32_t(Sym)];
   }

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -193,7 +193,9 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   virtual void setTrace(std::shared_ptr<utils::TraceClass> Trace);
   std::shared_ptr<utils::TraceClass> getTracePtr();
 
-  FILE* error();
+  FILE* getErrorFile() const;
+  // getErrorFile with error prefix added.
+  FILE* error() const;
 
   // For debugging.
   utils::TraceClass& getTrace();
@@ -304,6 +306,7 @@ class Node {
   // Gets the corresponding format if definesIntTypeFormat() returns true.
   interp::IntTypeFormat getIntTypeFormat() const;
 
+  FILE* getErrorFile() const { return Symtab.getErrorFile(); }
   FILE* error() { return Symtab.error(); }
 
   static bool implementsClass(NodeType /*Type*/) { return true; }
@@ -347,13 +350,7 @@ class IntegerNode : public NullaryNode {
   static bool implementsClass(NodeType Type);
 
  protected:
-#if 0
-  decode::IntType Value;
-  decode::ValueFormat Format;
-  bool isDefault;
-#else
   IntegerValue Value;
-#endif
   // Note: ValueFormat provided so that we can echo back out same
   // representation as when lexing s-expressions.
   IntegerNode(SymbolTable& Symtab,
@@ -716,11 +713,9 @@ class OpcodeNode FINAL : public SelectBaseNode {
     uint32_t ShiftValue;
   };
 
-  void clearCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
-  void installCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
+  bool validateNode(NodeVectorType& Paremts) OVERRIDE;
   typedef std::vector<WriteRange> CaseRangeVectorType;
   CaseRangeVectorType CaseRangeVector;
-  void installCaseRanges();
 };
 
 class BinaryEvalNode : public UnaryNode {

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -229,12 +229,6 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   void deallocateNodes();
 
   void installDefinitions(Node* Root);
-  void clearSubtreeCaches(Node* Nd,
-                          VisitedNodesType& VisitedNodes,
-                          NodeVectorType& AdditionalNodes);
-  void installSubtreeCaches(Node* Nd,
-                            VisitedNodesType& VisitedNoes,
-                            NodeVectorType& AdditionalNodes);
 
   Node* stripUsing(Node* Root, std::function<Node*(Node*)> stripKid);
   Node* stripCallbacksExcept(std::set<std::string>& KeepActions, Node* Root);
@@ -577,8 +571,6 @@ class SymbolNode FINAL : public NullaryNode {
   PredefinedSymbol PredefinedValue;
   void init();
   SymbolDefnNode* getSymbolDefn() const;
-  void clearCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
-  void installCaches(NodeVectorType& AdditionalNodes) OVERRIDE;
   void setPredefinedSymbol(PredefinedSymbol NewValue);
 };
 

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -501,7 +501,7 @@ class SymbolDefnNode FINAL : public NullaryNode {
   const SymbolNode* getSymbol() const { return Symbol; }
   void setSymbol(const SymbolNode* Nd) { Symbol = Nd; }
   const std::string& getName() const;
-  const Node* getDefineDefinition() { return DefineDefinition; }
+  const Node* getDefineDefinition() const { return DefineDefinition; }
   void setDefineDefinition(const Node* Defn) { DefineDefinition = Defn; }
   const Node* getLiteralDefinition() const { return LiteralDefinition; }
   void setLiteralDefinition(const Node* Defn) { LiteralDefinition = Defn; }
@@ -524,28 +524,23 @@ class SymbolNode FINAL : public NullaryNode {
   SymbolNode(SymbolTable& Symtab, const std::string& Name);
   ~SymbolNode() OVERRIDE;
   const std::string& getName() const { return Name; }
-  const Node* getDefineDefinition() const { return DefineDefinition; }
-  void setDefineDefinition(Node* Defn) { DefineDefinition = Defn; }
-#if 0
-  const Node* getLiteralDefinition() const { return LiteralDefinition; }
-  void setLiteralDefinition(Node* Defn) { LiteralDefinition = Defn; }
-#else
+  const Node* getDefineDefinition() const {
+    return getSymbolDefn()->getDefineDefinition();
+  }
+  void setDefineDefinition(const Node* Defn) {
+    getSymbolDefn()->setDefineDefinition(Defn);
+  }
   const Node* getLiteralDefinition() const {
     return getSymbolDefn()->getLiteralDefinition();
   }
-  void setLiteralDefinition(Node* Defn) {
+  void setLiteralDefinition(const Node* Defn) {
     getSymbolDefn()->setLiteralDefinition(Defn);
   }
-#endif
   PredefinedSymbol getPredefinedSymbol() const { return PredefinedValue; }
   static bool implementsClass(NodeType Type) { return Type == OpSymbol; }
 
  private:
   std::string Name;
-  Node* DefineDefinition;
-#if 0
-  Node* LiteralDefinition;
-#endif
   PredefinedSymbol PredefinedValue;
   void init();
   SymbolDefnNode* getSymbolDefn() const;

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -639,10 +639,11 @@ class SelectBaseNode : public NaryNode {
   const CaseNode* getCase(decode::IntType Key) const;
 
  protected:
-  // TODO(karlschimpf) Hook this up to an allocator?
+#if 0
   std::unordered_map<decode::IntType, const CaseNode*> LookupMap;
-
+#endif
   SelectBaseNode(SymbolTable& Symtab, NodeType Type);
+  IntLookupNode* getIntLookup() const;
 };
 
 #define X(tag, NODE_DECLS)                                                 \

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -40,8 +40,10 @@ class TraceClass;
 namespace filt {
 
 class BinaryAcceptNode;
+class DefineNode;
 class FileHeaderNode;
 class IntegerNode;
+class LiteralDefNode;
 class Node;
 class SymbolNode;
 class SymbolTable;
@@ -137,6 +139,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   explicit SymbolTable();
   explicit SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope);
   ~SymbolTable();
+  SymbolTable* getEnclosingScope() { return EnclosingScope.get(); }
   // Gets existing symbol if known. Otherwise returns nullptr.
   SymbolNode* getSymbol(const std::string& Name);
   SymbolNode* getPredefined(PredefinedSymbol Sym) {
@@ -524,17 +527,19 @@ class SymbolDefnNode FINAL : public NullaryNode {
   const SymbolNode* getSymbol() const { return Symbol; }
   void setSymbol(const SymbolNode* Nd) { Symbol = Nd; }
   const std::string& getName() const;
-  const Node* getDefineDefinition() const { return DefineDefinition; }
-  void setDefineDefinition(const Node* Defn) { DefineDefinition = Defn; }
-  const Node* getLiteralDefinition() const { return LiteralDefinition; }
-  void setLiteralDefinition(const Node* Defn) { LiteralDefinition = Defn; }
+  const DefineNode* getDefineDefinition() const;
+  void setDefineDefinition(const DefineNode* Defn) { DefineDefinition = Defn; }
+  const LiteralDefNode* getLiteralDefinition() const;
+  void setLiteralDefinition(const LiteralDefNode* Defn) {
+    LiteralDefinition = Defn;
+  }
 
   static bool implementsClass(NodeType Type) { return Type == OpSymbolDefn; }
 
  private:
   const SymbolNode* Symbol;
-  const Node* DefineDefinition;
-  const Node* LiteralDefinition;
+  mutable const DefineNode* DefineDefinition;
+  mutable const LiteralDefNode* LiteralDefinition;
 };
 
 class SymbolNode FINAL : public NullaryNode {
@@ -547,16 +552,16 @@ class SymbolNode FINAL : public NullaryNode {
   SymbolNode(SymbolTable& Symtab, const std::string& Name);
   ~SymbolNode() OVERRIDE;
   const std::string& getName() const { return Name; }
-  const Node* getDefineDefinition() const {
+  const DefineNode* getDefineDefinition() const {
     return getSymbolDefn()->getDefineDefinition();
   }
-  void setDefineDefinition(const Node* Defn) {
+  void setDefineDefinition(const DefineNode* Defn) {
     getSymbolDefn()->setDefineDefinition(Defn);
   }
-  const Node* getLiteralDefinition() const {
+  const LiteralDefNode* getLiteralDefinition() const {
     return getSymbolDefn()->getLiteralDefinition();
   }
-  void setLiteralDefinition(const Node* Defn) {
+  void setLiteralDefinition(const LiteralDefNode* Defn) {
     getSymbolDefn()->setLiteralDefinition(Defn);
   }
   PredefinedSymbol getPredefinedSymbol() const { return PredefinedValue; }

--- a/src/sexp/FlattenAst.cpp
+++ b/src/sexp/FlattenAst.cpp
@@ -140,6 +140,7 @@ void FlattenAst::flattenNode(const Node* Nd) {
   TRACE(node_ptr, nullptr, Nd);
   switch (NodeType Opcode = Nd->getType()) {
     case NO_SUCH_NODETYPE:
+    case OpSymbolDefn:
     case OpBinaryEvalBits:
     case OpUnknownSection: {
       reportError("Unexpected s-expression, can't write!");

--- a/src/sexp/FlattenAst.cpp
+++ b/src/sexp/FlattenAst.cpp
@@ -141,6 +141,7 @@ void FlattenAst::flattenNode(const Node* Nd) {
   switch (NodeType Opcode = Nd->getType()) {
     case NO_SUCH_NODETYPE:
     case OpSymbolDefn:
+    case OpIntLookup:
     case OpBinaryEvalBits:
     case OpUnknownSection: {
       reportError("Unexpected s-expression, can't write!");


### PR DESCRIPTION
The old scheme of installing a root was very complex because it had to process all enclosing symbol tables (not just the one being installed) to work. In addition, it meant that all enclosing symbol tables couldn't be reused to enclose any other symbol table.

The main fix was to define a "cache" on each symbol table that holds nodes corresponding to cached values. This moves the cached values off AST nodes, and allows ast nodes from enclosing symbol tables to work. That is, the cache on the symbol table has only that symbol table's cached values. Clearing is just empty the cache. Installing is creating them as needed

For most nodes, this is done with the validateNode() method. For symbols, this (sometimes) has to by done dynamically (i.e. lazy). The cases are when interpreting an enclosing symbol from an enclosing symbol table. That is the EvalNode and LiteralUseNode classes. In these cases, validate can't set it for enclosing symbol tables since it only knows about the symbol table it appears in.

To fix symbol in EvalNode and LiteralUse, we use a special symbol table look up to get the (locally) cached definitions. This lookup will use the cached value if the symbol is local. Otherwise, it will create a new SymbolDefnNode instance for the local scope.