### PR TITLE
Separate out source generation into separate build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -767,6 +767,9 @@ ifeq ($(GEN), 1)
   $(PARSER_GENDIR)/Lexer.lex: $(PARSER_DIR)/Lexer.lex $(PARSER_GENDIR)
 	cp $< $@
 
+  $(PARSER_GENDIR)/Lexer.cpp: $(PARSER_GENDIR)/Lexer.lex
+	cd $(PARSER_GENDIR); lex -o Lexer.cpp Lexer.lex
+
   $(PARSER_GENDIR)/Parser.ypp: $(PARSER_DIR)/Parser.ypp $(PARSER_GENDIR)
 	cp $< $@
 
@@ -817,9 +820,6 @@ else
   $(PARSER_OBJS): | $(PARSER_OBJDIR)
 
   -include $(PARSER_GENDIR)/Lexer.d
-
-  $(PARSER_GENDIR)/Lexer.cpp: $(PARSER_GENDIR)/Lexer.lex
-	cd $(PARSER_GENDIR); lex -o Lexer.cpp Lexer.lex
 
   # -include $(PARSER_GENDIR)/Parser.tab.d
 
@@ -936,10 +936,8 @@ test: build-all test-parser test-raw-streams test-byte-queues \
 
 test-all:
 	@echo "*** testing release version ***"
-	#$(MAKE) $(MAKE_PAGE_SIZE) DEBUG=0 RELEASE=1 BOOTSTRAP=0 test
 	$(MAKE) $(MAKE_PAGE_SIZE) DEBUG=0 RELEASE=1 test
 	@echo "*** testing debug version ***"
-	#$(MAKE) $(MAKE_PAGE_SIZE)  DEBUG=1 RELEASE=0 BOOTSTRAP=0 test
 	$(MAKE) $(MAKE_PAGE_SIZE)  DEBUG=1 RELEASE=0 test
 	@echo "*** all tests passed on both debug and release builds ***"
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,10 +28,14 @@ EXE :=
 CXX_BOOT := clang++
 EXE_BOOT :=
 
+ifndef GEN
+  GEN=0
+endif
+
 # Define if updating tests
-#ifndef UPDATE
+ifndef UPDATE
   UPDATE=0
-#endif
+endif
 
 # Define if release or debug build
 ifdef DEBUG
@@ -143,7 +147,8 @@ else
   BUILDDIR = $(BUILDBASEDIR)/release
 endif
 
-BUILDDIR_BOOT = build/boot$(CXX_SUBDIR)$(PAGE_BUILD_SUFFIX)
+#BUILDDIR_BOOT = build/boot$(CXX_SUBDIR)$(PAGE_BUILD_SUFFIX)
+BUILDDIR_BOOT = build/boot
 
 GENDIR = build/src
 
@@ -168,8 +173,10 @@ $(info Using RELEASE = $(RELEASE))
 $(info Using PAGE_SIZE = $(USE_PAGE_SIZE))
 $(info Using CXX_SUBDIR = $(CXX_SUBDIR))
 $(info Using WASM = $(WASM))
-
-$(info Using BUILDDIR = $(BUILDDIR))
-$(info Using BUILDDIR_BOOT = $(BUILDDIR_BOOT))
+ifeq ($(GEN), 1)
+  $(info Using BUILDDIR_BOOT = $(BUILDDIR_BOOT))
+else
+  $(info Using BUILDDIR = $(BUILDDIR))
+endif
 $(info -----------------------------------------------)
 

--- a/travis/build_and_test.sh
+++ b/travis/build_and_test.sh
@@ -18,7 +18,8 @@ cd ${ROOT_DIR}
 
 # Build for Wasm Vanilla.
 make clean-all
+make -j8 PLATFORM=Travis GEN=1
 make -j8 PLATFORM=Travis WASM=1 WASM_VANILLA=1 RELEASE=1
 
 # Build for host.
-make presubmit -j8 PLATFORM=Travis
+make -j8 PLATFORM=Travis presubmit


### PR DESCRIPTION
Fixing make system to separate out source generation as a separate build step (using 'make GEN=1'). This was done because the previous make system was too easy to get pollution between the two steps, and frequently caused much more churn than was necessary.