### PR TITLE
Add interpretation flag to define if macros should be expanded.

### DIFF
--- a/src/interp/InterpreterFlags.h
+++ b/src/interp/InterpreterFlags.h
@@ -23,8 +23,16 @@ namespace wasm {
 
 namespace interp {
 
+enum class MacroDirective {
+  // Read once, duplicate (expand) when writing.
+  Expand,
+  // Read all, write once.
+  Contract
+};
+
 struct InterpreterFlags {
   InterpreterFlags();
+  MacroDirective MacroContext;
   bool TraceProgress;
   bool TraceIntermediateStreams;
   bool TraceAppliedAlgorithms;


### PR DESCRIPTION
Adds Expanded/Contracted interpretation flag values. This allows thde interpreter to be the exclusive handler of macros. Other filters do not need to worry about handling it, simplifying the code. In particular, this frees compression code from having to apply macro contraction when it generates an (integer) sequence. Rather, it just (always) generated the expanded versions, and lets the macros (in the write algorithm) do the work.