### PR TITLE
Modify parser to handle missing headers.

### DIFF
--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -16,8 +16,8 @@
 # algorithm" ("CASM") files.
 
 (header (u32.const 0x6d736163) (u32.const 0x0))
-(void)
-(void)
+
+(declarations)
 
 (literal.action.base (u32.const 101))
 

--- a/src/algorithms/cism0x0.cast
+++ b/src/algorithms/cism0x0.cast
@@ -19,6 +19,8 @@
 (header (u32.const 0x6d736963) (u32.const 0x0))
 (void)
 
+(declarations)
+
 (literal.action.base (u32.const 5001))
 
 (define 'file' (params) (locals 1)

--- a/src/algorithms/wasm0xd.cast
+++ b/src/algorithms/wasm0xd.cast
@@ -19,6 +19,8 @@
 (header (u32.const 0x6d736100) (u32.const 0xd))
 (void)
 
+(declarations)
+
 (literal.action.base (u32.const 1001))
 
 #### WASM opcodes.

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -219,6 +219,7 @@ letter	[a-zA-Z]
 "block"           return Parser::make_BLOCK(Driver.getLoc());
 "bitwise"         return Parser::make_BITWISE(Driver.getLoc());
 "case"            return Parser::make_CASE(Driver.getLoc());
+"declarations"    return Parser::make_DECLARATIONS(Driver.getLoc());
 "define"          return Parser::make_DEFINE(Driver.getLoc());
 "error"           return Parser::make_ERROR(Driver.getLoc());
 "eval"            return Parser::make_EVAL(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -88,6 +88,7 @@ struct IntValue {
 %token CASE          "case"
 %token CLOSEPAREN    ")"
 %token COLON         ":"
+%token DECLARATIONS  "declarations"
 %token DEFINE        "define"
 %token DOT           "."
 %token DOUBLE_ARROW  "=>"
@@ -376,13 +377,31 @@ eval_args
 
 file
          : file_header file_header_optional file_header_optional section {
-           $$ = Driver.create<FileNode>();
-           $$->append($1);
-           $$->append($2);
-           $$->append($3);
-           $$->append($4);
-            Driver.setParsedAst($$);
-          }
+             $$ = Driver.create<FileNode>();
+             $$->append($1);
+             $$->append($2);
+             $$->append($3);
+             $$->append($4);
+             Driver.setParsedAst($$);
+           }
+         | file_header file_header_optional section {
+             $$ = Driver.create<FileNode>();
+             $$->append($1);
+             $$->append($2);
+             $$->append($3);
+             Driver.setParsedAst($$);
+           }
+         | file_header section {
+             $$ = Driver.create<FileNode>();
+             $$->append($1);
+             $$->append($2);
+             Driver.setParsedAst($$);
+           }
+         | section {
+             $$ = Driver.create<FileNode>();
+             $$->append($1);
+             Driver.setParsedAst($$);
+           }
         ;
 
 file_header
@@ -540,7 +559,7 @@ params_decl
         ;
 
 section
-        : %empty {
+        : "(" "declarations" ")"  {
             $$ = Driver.create<SectionNode>();
           }
           | section declaration { // defines etc.

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -95,7 +95,7 @@
   X(Define,            0x60, "define",           2, 1)                         \
   X(File,              0x62, "file",             2, 0)                         \
   X(FileHeader,        0x77, "header",           0, 3)                         \
-  X(Section,           0x63, "section",          0, 0)                         \
+  X(Section,           0x63, "declarations",     0, 0)                         \
   X(Undefine,          0x64, "undefine",         1, 0)                         \
   X(LiteralDef,        0x65, "literal",          2, 0)                         \
   X(LiteralUse,        0x66, "literal.use",      1, 0)                         \

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -239,6 +239,7 @@ void TextWriter::writeNode(const Node* Nd,
     case OpSection:
       if (ShowInternalStructure)
         break;
+      { Parenthesize _(this, Type, true); }
       for (auto* Kid : *Nd)
         writeNode(Kid, true, false);
       return;

--- a/test/test-sources/BinaryFormat.cast
+++ b/test/test-sources/BinaryFormat.cast
@@ -2,6 +2,8 @@
 (void)
 (void)
 
+(declarations)
+
 (define 'file' (params)
   (switch
     (opcode

--- a/test/test-sources/BinaryFormat.cast-out
+++ b/test/test-sources/BinaryFormat.cast-out
@@ -1,6 +1,7 @@
 (header (u32.const 0x6d736163) (u32.const 0x0))
 (void)
 (void)
+(declarations)
 (define 'file' (params)
   (switch
     (opcode

--- a/test/test-sources/ExprRedirects.cast
+++ b/test/test-sources/ExprRedirects.cast
@@ -19,6 +19,8 @@
 (void)
 (void)
 
+(declarations)
+
 (define 'code' (params)
    (read)
    (peek (uint8))

--- a/test/test-sources/ExprRedirects.cast-out
+++ b/test/test-sources/ExprRedirects.cast-out
@@ -1,6 +1,7 @@
 (header (u32.const 0x6d736163) (u32.const 0x0))
 (void)
 (void)
+(declarations)
 (define 'code' (params)
   (read)
   (peek (uint8))

--- a/test/test-sources/MismatchedParens.cast
+++ b/test/test-sources/MismatchedParens.cast
@@ -2,4 +2,6 @@
 (void)
 (void)
 
+(declarations)
+
 (define 'foo' (params) (void)))

--- a/test/test-sources/MismatchedParens.cast-out
+++ b/test/test-sources/MismatchedParens.cast-out
@@ -1,2 +1,2 @@
-error: 5.31: syntax error, unexpected ), expecting $END
+error: 7.31: syntax error, unexpected ), expecting $END
 Errors detected: test/test-sources/MismatchedParens.cast

--- a/test/test-sources/TableEx.cast
+++ b/test/test-sources/TableEx.cast
@@ -2,6 +2,8 @@
 (void)
 (void)
 
+(declarations)
+
 (define 'file' (params)
   (loop.unbounded
     (table (uint8)

--- a/test/test-sources/TableEx.cast-out
+++ b/test/test-sources/TableEx.cast-out
@@ -1,6 +1,7 @@
 (header (u32.const 0x6d736163) (u32.const 0x0))
 (void)
 (void)
+(declarations)
 (define 'file' (params)
   (loop.unbounded
     (table (uint8)

--- a/test/test-sources/Wasm0xd.cast
+++ b/test/test-sources/Wasm0xd.cast
@@ -19,6 +19,8 @@
 (header (u32.const 0x6d736100) (u32.const 0xd))
 (void)
 
+(declarations)
+
 #### WASM opcodes.
 
 (literal 'inst.unreachable'         (u8.const 0x00))

--- a/test/test-sources/Wasm0xd.cast-out
+++ b/test/test-sources/Wasm0xd.cast-out
@@ -1,6 +1,7 @@
 (header (u32.const 0x6d736163) (u32.const 0x0))
 (header (u32.const 0x6d736100) (u32.const 0xd))
 (void)
+(declarations)
 (literal 'inst.unreachable' (u8.const 0x0))
 (literal 'inst.nop' (u8.const 0x1))
 (literal 'inst.block' (u8.const 0x2))


### PR DESCRIPTION
Doesn't handle fact that flatter/inflate works (still assumes fixed number of headers).