### PR TITLE
Add table operation to interpreter

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -222,7 +222,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceIntCountsCollectionFlag(
         MyCompressionFlags.TraceIntCountsCollection);
     Args.add(TraceIntCountsCollectionFlag.setLongName(
-                                              "verbose=int-counts-collection")
+                                             "verbose=int-counts-collection")
                  .setDescription("Show how int counts were selected"));
 
     ArgsParser::Optional<bool> TraceSequenceCountsFlag(
@@ -236,7 +236,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceSequenceCountsCollection);
     Args.add(
         TraceSequenceCountsCollectionFlag.setLongName(
-                                              "verbose=seq-counts-collection")
+                                             "verbose=seq-counts-collection")
             .setDescription(
                 "Show how frequency of integer sequences were "
                 "selected"));
@@ -293,7 +293,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbrevSelectionProgress);
     Args.add(
         TraceAbbrevSelectionProgressFlag.setLongName(
-                                             "verbose=select-abbrevs-progress")
+                                            "verbose=select-abbrevs-progress")
             .setOptionName("INTEGER")
             .setDescription(
                 "For every INTEGER values generated in the output integer "
@@ -304,7 +304,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceAbbrevSelectionSelectFlag(
         MyCompressionFlags.TraceAbbrevSelectionSelect);
     Args.add(TraceAbbrevSelectionSelectFlag.setLongName(
-                                                "verbose=select-abbrevs-select")
+                                               "verbose=select-abbrevs-select")
                  .setDescription(
                      "Show selected pattern sequences, as they apply. "
                      "Only appiles when --verbose=select-abbrevs is "
@@ -314,7 +314,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbrevSelectionCreate);
     Args.add(
         TraceAbbrevSelectionCreateFlag.setLongName(
-                                           "verbose=select-abbrevs-create")
+                                          "verbose=select-abbrevs-create")
             .setDescription(
                 "Show each created pattern sequence that is tried (not just "
                 "the selected ones). Only applies when "
@@ -323,7 +323,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceAbbrevSelectionDetailFlag(
         MyCompressionFlags.TraceAbbrevSelectionDetail);
     Args.add(TraceAbbrevSelectionDetailFlag.setLongName(
-                                                "verbose=select-abbrev-details")
+                                               "verbose=select-abbrev-details")
                  .setDescription(
                      "Show additional detail (besides creating and selecting) "
                      "when creating the applied pattern sequence. Only applies "

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -660,6 +660,7 @@ void Interpreter::algorithmResume() {
           case OpRename:
           case OpSymbol:
           case OpSection:
+          case OpTable:
           case OpUndefine:
           case OpUnknownSection:  // Method::Eval
             return failNotImplemented();

--- a/src/sexp-parser/Driver.cpp
+++ b/src/sexp-parser/Driver.cpp
@@ -23,6 +23,17 @@ namespace {
 const char* ErrorLevelName[] = {"warning", "error", "fatal"};
 }
 
+void Driver::appendArgument(Node* Nd, Node* Arg) {
+  Node* LastKid = Nd->getLastKid();
+  auto* Seq = dyn_cast<SequenceNode>(LastKid);
+  if (Seq == nullptr) {
+    Seq = create<SequenceNode>();
+    Seq->append(LastKid);
+    Nd->setLastKid(Seq);
+  }
+  Seq->append(Arg);
+}
+
 const char* Driver::getName(ErrorLevel Level) {
   size_t Index = size_t(Level);
   if (Index < size(ErrorLevelName))

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -79,6 +79,8 @@ class Driver {
     return Table->getSymbolDefinition(Name);
   }
 
+  void appendArgument(Node* Nd, Node* Arg);
+
   // The name of the file being parsed.
   std::string& getFilename() { return Filename; }
 

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -245,6 +245,7 @@ letter	[a-zA-Z]
 "set"             return Parser::make_SET(Driver.getLoc());
 "switch"          return Parser::make_SWITCH(Driver.getLoc());
 "symbol"          return Parser::make_SYMBOL(Driver.getLoc());
+"table"           return Parser::make_TABLE(Driver.getLoc());
 "uint8"           return Parser::make_UINT8(Driver.getLoc());
 "uint32"          return Parser::make_UINT32(Driver.getLoc());
 "uint64"          return Parser::make_UINT64(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -117,6 +117,7 @@ struct IntValue {
 %token SET           "set"
 %token SWITCH        "switch"
 %token SYMBOL        "symbol"
+%token TABLE         "table"
 %token UINT8         "uint8"
 %token UINT32        "uint32"
 %token UINT64        "uint64"
@@ -152,6 +153,7 @@ struct IntValue {
 %type <wasm::filt::Node *> file
 %type <wasm::filt::Node *> file_header
 %type <wasm::filt::Node *> file_header_args
+%type <wasm::filt::Node *> file_header_write
 %type <wasm::filt::Node *> fixed_format_directive
 %type <wasm::filt::Node *> format_binary
 %type <wasm::filt::Node *> format_directive
@@ -166,8 +168,8 @@ struct IntValue {
 %type <wasm::filt::Node *> section
 %type <wasm::filt::Node *> sequence_args
 %type <wasm::filt::Node *> symbol
+%type <wasm::filt::Node *> table_args
 %type <wasm::filt::Node *> write_args
-%type <wasm::filt::Node *> file_header_write
 
 %start file
 
@@ -179,14 +181,7 @@ block_args
           }
         | block_args expression {
             $$ = $1;
-            Node* StmtList = $1->getLastKid();
-            auto* Seq = dyn_cast<SequenceNode>(StmtList);
-            if (Seq == nullptr) {
-              Seq = Driver.create<SequenceNode>();
-              Seq->append(StmtList);
-              $1->setLastKid(Seq);
-            }
-            Seq->append($2);
+            Driver.appendArgument($1, $2);
           }
         ;
 
@@ -228,14 +223,7 @@ case_args
         | case_args expression {
             // remaining expressions of case.
             $$ = $1;
-            Node *StmtList = $1->getLastKid();
-            auto *Seq = dyn_cast<SequenceNode>(StmtList);
-            if (Seq == nullptr) {
-              Seq = Driver.create<SequenceNode>();
-              Seq->append(StmtList);
-              $1->setLastKid(Seq);
-            }
-            Seq->append($2);
+            Driver.appendArgument($1, $2);
           }
         ;
 
@@ -297,14 +285,7 @@ define_args
           }
         | define_args expression {
             $$ = $1;
-            Node *LastKid = $1->getLastKid();
-            auto *Seq = dyn_cast<SequenceNode>(LastKid);
-            if (Seq == nullptr) {
-              Seq = Driver.create<SequenceNode>();
-              Seq->append(LastKid);
-              $1->setLastKid(Seq);
-            }
-            Seq->append($2);
+            Driver.appendArgument($1, $2);
           }
         ;
 
@@ -336,6 +317,9 @@ expression
         | "(" expression_redirect ")" {
             $$ = $2;
           }
+        |  "(" "table" table_args ")" {
+            $$ = $3;
+           }
         ;
 
 expression_redirect
@@ -347,14 +331,7 @@ expression_redirect
           }
         | expression_redirect expression {
             $$ = $1;
-            Node* ExpList = $1->getLastKid();
-            auto* Seq = dyn_cast<SequenceNode>(ExpList);
-            if (Seq == nullptr) {
-              Seq = Driver.create<SequenceNode>();
-              Seq->append(ExpList);
-              $$->setLastKid(Seq);
-            }
-            Seq->append($2);
+            Driver.appendArgument($1, $2);
           }
         ;
 
@@ -500,14 +477,7 @@ loop_body
           }
         | loop_body expression {
             $$ = $1;
-            Node *StmtList = $1->getLastKid();
-            auto *Seq = dyn_cast<SequenceNode>(StmtList);
-            if (Seq == nullptr) {
-              Seq = Driver.create<SequenceNode>();
-              Seq->append(StmtList);
-              $1->setLastKid(Seq);
-            }
-            Seq->append($2);
+            Driver.appendArgument($1, $2);
           }
         ;
 
@@ -587,6 +557,16 @@ write_args
         ;
 
 symbol  : IDENTIFIER { $$ = Driver.getSymbolDefinition($1); }
+        ;
+
+table_args
+        : expression expression {
+            $$ = Driver.create<TableNode>($1, $2);
+          }
+        | table_args expression {
+            Driver.appendArgument($1, $2);
+            $$ = $1;
+          }
         ;
 
 %%

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -83,6 +83,7 @@
   X(Read,              0x41, "read",             nullptr,           1, 0)      \
   X(LastRead,          0x42, "read",             "lastRead",        0, 0)      \
   X(Write,             0x43, "write",            nullptr,           1, 1)      \
+  X(Table,             0x44, "table",            nullptr,           1, 1)      \
                                                                                \
   /* Other */                                                                  \
   X(Param,             0x51, "param",            nullptr,           1, 0)      \
@@ -167,11 +168,12 @@
   X(BitwiseXor,)                                                               \
   X(Case, CASE_DECLS)                                                          \
   X(IfThen,)                                                                   \
+  X(LiteralDef,)                                                               \
   X(Loop,)                                                                     \
   X(Or,)                                                                       \
   X(Rename,)                                                                   \
   X(Set,)                                                                      \
-  X(LiteralDef,)                                                               \
+  X(Table,)                                                                    \
 
 #define CASE_DECLS                                                             \
   decode::IntType getValue() const { return Value; }                           \
@@ -227,6 +229,7 @@
   X(LoopUnbounded)                                                             \
   X(Peek)                                                                      \
   X(Read)                                                                      \
+  X(Table)                                                                     \
 
 //#define X(tag)
 #define AST_NODE_NEVER_SAME_LINE                                               \

--- a/src/sexp/FlattenAst.cpp
+++ b/src/sexp/FlattenAst.cpp
@@ -140,9 +140,10 @@ void FlattenAst::flattenNode(const Node* Nd) {
   TRACE(node_ptr, nullptr, Nd);
   switch (NodeType Opcode = Nd->getType()) {
     case NO_SUCH_NODETYPE:
-    case OpSymbolDefn:
-    case OpIntLookup:
     case OpBinaryEvalBits:
+    case OpIntLookup:
+    case OpSymbolDefn:
+    case OpTable:
     case OpUnknownSection: {
       reportError("Unexpected s-expression, can't write!");
       reportError("s-expression: ", Nd);


### PR DESCRIPTION
The table option allows one (via an index expression), to freeze input positions, and then re-parse that input position multiple times. Provides a simple implementation of constant abbreviation sequences.

Also realized that there was a pattern in the algorithm parser for extending fixed-arity AST nodes to arbitrary arity by inserting a hidden sequence node over trailing kids. Factored it out and replaced the patterns with an appropriate method call.