### PR TITLE
Remove automatic install when reading/parsing an algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1313,12 +1313,12 @@ test-casm-cast: $(BUILD_EXECDIR)/cast2casm $(BUILD_EXECDIR)/casm2cast \
 .PHONY: test-casm-cast
 
 test-parser: $(TEST_EXECDIR)/TestParser
-	$< -w $(TEST_DEFAULT_CAST) | diff - $(TEST_DEFAULT_CAST_OUT)
+	$< -p $(TEST_DEFAULT_CAST) | diff - $(TEST_DEFAULT_CAST_OUT)
 	$< --expect-fail $(TEST_SRCS_DIR)/MismatchedParens.cast 2>&1 | \
 		diff - $(TEST_SRCS_DIR)/MismatchedParens.cast-out
-	$< -w $(TEST_SRCS_DIR)/ExprRedirects.cast | \
+	$< -p $(TEST_SRCS_DIR)/ExprRedirects.cast | \
 		diff - $(TEST_SRCS_DIR)/ExprRedirects.cast-out
-	$< -w $(TEST_SRCS_DIR)/BinaryFormat.cast | \
+	$< -p -v $(TEST_SRCS_DIR)/BinaryFormat.cast | \
 		diff - $(TEST_SRCS_DIR)/BinaryFormat.cast-out
 	@echo "*** parser tests passed ***"
 

--- a/src/binary/SectionSymbolTable.cpp
+++ b/src/binary/SectionSymbolTable.cpp
@@ -54,7 +54,8 @@ void SectionSymbolTable::clear() {
 }
 
 void SectionSymbolTable::install(FileNode* Root) {
-  Symtab->install(Root);
+  Symtab->setRoot(Root);
+  Symtab->install();
 }
 
 void SectionSymbolTable::installSymbols(const Node* Nd) {

--- a/src/casm/CasmWriter.cpp
+++ b/src/casm/CasmWriter.cpp
@@ -67,16 +67,12 @@ const BitWriteCursor& CasmWriter::writeBinary(
   auto StrmWriter = std::make_shared<ByteWriter>(Output);
   std::shared_ptr<Writer> Writer = StrmWriter;
   Writer->setMinimizeBlockSize(MinimizeBlockSize);
-#if 0
-  if (TraceTree)
-#else
-    // Inflate as written to verify tree written is correct!
-#endif
   {
+    // Inflate as written to verify tree written is correct!
     auto Tee = std::make_shared<TeeWriter>();
     auto Inflator = std::make_shared<InflateAst>();
     Inflator->setEnclosingScope(Symtab->getEnclosingScope());
-    Tee->add(Inflator, false, true, false);
+    Tee->add(Inflator, false, TraceTree, false);
     Tee->add(Writer, true, false, true);
     Writer = Tee;
   }

--- a/src/casm/CasmWriter.cpp
+++ b/src/casm/CasmWriter.cpp
@@ -67,9 +67,16 @@ const BitWriteCursor& CasmWriter::writeBinary(
   auto StrmWriter = std::make_shared<ByteWriter>(Output);
   std::shared_ptr<Writer> Writer = StrmWriter;
   Writer->setMinimizeBlockSize(MinimizeBlockSize);
-  if (TraceTree) {
+#if 0
+  if (TraceTree)
+#else
+    // Inflate as written to verify tree written is correct!
+#endif
+  {
     auto Tee = std::make_shared<TeeWriter>();
-    Tee->add(std::make_shared<InflateAst>(), false, true, false);
+    auto Inflator = std::make_shared<InflateAst>();
+    Inflator->setEnclosingScope(Symtab->getEnclosingScope());
+    Tee->add(Inflator, false, true, false);
     Tee->add(Writer, true, false, true);
     Writer = Tee;
   }

--- a/src/casm/InflateAst.cpp
+++ b/src/casm/InflateAst.cpp
@@ -273,8 +273,9 @@ bool InflateAst::applyOp(IntType Op) {
       FileNode* File = buildNary<FileNode>() ? getGeneratedFile() : nullptr;
       if (File == nullptr)
         return failBuild("InflateAst", "Did not generate a file node");
+      Symtab->setRoot(File);
       if (InstallDuringInflation)
-        Symtab->install(File);
+        Symtab->install();
       return true;
     }
     case OpSequence:

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -823,10 +823,11 @@ void CodeGenerator::generateFunctionImplFile() {
       "    return Symtable;\n"
       "  Symtable = std::make_shared<SymbolTable>();\n"
       "  SymbolTable* Symtab = Symtable.get();\n"
-      "  Symtab->install(");
+      "  Symtab->setRoot(");
   generateFunctionCall(Index);
   puts(
       ");\n"
+      "  Symtab->install();\n"
       "  return Symtable;\n");
   generateFunctionFooter();
 }
@@ -895,6 +896,18 @@ std::shared_ptr<SymbolTable> readCasmFile(
   return Symtab;
 }
 
+bool installRoot(SymbolTable::SharedPtr Symtab, bool Display, const char* Title) {
+  if (Display) {
+    fprintf(stdout, "After stripping %s:\n", Title);
+    TextWriter Writer;
+    Writer.write(stdout, Symtab->getRoot());
+  }
+  bool Success = Symtab->install();
+  if (!Success)
+    fprintf(stderr, "Problems stripping %s, can't continue.\n", Title);
+  return Success;
+}
+
 }  // end of anonymous namespace
 
 }  // end of namespace wasm;
