### PR TITLE
Simplify boot steps

### DIFF
--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -208,10 +208,6 @@
   )
 )
 
-(define 'stream.node' (params)
-  (error)
-)
-
 (define 'symbol.lookup' (params)
   (varuint32)
   (=> 'symbol.lookup')

--- a/src/algorithms/casm0x0Boot.cast
+++ b/src/algorithms/casm0x0Boot.cast
@@ -1,0 +1,233 @@
+# Copyright 2016 WebAssembly Community Group participants
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Defines the CAST algorithm for reading/writing "Compressed binary
+# algorithm" ("CASM") files.
+
+(header (u32.const 0x6d736163) (u32.const 0x0))
+(void)
+
+(literal.action.base (u32.const 101))
+
+# Control flow operators
+(literal 'block'          (u8.const 0x01))
+(literal 'case'           (u8.const 0x02))
+(literal 'error'          (u8.const 0x03))
+(literal 'eval'           (u8.const 0x04))
+(literal 'loop'           (u8.const 0x07))
+(literal 'loop.unbounded' (u8.const 0x08))
+(literal 'switch'         (u8.const 0x09))
+(literal 'sequence'       (u8.const 0x0a))
+(literal 'if.then'        (u8.const 0x0b))
+(literal 'if.then.else'   (u8.const 0x0c))
+
+# Constants
+(literal 'void'           (u8.const 0x10))
+(literal 'symbol'         (u8.const 0x11))
+(literal 'i32.const'      (u8.const 0x12))
+(literal 'i64.const'      (u8.const 0x13))
+(literal 'u8.const'       (u8.const 0x14))
+(literal 'u32.const'      (u8.const 0x15))
+(literal 'u64.const'      (u8.const 0x16))
+
+# Formatting
+(literal 'uint32'         (u8.const 0x20))
+(literal 'uint64'         (u8.const 0x21))
+(literal 'uint8'          (u8.const 0x22))
+(literal 'varint32'       (u8.const 0x23))
+(literal 'varint64'       (u8.const 0x24))
+(literal 'varuint32'      (u8.const 0x25))
+(literal 'varuint64'      (u8.const 0x26))
+(literal 'opcode.bytes'   (u8.const 0x27))
+(literal 'accept'         (u8.const 0x28))
+(literal 'binary'         (u8.const 0x29))
+(literal 'opcode.binary'  (u8.const 0x2a))
+(literal 'bit'            (u8.const 0x2b))
+(literal 'opcode.bits'    (u8.const 0x2c))
+
+# Boolean expressions
+(literal 'and'            (u8.const 0x30))
+(literal 'or'             (u8.const 0x31))
+(literal 'not'            (u8.const 0x32))
+(literal 'bitwise.and'    (u8.const 0x34))
+(literal 'bitwise.or'     (u8.const 0x35))
+(literal 'bitwise.xor'    (u8.const 0x36))
+(literal 'bitwise.negate' (u8.const 0x37))
+(literal 'last.symbol.is' (u8.const 0x38))
+
+# I/O operations
+(literal 'peek'           (u8.const 0x40))
+(literal 'read'           (u8.const 0x41))
+(literal 'last.read'      (u8.const 0x42))
+(literal 'write'          (u8.const 0x43))
+(literal 'table'          (u8.const 0x44))
+
+# Other
+(literal 'param'          (u8.const 0x51))
+(literal 'local'          (u8.const 0x53))
+(literal 'set'            (u8.const 0x54))
+(literal 'map'            (u8.const 0x55))
+(literal '=>'             (u8.const 0x56))
+
+# declarations
+(literal 'define'         (u8.const 0x60))
+#(literal 'file'           (u8.const 0x62))
+(literal 'file.header'    (u8.const 0x77))
+(literal 'section'        (u8.const 0x63))
+(literal 'undefine'       (u8.const 0x64))
+(literal 'literal.define' (u8.const 0x65))
+(literal 'literal.use'    (u8.const 0x66))
+(literal 'rename'         (u8.const 0x67))
+(literal 'locals'         (u8.const 0x68))
+(literal 'params'         (u8.const 0x69))
+(literal 'literal.action.define'  (u8.const 0x6a))
+(literal 'literal.action.use'     (u8.const 0x6b))
+(literal 'literal.action.base'    (u8.const 0x6c))
+
+(define 'file' (params)
+  (eval 'header')
+  (eval 'section')
+)
+
+(define 'header' (params)
+  (loop (varuint32)
+    (eval 'node')
+  )
+)
+
+(define 'int.value' (params 1)
+  (=> 'int.value.begin')
+  (if (uint8)                   # 0 or (decode::ValueFormat+1)
+    (param 0)                   # integer value.
+  )
+  (=> 'int.value.end')
+)
+
+(define 'nary.node' (params)
+  (varuint32)
+  (=> 'nary.inst')
+)
+
+(define 'node' (params)
+  (switch (uint8)
+    (error)
+    (#case 'accept'
+    #case 'and'
+    #case 'binary'
+    case 'bit'
+    #case 'bitwise.and'
+    #case 'bitwise.negate'
+    #case 'bitwise.or'
+    #case 'bitwise.xor'
+     case 'block'
+     case 'case'
+     case 'error'
+     case 'if.then'
+     #case 'if.then.else'
+     #case 'last.read'
+     #case 'last.symbol.is'
+     case 'literal.action.base'
+     #case 'literal.action.define'
+     case 'literal.action.use'
+     case 'literal.define'
+     case 'literal.use'
+     case 'loop'
+     case 'loop.unbounded'
+     #case 'not'
+     #case 'opcode.binary'
+     #case 'or'
+     #case 'peek'
+     #case 'read'
+     #case 'rename'
+     case 'section'
+     #case 'set'
+     #case 'table'
+     #case 'undefine'
+     #case 'uint32'
+     #case 'uint64'
+     case 'uint8'
+     case 'varint32'
+     case 'varint64'
+     case 'varuint32'
+     case 'varuint64'
+     case 'void'
+     case '=>'
+                                (=> 'postorder.inst'))
+
+    (case 'define'
+     case 'eval'
+     #case 'file.header'
+     #case 'map'
+     #case 'opcode.bytes'
+     case 'sequence'
+     case 'switch'
+     #case 'write'
+                                (eval 'nary.node'))
+
+    (case 'param'
+     case 'params'
+     #case 'local'
+     #case 'locals'
+     case 'u32.const'
+                                (eval 'int.value' (varuint32)))
+    #(case 'i32.const'           (eval 'int.value' (varint32)))
+    #(case 'i64.const'           (eval 'int.value' (varint64)))
+    #(case 'u64.const'           (eval 'int.value' (varuint64)))
+    (case 'u8.const'            (eval 'int.value' (uint8)))
+
+    (case 'symbol'              (eval 'symbol.lookup'))
+
+    #(case 'opcode.bits'         (eval 'opcode.binary'))
+  )
+)
+
+#(define 'opcode.binary' (params)
+#  (loop (seq (varuint32) (=> 'binary.begin'))
+#    (bit)
+#    (=> 'binary.bit')
+#  )
+#  (=> 'binary.end')
+#  (=> 'align')
+#)
+
+(define 'section' (params)
+  (block
+    (eval 'symbol.table')
+    (loop.unbounded
+      (eval 'node')
+    )
+  )
+)
+
+(define 'symbol.lookup' (params)
+  (varuint32)
+  (=> 'symbol.lookup')
+)
+
+(define 'symbol.name' (params)
+  (loop
+    (seq
+      (varuint32)
+      (=> 'symbol.name.begin'))
+    (uint8)
+  )
+  (=> 'symbol.name.end')
+)
+
+(define 'symbol.table' (params)
+  (loop
+    (varuint32)
+    (eval 'symbol.name')
+  )
+)

--- a/src/algorithms/cism0x0.cast
+++ b/src/algorithms/cism0x0.cast
@@ -18,14 +18,14 @@
 (header (u32.const 0x6d736163) (u32.const 0x0))
 (header (u32.const 0x6d736963) (u32.const 0x0))
 
-#(literal.action.base (u32.const 5001))
+(literal.action.base (u32.const 5001))
 
 (define 'file' (params) (locals 1)
   (loop.unbounded
     (set (local 0) (eval 'categorize' (eval 'opcode')))
     (switch (local 0)
       (table (local 0)
-        (case (u32.const 32868)
+        (case (u32.const 32772)
           (loop (read (varuint64)) (varuint64))
         )
       )

--- a/src/casm/InflateAst.cpp
+++ b/src/casm/InflateAst.cpp
@@ -19,6 +19,7 @@
 
 #include "casm/InflateAst.h"
 
+// TODO(karlschimpf): Remove boot dependency
 #include "algorithms/casm0x0.h"
 #include "binary/SectionSymbolTable.h"
 #include "sexp/Ast.h"

--- a/src/casm/InflateAst.h
+++ b/src/casm/InflateAst.h
@@ -24,6 +24,7 @@
 #ifndef DECOMPRESSOR_SRC_SEXP_INFLATEAST_H
 #define DECOMPRESSOR_SRC_SEXP_INFLATEAST_H
 
+#include "algorithms/casm0x0-enum.h"
 #include "utils/ValueStack.h"
 #include "interp/Writer.h"
 

--- a/src/exec/cast2casm-boot2.cpp
+++ b/src/exec/cast2casm-boot2.cpp
@@ -16,5 +16,10 @@
 
 // Converts textual algorithm into binary file form
 
+#include "algorithms/casm0x0.h"
+#include "casm/CasmReader.h"
+#include "casm/CasmWriter.h"
+
 #define WASM_CAST_BOOT 2
+#define WASM_CASM_GET_SYMTAB getAlgcasm0x0Symtab
 #include "cast2casm.h"

--- a/src/exec/cast2casm.cpp
+++ b/src/exec/cast2casm.cpp
@@ -16,5 +16,10 @@
 
 // Converts textual algorithm into binary file form.
 
+#include "algorithms/casm0x0.h"
+#include "casm/CasmReader.h"
+#include "casm/CasmWriter.h"
+
 #define WASM_CAST_BOOT 3
+#define WASM_CASM_GET_SYMTAB getAlgcasm0x0Symtab
 #include "cast2casm.h"

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -1078,10 +1078,17 @@ int main(int Argc, charstring Argv[]) {
     InputSymtab->stripLiteralDefs();
   if (StripLiterals)
     InputSymtab->stripLiterals();
+
   if (TraceInputTree) {
     TextWriter Writer;
     Writer.write(stderr, InputSymtab.get());
   }
+
+  if (DisplayParsedInput) {
+    InputSymtab->describe(stderr, ShowInternalStructure);
+    return exit_status(EXIT_SUCCESS);
+  }
+
   if (Verbose) {
     if (AlgorithmFilename)
       fprintf(stderr, "Reading algorithms file: %s\n", AlgorithmFilename);
@@ -1104,11 +1111,6 @@ int main(int Argc, charstring Argv[]) {
   if (TraceAlgorithm) {
     TextWriter Writer;
     Writer.write(stderr, AlgSymtab.get());
-  }
-
-  if (DisplayParsedInput) {
-    InputSymtab->describe(stderr, ShowInternalStructure);
-    return exit_status(EXIT_SUCCESS);
   }
 
   if (Verbose && strcmp(OutputFilename, "-") != 0)

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -22,11 +22,6 @@
 #include <cctype>
 #include <cstdio>
 
-#if WASM_CAST_BOOT > 1
-#include "algorithms/casm0x0.h"
-#include "casm/CasmReader.h"
-#include "casm/CasmWriter.h"
-#endif
 #include "sexp/Ast.h"
 #include "sexp/TextWriter.h"
 #include "sexp-parser/Driver.h"
@@ -43,8 +38,11 @@ using namespace utils;
 
 namespace {
 
-static charstring LocalName = "Local_";
-static charstring FuncName = "Func_";
+charstring LocalName = "Local_";
+charstring FuncName = "Func_";
+
+bool GenerateEnum = false;
+bool GenerateFunction = false;
 
 constexpr size_t WorkBufferSize = 128;
 typedef char BufferType[WorkBufferSize];
@@ -59,12 +57,12 @@ class CodeGenerator {
                 std::shared_ptr<RawStream> Output,
                 std::shared_ptr<SymbolTable> Symtab,
                 std::vector<charstring>& Namespaces,
-                charstring FunctionName)
+                charstring AlgName)
       : Filename(Filename),
         Output(Output),
         Symtab(Symtab),
         Namespaces(Namespaces),
-        FunctionName(FunctionName),
+        AlgName(AlgName),
         ErrorsFound(false),
         NextIndex(1) {}
   ~CodeGenerator() {}
@@ -80,7 +78,7 @@ class CodeGenerator {
   std::shared_ptr<ReadCursor> ReadPos;
   std::vector<charstring>& Namespaces;
   std::vector<const LiteralActionDefNode*> ActionDefs;
-  charstring FunctionName;
+  charstring AlgName;
   bool ErrorsFound;
   size_t NextIndex;
 
@@ -121,7 +119,7 @@ class CodeGenerator {
   void generateReturnCreate(charstring NodeType);
   size_t generateBadLocal(const Node* Nd);
   void generateArrayName() {
-    puts(FunctionName);
+    puts(AlgName);
     puts("Array");
   }
 };
@@ -317,7 +315,7 @@ void CodeGenerator::collectActionDefs() {
 void CodeGenerator::generatePredefinedEnum() {
   collectActionDefs();
   puts("enum class Predefined");
-  puts(FunctionName);
+  puts(AlgName);
   puts(" : uint32_t {\n");
   bool IsFirst = true;
   for (const LiteralActionDefNode* Def : ActionDefs) {
@@ -336,7 +334,7 @@ void CodeGenerator::generatePredefinedEnum() {
       "};\n"
       "\n"
       "charstring getName(Predefined");
-  puts(FunctionName);
+  puts(AlgName);
   puts(
       " Value);\n"
       "\n");
@@ -347,7 +345,7 @@ void CodeGenerator::generatePredefinedEnumNames() {
   puts(
       "struct {\n"
       "  Predefined");
-  puts(FunctionName);
+  puts(AlgName);
   puts(
       " Value;\n"
       "  charstring Name;\n"
@@ -359,7 +357,7 @@ void CodeGenerator::generatePredefinedEnumNames() {
     else
       puts(",\n");
     puts("  {Predefined");
-    puts(FunctionName);
+    puts(AlgName);
     puts("::");
     putSymbol(getActionDefName(Def).c_str());
     puts(", \"");
@@ -374,7 +372,7 @@ void CodeGenerator::generatePredefinedEnumNames() {
 
 void CodeGenerator::generatePredefinedNameFcn() {
   puts("charstring getName(Predefined");
-  puts(FunctionName);
+  puts(AlgName);
   puts(
       " Value) {\n"
       "  for (size_t i = 0; i < size(PredefinedNames); ++i) {\n"
@@ -388,7 +386,7 @@ void CodeGenerator::generatePredefinedNameFcn() {
 
 void CodeGenerator::generateAlgorithmHeader() {
   puts("std::shared_ptr<filt::SymbolTable> get");
-  puts(FunctionName);
+  puts(AlgName);
   puts("Symtab()");
 }
 
@@ -681,9 +679,12 @@ size_t CodeGenerator::generateNode(const Node* Nd) {
 void CodeGenerator::generateDeclFile() {
   generateHeader();
   generateEnterNamespaces();
-  generatePredefinedEnum();
-  generateAlgorithmHeader();
-  puts(";\n\n");
+  if (GenerateEnum)
+    generatePredefinedEnum();
+  if (GenerateFunction) {
+    generateAlgorithmHeader();
+    puts(";\n\n");
+  }
   generateExitNamespaces();
 }
 
@@ -803,20 +804,25 @@ void CodeGenerator::generateImplFile(bool UseArrayImpl) {
   generateEnterNamespaces();
   // Note: We don't know the include path for the enum, so just repeat
   // generating it.
-  generatePredefinedEnum();
-  puts(
-      "using namespace wasm::filt;\n"
-      "\n"
-      "namespace {\n"
-      "\n");
-  generatePredefinedEnumNames();
+  if (GenerateEnum) {
+    generatePredefinedEnum();
+    puts(
+        "using namespace wasm::filt;\n"
+        "\n"
+        "namespace {\n"
+        "\n");
+    generatePredefinedEnumNames();
+  }
+  if (GenerateFunction) {
 #if WASM_CAST_BOOT > 1
-  if (UseArrayImpl)
-    generateArrayImplFile();
-  else
+    if (UseArrayImpl)
+      generateArrayImplFile();
+    else
 #endif
-    generateFunctionImplFile();
-  generatePredefinedNameFcn();
+      generateFunctionImplFile();
+  }
+  if (GenerateEnum)
+    generatePredefinedNameFcn();
   generateExitNamespaces();
 }
 
@@ -853,7 +859,7 @@ using namespace wasm::utils;
 
 int main(int Argc, charstring Argv[]) {
   charstring AlgorithmFilename = nullptr;
-  charstring FunctionName = nullptr;
+  charstring AlgName = nullptr;
   charstring OutputFilename = "-";
   charstring InputFilename = "-";
   std::set<std::string> KeepActions;
@@ -893,18 +899,26 @@ int main(int Argc, charstring Argv[]) {
 
     ArgsParser::Optional<bool> ExpectFailFlag(ExpectExitFail);
     Args.add(ExpectFailFlag.setDefault(false)
-
                  .setLongName("expect-fail")
                  .setDescription("Succeed on failure/fail on success"));
 
-    ArgsParser::Optional<charstring> FunctionNameFlag(FunctionName);
-    Args.add(FunctionNameFlag.setShortName('f')
-                 .setLongName("function")
+    ArgsParser::Optional<bool> GenerateEnumFlag(GenerateEnum);
+    Args.add(GenerateEnumFlag.setLongName("enum").setDescription(
+        "Generate C++ source code implementing an enum for actions"));
+
+    ArgsParser::Optional<bool> GenerateFunctionFlag(GenerateFunction);
+    Args.add(GenerateFunctionFlag.setLongName("function")
+                 .setDescription(
+                     "Generate C++ source code implementing algorithm creation "
+                     "function"));
+
+    ArgsParser::Optional<charstring> AlgNameFlag(AlgName);
+    Args.add(AlgNameFlag.setShortName('f')
+                 .setLongName("name")
                  .setOptionName("NAME")
                  .setDescription(
-                     "Generate c++ source code to implement a function "
-                     "'void NAME(std::shared_ptr<SymbolTable>) to install "
-                     "the INPUT cast algorithm"));
+                     "The name prefix used to generate the name of C++ "
+                     "generated enum and/or function"));
 
     ArgsParser::Optional<bool> HeaderFileFlag(HeaderFile);
     Args.add(HeaderFileFlag.setLongName("header").setDescription(
@@ -1046,7 +1060,7 @@ int main(int Argc, charstring Argv[]) {
       TraceWrite = true;
     // TODO(karlschimpf) Extend ArgsParser to be able to return option
     // name so that we don't have hard-coded dependency.
-    if (UseArrayImpl && FunctionName == nullptr) {
+    if (UseArrayImpl && AlgName == nullptr) {
       fprintf(stderr, "Option --array can't be used without option -f\n");
       return exit_status(EXIT_FAILURE);
     }
@@ -1104,7 +1118,7 @@ int main(int Argc, charstring Argv[]) {
     }
 #if WASM_CAST_BOOT > 1
   } else {
-    AlgSymtab = getAlgcasm0x0Symtab();
+    AlgSymtab = WASM_CASM_GET_SYMTAB();
 #endif
   }
 
@@ -1123,7 +1137,7 @@ int main(int Argc, charstring Argv[]) {
 
   std::shared_ptr<Queue> OutputStream;
   std::shared_ptr<ReadCursor> OutputStartPos;
-  if (FunctionName != nullptr) {
+  if (AlgName != nullptr) {
 #if WASM_CAST_BOOT > 1
     if (UseArrayImpl) {
       OutputStream = std::make_shared<Queue>();
@@ -1152,7 +1166,7 @@ int main(int Argc, charstring Argv[]) {
   }
 #endif
 
-  if (FunctionName == nullptr)
+  if (AlgName == nullptr)
     return exit_status(EXIT_SUCCESS);
 
   // Generate C++ code.
@@ -1160,7 +1174,7 @@ int main(int Argc, charstring Argv[]) {
   Namespaces.push_back("wasm");
   Namespaces.push_back("decode");
   CodeGenerator Generator(InputFilename, Output, InputSymtab, Namespaces,
-                          FunctionName);
+                          AlgName);
   if (HeaderFile)
     Generator.generateDeclFile();
   else {

--- a/src/intcomp/AbbreviationCodegen.cpp
+++ b/src/intcomp/AbbreviationCodegen.cpp
@@ -32,11 +32,13 @@ namespace intcomp {
 AbbreviationCodegen::AbbreviationCodegen(CountNode::RootPtr Root,
                                          HuffmanEncoder::NodePtr EncodingRoot,
                                          IntTypeFormat AbbrevFormat,
-                                         CountNode::PtrSet& Assignments)
+                                         CountNode::PtrSet& Assignments,
+                                         bool ToRead)
     : Root(Root),
       EncodingRoot(EncodingRoot),
       AbbrevFormat(AbbrevFormat),
-      Assignments(Assignments) {
+      Assignments(Assignments),
+      ToRead(ToRead) {
 }
 
 Node* AbbreviationCodegen::generateFileHeader(uint32_t MagicNumber,
@@ -197,8 +199,7 @@ Node* AbbreviationCodegen::generateIntLitActionWrite(IntCountNode* Nd) {
   return Symtab->create<VoidNode>();
 }
 
-std::shared_ptr<SymbolTable> AbbreviationCodegen::getCodeSymtab(bool ToRead) {
-  this->ToRead = ToRead;
+std::shared_ptr<SymbolTable> AbbreviationCodegen::getCodeSymtab() {
   Symtab = std::make_shared<SymbolTable>();
   generateFile(generateFileHeader(CasmBinaryMagic, CasmBinaryVersion),
                generateFileHeader(WasmBinaryMagic, WasmBinaryVersionD));

--- a/src/intcomp/AbbreviationCodegen.h
+++ b/src/intcomp/AbbreviationCodegen.h
@@ -35,10 +35,11 @@ class AbbreviationCodegen {
   AbbreviationCodegen(CountNode::RootPtr Root,
                       utils::HuffmanEncoder::NodePtr EncodingRoot,
                       interp::IntTypeFormat AbbrevFormat,
-                      CountNode::PtrSet& Assignments);
+                      CountNode::PtrSet& Assignments,
+                      bool ToRead);
   ~AbbreviationCodegen();
 
-  std::shared_ptr<filt::SymbolTable> getCodeSymtab(bool ToRead);
+  std::shared_ptr<filt::SymbolTable> getCodeSymtab();
 
  private:
   std::shared_ptr<filt::SymbolTable> Symtab;
@@ -47,6 +48,7 @@ class AbbreviationCodegen {
   interp::IntTypeFormat AbbrevFormat;
   CountNode::PtrSet& Assignments;
   bool ToRead;
+
   filt::Node* generateFileHeader(uint32_t MagicNumber, uint32_t VersionNumber);
   void generateFile(filt::Node* SourceHeader, filt::Node* TargetHeader);
   filt::Node* generateFileBody();

--- a/src/intcomp/CompressionFlags.cpp
+++ b/src/intcomp/CompressionFlags.cpp
@@ -48,6 +48,7 @@ CompressionFlags::CompressionFlags()
       TrimOverriddenPatterns(false),
       BitCompressOpcodes(false),
       ReassignAbbreviations(true),
+      UseCismModel(false),
       DefaultFormat(IntTypeFormat::Varint64),
       LoopSizeFormat(IntTypeFormat::Varuint64),
       TraceHuffmanAssignments(false),

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -58,6 +58,7 @@ struct CompressionFlags {
   bool TrimOverriddenPatterns;
   bool BitCompressOpcodes;
   bool ReassignAbbreviations;
+  bool UseCismModel;
   interp::IntTypeFormat DefaultFormat;
   interp::IntTypeFormat LoopSizeFormat;
 

--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -245,8 +245,8 @@ std::shared_ptr<SymbolTable> IntCompressor::generateCode(
     bool Trace) {
   TRACE_METHOD("generateCode");
   AbbreviationCodegen Codegen(Root, EncodingRoot, MyFlags.AbbrevFormat,
-                              Assignments);
-  std::shared_ptr<SymbolTable> Symtab = Codegen.getCodeSymtab(ToRead);
+                              Assignments, ToRead);
+  std::shared_ptr<SymbolTable> Symtab = Codegen.getCodeSymtab();
   if (Trace) {
     TextWriter Writer;
     Writer.write(stderr, Symtab->getInstalledRoot());

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -1029,8 +1029,8 @@ Node* SymbolTable::stripCallbacksExcept(std::set<std::string>& KeepActions,
 }
 
 void SymbolTable::stripLiterals() {
-  install(dyn_cast<FileNode>(
-      stripLiteralDefs(dyn_cast<FileNode>(stripLiteralUses(Root)))));
+  stripLiteralUses();
+  stripLiteralDefs();
 }
 
 void SymbolTable::stripLiteralUses() {
@@ -1038,7 +1038,9 @@ void SymbolTable::stripLiteralUses() {
 }
 
 void SymbolTable::stripLiteralDefs() {
-  install(dyn_cast<FileNode>(stripLiteralDefs(Root)));
+  SymbolSet DefSyms;
+  collectLiteralUseSymbols(DefSyms);
+  install(dyn_cast<FileNode>(stripLiteralDefs(Root, DefSyms)));
 }
 
 Node* SymbolTable::stripLiteralUses(Node* Root) {
@@ -1067,11 +1069,32 @@ Node* SymbolTable::stripLiteralUses(Node* Root) {
   return create<VoidNode>();
 }
 
-Node* SymbolTable::stripLiteralDefs(Node* Root) {
+void SymbolTable::collectLiteralUseSymbols(SymbolSet& Symbols) {
+  ConstNodeVectorType ToVisit;
+  ToVisit.push_back(Root);
+  while (!ToVisit.empty()) {
+    const Node* Nd = ToVisit.back();
+    ToVisit.pop_back();
+    for (const Node* Kid : *Nd)
+      ToVisit.push_back(Kid);
+    const auto* Use = dyn_cast<LiteralUseNode>(Nd);
+    if (Use == nullptr)
+      continue;
+    const Node* Sym = Use->getKid(0);
+    assert(isa<SymbolNode>(Sym));
+    Symbols.insert(cast<SymbolNode>(Sym));
+  }
+}
+
+Node* SymbolTable::stripLiteralDefs(Node* Root, SymbolSet& DefSyms) {
   switch (Root->getType()) {
     default:
       return stripUsing(
-          Root, [&](Node* Nd) -> Node* { return stripLiteralDefs(Nd); });
+          Root, [&](Node* Nd) -> Node* { return stripLiteralDefs(Nd, DefSyms); });
+    case OpLiteralDef:
+      if (DefSyms.count(dyn_cast<SymbolNode>(Root->getKid(0))))
+        return Root;
+      break;
     case OpLiteralActionDef:
       if (CallbackLiterals.count(cast<LiteralActionDefNode>(Root)))
         return Root;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -1089,8 +1089,9 @@ void SymbolTable::collectLiteralUseSymbols(SymbolSet& Symbols) {
 Node* SymbolTable::stripLiteralDefs(Node* Root, SymbolSet& DefSyms) {
   switch (Root->getType()) {
     default:
-      return stripUsing(
-          Root, [&](Node* Nd) -> Node* { return stripLiteralDefs(Nd, DefSyms); });
+      return stripUsing(Root, [&](Node* Nd) -> Node* {
+        return stripLiteralDefs(Nd, DefSyms);
+      });
     case OpLiteralDef:
       if (DefSyms.count(dyn_cast<SymbolNode>(Root->getKid(0))))
         return Root;

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -258,7 +258,8 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   Node* stripUsing(Node* Root, std::function<Node*(Node*)> stripKid);
   Node* stripCallbacksExcept(std::set<std::string>& KeepActions, Node* Root);
   Node* stripLiteralUses(Node* Root);
-  Node* stripLiteralDefs(Node* Root);
+  void collectLiteralUseSymbols(SymbolSet& Symbols);
+  Node* stripLiteralDefs(Node* Root, SymbolSet& DefSyms);
 };
 
 class Node {

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -337,7 +337,7 @@ void TextWriter::writeNodeAbbrev(const Node* Nd,
       if (ShowInternalStructure)
         break;
       writeNodeAbbrev(Nd->getKid(0), AddNewline, EmbedInParent);
-      break;
+      return;
   }
   Parenthesize _(this, Type, AddNewline);
   writeNodeKidsAbbrev(Nd, false);


### PR DESCRIPTION
Starts the process of simplifying (and reducing the size) of the boot steps.

Begins by separating the action enumerated type when generating source. This allows us in boot step 1 to generate the enums (even without the corresponding implementation) early so that we can compile the AST inflator for boot step 2.