### PR TITLE
Modify code to handle variable number of headers in an algorithm.

### DIFF
--- a/src/interp/DecompressSelector.cpp
+++ b/src/interp/DecompressSelector.cpp
@@ -121,8 +121,9 @@ bool DecompressSelector::resetAlgorithm(Interpreter* R) {
     return false;
   }
   std::shared_ptr<SymbolTable> Algorithm = State->Inflator->getSymtab();
-  Algorithm->setEnclosingScope(
-      State->MyInterpreter->getDefaultAlgorithm(Root->getReadHeader()));
+  constexpr bool UseEnclosing = true;
+  Algorithm->setEnclosingScope(State->MyInterpreter->getDefaultAlgorithm(
+      Root->getReadHeader(!UseEnclosing)));
   Algorithm->install(Root);
   State->AlgQueue.push(Algorithm);
   State->Inflator.reset();

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1220,10 +1220,12 @@ void Interpreter::algorithmResume() {
             break;
           case OpCase:  // Method::Eval
             switch (Frame.CallState) {
-              case State::Enter:
+              case State::Enter: {
                 Frame.CallState = State::Exit;
-                call(Method::Eval, Frame.CallModifier, Frame.Nd->getKid(1));
+                call(Method::Eval, Frame.CallModifier,
+                     cast<CaseNode>(Frame.Nd)->getCaseBody());
                 break;
+              }
               case State::Exit:
                 popAndReturn();
                 break;

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -1728,9 +1728,10 @@ const SectionNode* FileNode::getDeclarations() const {
   return cast<SectionNode>(Nd);
 }
 
-bool FileNode::validateNode(NodeVectorType &Parents) {
+bool FileNode::validateNode(NodeVectorType& Parents) {
   if (!Parents.empty()) {
-    fprintf(error(), "File nodes can only appear as a top-level s-expression\n");
+    fprintf(error(),
+            "File nodes can only appear as a top-level s-expression\n");
     errorDescribeNode("Bad file node", this);
     errorDescribeContext(Parents);
     return false;
@@ -1743,7 +1744,7 @@ bool FileNode::validateNode(NodeVectorType &Parents) {
     return false;
   }
   for (int i = 0; i < NumKids - 1; ++i) {
-    const Node *Nd = getKid(i);
+    const Node* Nd = getKid(i);
     switch (Nd->getType()) {
       case OpFileHeader:
       case OpVoid:

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -199,9 +199,11 @@
 #define CASE_DECLS                                                             \
   public:                                                                      \
     decode::IntType getValue() const { return Value; }                         \
+    const Node* getCaseBody() const { return CaseBody; }                       \
     bool validateNode(NodeVectorType &Parents) OVERRIDE;                       \
   private:                                                                     \
     decode::IntType Value;                                                     \
+    const Node* CaseBody;                                                      \
 
 //#define X(tag, NODE_DECLS)
 #define AST_SELECTNODE_TABLE                                                   \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -223,6 +223,8 @@
     const FileHeaderNode* getSourceHeader() const;                             \
     const FileHeaderNode* getReadHeader() const;                               \
     const FileHeaderNode* getWriteHeader() const;                              \
+    const SectionNode* getDeclarations() const;                                \
+    bool validateNode(NodeVectorType &Parents) OVERRIDE;                       \
 
 #define DEFINE_DECLS                                                           \
   public:                                                                      \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -222,9 +222,9 @@
 
 #define FILE_DECLS                                                             \
   public:                                                                      \
-    const FileHeaderNode* getSourceHeader() const;                             \
-    const FileHeaderNode* getReadHeader() const;                               \
-    const FileHeaderNode* getWriteHeader() const;                              \
+    const FileHeaderNode* getSourceHeader(bool UseEnclosing=true) const;       \
+    const FileHeaderNode* getReadHeader(bool UseEnclosing=true) const;         \
+    const FileHeaderNode* getWriteHeader(bool UseEnclosing=true) const;        \
     const SectionNode* getDeclarations() const;                                \
     bool validateNode(NodeVectorType &Parents) OVERRIDE;                       \
 

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -51,6 +51,7 @@ class SymbolDefnNode;
 class SymbolNode;
 class SymbolTable;
 class CallbackNode;
+class SectionNode;
 
 #define X(tag, format, defval, mergable, NODE_DECLS) class tag##Node;
 AST_INTEGERNODE_TABLE
@@ -292,7 +293,7 @@ class Node {
 
   virtual ~Node();
 
-  SymbolTable& getSymtab() { return Symtab; }
+  SymbolTable& getSymtab() const { return Symtab; }
   NodeType getRtClassId() const { return Type; }
   NodeType getType() const { return Type; }
   const char* getName() const;


### PR DESCRIPTION
Doesn't actually change algorithms (yet). Only modifies the code to handle it. Hence the next step is to actually remove trailing "(void)" headers.

Also speeds up the algorithm interpreter to jump from the selected case, to the corresponding s-expression the case is associated with. It also makes traces easier to read, since it no longer needs to cascade over nested cases.