### PR TITLE
Add capability to add algorithms when decompressing.

### DIFF
--- a/src/utils/ArgsParse.h
+++ b/src/utils/ArgsParse.h
@@ -249,6 +249,27 @@ class ArgsParser {
     set_type& Values;
   };
 
+  template <class T>
+  class RepeatableVector : public OptionalArg {
+    RepeatableVector() = delete;
+    RepeatableVector(const RepeatableVector&) = delete;
+    RepeatableVector& operator=(const RepeatableVector&) = delete;
+
+   public:
+    typedef std::vector<T> vector_type;
+    explicit RepeatableVector(vector_type& Values,
+                              charstring Description = nullptr)
+        : OptionalArg(Description), Values(Values) {}
+
+    bool select(ArgsParser* Parser, charstring Add) OVERRIDE;
+    void describeDefault(FILE* Out,
+                         size_t TabSize,
+                         size_t& Indent) const OVERRIDE;
+
+   protected:
+    vector_type& Values;
+  };
+
   class RequiredArg : public Arg {
     RequiredArg() = delete;
     RequiredArg(const RequiredArg&) = delete;

--- a/src/utils/ArgsParseCharstring.cpp
+++ b/src/utils/ArgsParseCharstring.cpp
@@ -55,6 +55,23 @@ bool ArgsParser::Required<charstring>::select(ArgsParser* Parser,
   return true;
 }
 
+template <>
+bool ArgsParser::RepeatableVector<charstring>::select(ArgsParser* Parser,
+                                                      charstring Add) {
+  if (!validOptionValue(Parser, Add))
+    return false;
+  Values.push_back(Add);
+  return true;
+}
+
+template <>
+void ArgsParser::RepeatableVector<charstring>::describeDefault(
+    FILE* Out,
+    size_t TabSize,
+    size_t& Indent) const {
+  printDescriptionContinue(Out, TabSize, Indent, " (can be repeated)");
+}
+
 }  // end of namespace utils
 
 }  // end of namespace wasm


### PR DESCRIPTION
Algorithms can be specified on the command line for the decompressor. They are added first before default algorithms. This allows adding new algorithms on the command line, as well as replacing built in algorithms.

The facility allows the decompressor to test new decompression techniques without (necessarily) rebuilding the decompressor.