### PR TITLE
Remove inflating from writing a casm file.

### DIFF
--- a/src/casm/CasmWriter.cpp
+++ b/src/casm/CasmWriter.cpp
@@ -41,6 +41,7 @@ CasmWriter::CasmWriter()
       FreezeEofAtExit(true),
       ErrorsFound(false),
       BitCompress(false),
+      ValidateWhileWriting(false),
       TraceWriter(false),
       TraceFlatten(false),
       TraceTree(false) {
@@ -67,7 +68,7 @@ const BitWriteCursor& CasmWriter::writeBinary(
   auto StrmWriter = std::make_shared<ByteWriter>(Output);
   std::shared_ptr<Writer> Writer = StrmWriter;
   Writer->setMinimizeBlockSize(MinimizeBlockSize);
-  {
+  if (TraceTree || ValidateWhileWriting) {
     // Inflate as written to verify tree written is correct!
     auto Tee = std::make_shared<TeeWriter>();
     auto Inflator = std::make_shared<InflateAst>();

--- a/src/casm/CasmWriter.h
+++ b/src/casm/CasmWriter.h
@@ -75,6 +75,11 @@ class CasmWriter {
     return *this;
   }
 
+  CasmWriter& setValidateWhileWriting(bool Value) {
+    ValidateWhileWriting = Value;
+    return *this;
+  }
+
   CasmWriter& setTraceWriter(bool Value) {
     TraceWriter = Value;
     return *this;
@@ -95,6 +100,7 @@ class CasmWriter {
   bool FreezeEofAtExit;
   bool ErrorsFound;
   bool BitCompress;
+  bool ValidateWhileWriting;
   bool TraceWriter;
   bool TraceFlatten;
   bool TraceTree;

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -948,6 +948,7 @@ int main(int Argc, charstring Argv[]) {
   bool TraceWrite = false;
   bool TraceTree = false;
   bool UseArrayImpl = false;
+  bool ValidateWhileWriting = false;
 #endif
 
   {
@@ -1136,6 +1137,13 @@ int main(int Argc, charstring Argv[]) {
         "array implementation, rather than the default that "
         "uses direct code"));
 
+    ArgsParser::Toggle ValidateWhileWritingFlag(ValidateWhileWriting);
+    Args.add(
+        ValidateWhileWritingFlag.setLongName("validate")
+        .setDescription(
+            "While writing, validate that it is readable. Useful "
+            "when writing new algorithms to parse algorithms."));
+
 #endif
 
     switch (Args.parse(Argc, Argv)) {
@@ -1297,8 +1305,9 @@ int main(int Argc, charstring Argv[]) {
         .setTraceFlatten(TraceFlatten)
         .setTraceTree(TraceTree)
         .setMinimizeBlockSize(MinimizeBlockSize)
-        .setBitCompress(BitCompress);
-    Writer.writeBinary(InputSymtab, OutputStream, AlgSymtab);
+        .setBitCompress(BitCompress)
+        .setValidateWhileWriting(ValidateWhileWriting)
+        .writeBinary(InputSymtab, OutputStream, AlgSymtab);
     if (Writer.hasErrors()) {
       fprintf(stderr, "Problems writing: %s\n", OutputFilename);
       return exit_status(EXIT_FAILURE);


### PR DESCRIPTION
The code used to do unnecessary work when writing a CASM file by inflating the written AST at the same time. This should only be done when either tracing (a casm write), or when testing cast2casm when the input file is an algorithm to parse algorithms.

In the latter case, the check makes testing simpler by reporting errors when written, rather than waiting till it is reread (using casm2cast) and having to coordinate where in the write, the corresponding read error occurs.