@@ -912,6 +925,7 @@ int main(int Argc, charstring Argv[]) {
   std::set<std::string> KeepActions;
   bool DisplayParsedInput = false;
   bool DisplayStrippedInput = false;
+  bool DisplayStripAll = false;
   bool ShowInternalStructure = false;
   bool StripActions = false;
   bool StripSymbolicActions = false;
@@ -1012,11 +1026,17 @@ int main(int Argc, charstring Argv[]) {
                  .setDescription("Generated binary file"));
 
     ArgsParser::Toggle DisplayParsedInputFlag(DisplayParsedInput);
-    Args.add(DisplayParsedInputFlag.setLongName("display=input")
+    Args.add(DisplayParsedInputFlag.setShortName('d').setLongName("display=input")
                  .setDescription("Display parsed cast text"));
 
     ArgsParser::Toggle DisplayStrippedInputFlag(DisplayStrippedInput);
     Args.add(DisplayStrippedInputFlag.setLongName("display=stripped")
+                 .setDescription(
+                     "Display parsed cast text after all strip "
+                     "operations"));
+
+    ArgsParser::Toggle DisplayStripAllFlag(DisplayStripAll);
+    Args.add(DisplayStripAllFlag.setLongName("display=strip-all")
                  .setDescription(
                      "Display parsed cast text after each strip "
                      "operation"));
@@ -1136,7 +1156,7 @@ int main(int Argc, charstring Argv[]) {
     if (InputFilenames.empty())
       InputFilenames.push_back("-");
 
-#if WASM_CAST_BOOT < 3
+#if WASM_CAST_BOOT < 2
     if (AlgorithmFilenames.empty() && !DisplayParsedInput) {
       fprintf(stderr, "No algorithm files specified, can't continue\n");
       return exit_status(EXIT_FAILURE);
@@ -1167,36 +1187,56 @@ int main(int Argc, charstring Argv[]) {
     if (Verbose)
       fprintf(stderr, "Reading input: %s\n", InputFilename);
     InputSymtab = readCasmFile(Filename, TraceLexer, TraceParser, InputSymtab);
-    if (!InputSymtab) {
+    if (!InputSymtab || !InputSymtab->install()) {
       fprintf(stderr, "Unable to parse: %s\n", InputFilename);
       return exit_status(EXIT_FAILURE);
     }
   }
 
   if (DisplayParsedInput) {
-    fprintf(stderr, "Parsed input:\n");
-    InputSymtab->describe(stderr, ShowInternalStructure);
-    if (!DisplayStrippedInput)
+    if (Verbose)
+      fprintf(stdout, "Parsed input:\n");
+    InputSymtab->describe(stdout, ShowInternalStructure);
+    if (!(DisplayStrippedInput || DisplayStripAll))
       return exit_status(EXIT_SUCCESS);
   }
 
-  if (StripActions)
+  if (StripActions) {
     InputSymtab->stripCallbacksExcept(KeepActions);
+    if (!installRoot(InputSymtab, DisplayStripAll, "actions"))
+      return exit_status(EXIT_FAILURE);
+  }
 
-  if (StripSymbolicActions)
+  if (StripSymbolicActions) {
     InputSymtab->stripSymbolicCallbacks();
+    if (!installRoot(InputSymtab, DisplayStripAll, "symbolic actions"))
+      return exit_status(EXIT_FAILURE);
+  }
 
-  if (StripLiteralUses)
+  if (StripLiteralUses) {
     InputSymtab->stripLiteralUses();
+    if (!installRoot(InputSymtab, DisplayStripAll, "literal uses"))
+      return exit_status(EXIT_FAILURE);
+  }
 
-  if (StripLiteralDefs)
+  if (StripLiteralDefs) {
     InputSymtab->stripLiteralDefs();
+    if (!installRoot(InputSymtab, DisplayStripAll, "literal definitions"))
+      return exit_status(EXIT_FAILURE);
+  }
 
-  if (StripLiterals)
+  if (StripLiterals) {
     InputSymtab->stripLiterals();
+    if (!installRoot(InputSymtab, DisplayStripAll, "literals"))
+      return exit_status(EXIT_FAILURE);
+  }
 
-  if (DisplayStrippedInput) {
-    InputSymtab->describe(stdout, ShowInternalStructure);
+  if (DisplayParsedInput || DisplayStrippedInput || DisplayStripAll) {
+    if (DisplayStrippedInput && !DisplayStripAll) {
+      if (Verbose)
+        fprintf(stdout, "Stripped input:\n");
+      InputSymtab->describe(stdout, ShowInternalStructure);
+    }
     return exit_status(EXIT_SUCCESS);
   }
 
@@ -1205,14 +1245,15 @@ int main(int Argc, charstring Argv[]) {
     if (Verbose)
       fprintf(stderr, "Reading algorithm file: %s\n", Filename);
     AlgSymtab = readCasmFile(Filename, TraceLexer, TraceParser, AlgSymtab);
-    if (!AlgSymtab) {
+    if (!AlgSymtab || !AlgSymtab->install()) {
       fprintf(stderr, "Problems reading file: %s\n", Filename);
       return exit_status(EXIT_FAILURE);
     }
   }
 #if WASM_CAST_BOOT > 1
   if (AlgorithmFilenames.empty()) {
-    fprintf(stderr, "Using prebuilt casm algorithm\n");
+    if (Verbose)
+      fprintf(stderr, "Using prebuilt casm algorithm\n");
     AlgSymtab = WASM_CASM_GET_SYMTAB();
   }
 #endif

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -896,7 +896,9 @@ std::shared_ptr<SymbolTable> readCasmFile(
   return Symtab;
 }
 
-bool installRoot(SymbolTable::SharedPtr Symtab, bool Display, const char* Title) {
+bool installRoot(SymbolTable::SharedPtr Symtab,
+                 bool Display,
+                 const char* Title) {
   if (Display) {
     fprintf(stdout, "After stripping %s:\n", Title);
     TextWriter Writer;
@@ -1026,7 +1028,8 @@ int main(int Argc, charstring Argv[]) {
                  .setDescription("Generated binary file"));
 
     ArgsParser::Toggle DisplayParsedInputFlag(DisplayParsedInput);
-    Args.add(DisplayParsedInputFlag.setShortName('d').setLongName("display=input")
+    Args.add(DisplayParsedInputFlag.setShortName('d')
+                 .setLongName("display=input")
                  .setDescription("Display parsed cast text"));
 
     ArgsParser::Toggle DisplayStrippedInputFlag(DisplayStrippedInput);

--- a/src/intcomp/AbbreviationCodegen.cpp
+++ b/src/intcomp/AbbreviationCodegen.cpp
@@ -57,7 +57,8 @@ void AbbreviationCodegen::generateFile(Node* SourceHeader, Node* TargetHeader) {
   File->append(TargetHeader);
   File->append(Symtab->create<VoidNode>());
   File->append(generateFileBody());
-  Symtab->install(File);
+  Symtab->setRoot(File);
+  Symtab->install();
 }
 
 AbbreviationCodegen::~AbbreviationCodegen() {

--- a/src/interp/DecompressSelector.cpp
+++ b/src/interp/DecompressSelector.cpp
@@ -124,7 +124,7 @@ bool DecompressSelector::resetAlgorithm(Interpreter* R) {
   constexpr bool UseEnclosing = true;
   Algorithm->setEnclosingScope(State->MyInterpreter->getDefaultAlgorithm(
       Root->getReadHeader(!UseEnclosing)));
-  Algorithm->install(Root);
+  Algorithm->install();
   State->AlgQueue.push(Algorithm);
   State->Inflator.reset();
   return true;

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1588,9 +1588,8 @@ void Interpreter::algorithmResume() {
             if (!Output->writeHeaderClose())
               return fail("Unable to write header");
             SymbolNode* File = Symtab->getPredefined(PredefinedSymbol::File);
-            if (File == nullptr) {
+            if (File == nullptr)
               throwMessage("Can't find sexpression to process file");
-            }
             const Node* FileDefn = File->getDefineDefinition();
             if (FileDefn == nullptr)
               throwMessage("Can't find sexpression to process file");

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1588,8 +1588,9 @@ void Interpreter::algorithmResume() {
             if (!Output->writeHeaderClose())
               return fail("Unable to write header");
             SymbolNode* File = Symtab->getPredefined(PredefinedSymbol::File);
-            if (File == nullptr)
+            if (File == nullptr) {
               throwMessage("Can't find sexpression to process file");
+            }
             const Node* FileDefn = File->getDefineDefinition();
             if (FileDefn == nullptr)
               throwMessage("Can't find sexpression to process file");

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -102,9 +102,13 @@ class Driver {
   // Returns the last parsed ast.
   Node* getParsedAst() const { return ParsedAst; }
 
+  SymbolTable::SharedPtr getSymbolTable() const { return Table; }
+
+  bool install() { return Table->install(); }
+
   void setParsedAst(Node* Ast) {
     ParsedAst = Ast;
-    Table->install(dyn_cast<FileNode>(ParsedAst));
+    Table->setRoot(dyn_cast<FileNode>(ParsedAst));
   }
 
   // Error handling.

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -138,6 +138,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   SymbolTable& operator=(const SymbolTable&) = delete;
 
  public:
+  typedef std::shared_ptr<SymbolTable> SharedPtr;
   typedef std::unordered_set<const SymbolNode*> SymbolSet;
   typedef std::unordered_set<const IntegerNode*> ActionValueSet;
   typedef std::unordered_set<const LiteralActionDefNode*> ActionDefSet;
@@ -145,9 +146,9 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   explicit SymbolTable();
   explicit SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope);
   ~SymbolTable();
-  SymbolTable* getEnclosingScope() { return EnclosingScope.get(); }
-  void setEnclosingScope(std::shared_ptr<SymbolTable> Value) {
-    EnclosingScope = Value;
+  SharedPtr getEnclosingScope() { return EnclosingScope; }
+  void setEnclosingScope(SharedPtr Symtab) {
+    EnclosingScope = Symtab;
   }
   // Gets existing symbol if known. Otherwise returns nullptr.
   SymbolNode* getSymbol(const std::string& Name);
@@ -175,8 +176,11 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   // Gets actions corresponding to enter/exit block.
   const CallbackNode* getBlockEnterCallback();
   const CallbackNode* getBlockExitCallback();
+  const FileNode* getRoot() const { return Root; }
+  void setRoot(FileNode* NewRoot);
   // Install definitions in tree defined by root.
-  void install(FileNode* Root);
+  bool install();
+  bool isRootInstalled() const { return RootInstalled; }
   const FileNode* getInstalledRoot() const { return Root; }
   Node* getError() const { return Error; }
   const FileHeaderNode* getSourceHeader() const;
@@ -239,6 +243,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   std::vector<Node*> Allocated;
   std::shared_ptr<utils::TraceClass> Trace;
   FileNode* Root;
+  bool RootInstalled;
   Node* Error;
   int NextCreationIndex;
   decode::IntType ActionBase;

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -147,9 +147,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   explicit SymbolTable(std::shared_ptr<SymbolTable> EnclosingScope);
   ~SymbolTable();
   SharedPtr getEnclosingScope() { return EnclosingScope; }
-  void setEnclosingScope(SharedPtr Symtab) {
-    EnclosingScope = Symtab;
-  }
+  void setEnclosingScope(SharedPtr Symtab) { EnclosingScope = Symtab; }
   // Gets existing symbol if known. Otherwise returns nullptr.
   SymbolNode* getSymbol(const std::string& Name);
   // Returns the corresponding symbol for the predefined symbol (creates if

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -110,12 +110,12 @@ void TextWriter::writeName(NodeType Type) {
 
 void TextWriter::write(FILE* File, SymbolTable* Symtab) {
   write(File, Symtab->getInstalledRoot());
-  Symtab = Symtab->getEnclosingScope();
+  Symtab = Symtab->getEnclosingScope().get();
   while (Symtab != nullptr) {
     writeIndent();
     fprintf(File, "Enclosing scope:\n");
     write(File, Symtab->getInstalledRoot());
-    Symtab = Symtab->getEnclosingScope();
+    Symtab = Symtab->getEnclosingScope().get();
   }
 }
 

--- a/src/test/TestParser.cpp
+++ b/src/test/TestParser.cpp
@@ -68,7 +68,7 @@ int main(int Argc, char* Argv[]) {
     if (Files.size() > 1) {
       fprintf(stdout, "Parsing: %s...\n", Filename);
     }
-    if (!Driver.parse(Filename)) {
+    if (!Driver.parse(Filename) || !Driver.install()) {
       fprintf(stderr, "Errors detected: %s\n", Filename);
       return exit_status(EXIT_FAILURE);
     }

--- a/src/utils/ArgsParse.cpp
+++ b/src/utils/ArgsParse.cpp
@@ -521,6 +521,8 @@ void ArgsParser::showUsage() {
   for (Arg* A : PlacementArgs) {
     printDescriptionContinue(stderr, TabWidth, Indent, " ");
     printDescriptionContinue(stderr, TabWidth, Indent, A->getOptionName());
+    if (A->isRepeatable())
+      printDescriptionContinue(stderr, TabWidth, Indent, " ...");
   }
   writeNewline(stderr, Indent);
   if (Description != nullptr) {

--- a/src/utils/ArgsParse.h
+++ b/src/utils/ArgsParse.h
@@ -69,6 +69,8 @@ class ArgsParser {
       Description = NewValue;
       return *this;
     }
+
+    bool isRepeatable() const { return IsRepeatable; }
     bool getOptionFound() const { return OptionFound; }
     virtual void setOptionFound();
     virtual void setPlacementFound(size_t& CurPlacement);

--- a/test/test-sources/MismatchedParens.cast-out
+++ b/test/test-sources/MismatchedParens.cast-out
@@ -1,2 +1,2 @@
 error: 7.31: syntax error, unexpected ), expecting $END
-Errors detected: test/test-sources/MismatchedParens.cast
+Errors detected while parsing: test/test-sources/MismatchedParens.cast


### PR DESCRIPTION
This fixes the problem that algorithms are now in multiple files. Hence, they can't be automatically installed (i.e. validated) in isolation. Rather, the corresponding enclosing algorithms must be injected before an algorithm is installed.

We also generalize the test parser to allow multiple algorithm files, and validation (i.e. installing) controllable via a command line argument.