### PR TITLE
Make CAST parser understand enclosing algorithm directive.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1318,7 +1318,7 @@ test-parser: $(TEST_EXECDIR)/TestParser
 		diff - $(TEST_SRCS_DIR)/MismatchedParens.cast-out
 	$< -p $(TEST_SRCS_DIR)/ExprRedirects.cast | \
 		diff - $(TEST_SRCS_DIR)/ExprRedirects.cast-out
-	$< -p -v $(TEST_SRCS_DIR)/BinaryFormat.cast | \
+	$< -p --validate $(TEST_SRCS_DIR)/BinaryFormat.cast | \
 		diff - $(TEST_SRCS_DIR)/BinaryFormat.cast-out
 	@echo "*** parser tests passed ***"
 

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -1140,11 +1140,10 @@ int main(int Argc, charstring Argv[]) {
         "uses direct code"));
 
     ArgsParser::Toggle ValidateWhileWritingFlag(ValidateWhileWriting);
-    Args.add(
-        ValidateWhileWritingFlag.setLongName("validate")
-        .setDescription(
-            "While writing, validate that it is readable. Useful "
-            "when writing new algorithms to parse algorithms."));
+    Args.add(ValidateWhileWritingFlag.setLongName("validate")
+                 .setDescription(
+                     "While writing, validate that it is readable. Useful "
+                     "when writing new algorithms to parse algorithms."));
 
 #endif
 
@@ -1197,7 +1196,8 @@ int main(int Argc, charstring Argv[]) {
   charstring InputFilename = "-";
   for (charstring Filename : InputFilenames) {
     InputFilename = Filename;
-    InputSymtab = readCasmFile(Filename, Verbose, TraceLexer, TraceParser, InputSymtab);
+    InputSymtab =
+        readCasmFile(Filename, Verbose, TraceLexer, TraceParser, InputSymtab);
     if (!InputSymtab || !InputSymtab->install()) {
       fprintf(stderr, "Unable to parse: %s\n", InputFilename);
       return exit_status(EXIT_FAILURE);
@@ -1253,7 +1253,8 @@ int main(int Argc, charstring Argv[]) {
 
   std::shared_ptr<SymbolTable> AlgSymtab;
   for (charstring Filename : AlgorithmFilenames) {
-    AlgSymtab = readCasmFile(Filename, Verbose, TraceLexer, TraceParser, AlgSymtab);
+    AlgSymtab =
+        readCasmFile(Filename, Verbose, TraceLexer, TraceParser, AlgSymtab);
     if (!AlgSymtab || !AlgSymtab->install()) {
       fprintf(stderr, "Problems reading file: %s\n", Filename);
       return exit_status(EXIT_FAILURE);

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -872,6 +872,7 @@ void CodeGenerator::generateImplFile(bool UseArrayImpl) {
 
 std::shared_ptr<SymbolTable> readCasmFile(
     const char* Filename,
+    bool Verbose,
     bool TraceLexer,
     bool TraceParser,
     std::shared_ptr<SymbolTable> EnclosingScope) {
@@ -882,6 +883,7 @@ std::shared_ptr<SymbolTable> readCasmFile(
   Driver Parser(Symtab);
   Parser.setTraceLexing(TraceLexer);
   Parser.setTraceParsing(TraceParser);
+  Parser.setTraceFilesParsed(Verbose);
   HasErrors = !Parser.parse(Filename);
 #else
   CasmReader Reader;
@@ -1195,9 +1197,7 @@ int main(int Argc, charstring Argv[]) {
   charstring InputFilename = "-";
   for (charstring Filename : InputFilenames) {
     InputFilename = Filename;
-    if (Verbose)
-      fprintf(stderr, "Reading input: %s\n", InputFilename);
-    InputSymtab = readCasmFile(Filename, TraceLexer, TraceParser, InputSymtab);
+    InputSymtab = readCasmFile(Filename, Verbose, TraceLexer, TraceParser, InputSymtab);
     if (!InputSymtab || !InputSymtab->install()) {
       fprintf(stderr, "Unable to parse: %s\n", InputFilename);
       return exit_status(EXIT_FAILURE);
@@ -1253,9 +1253,7 @@ int main(int Argc, charstring Argv[]) {
 
   std::shared_ptr<SymbolTable> AlgSymtab;
   for (charstring Filename : AlgorithmFilenames) {
-    if (Verbose)
-      fprintf(stderr, "Reading algorithm file: %s\n", Filename);
-    AlgSymtab = readCasmFile(Filename, TraceLexer, TraceParser, AlgSymtab);
+    AlgSymtab = readCasmFile(Filename, Verbose, TraceLexer, TraceParser, AlgSymtab);
     if (!AlgSymtab || !AlgSymtab->install()) {
       fprintf(stderr, "Problems reading file: %s\n", Filename);
       return exit_status(EXIT_FAILURE);

--- a/src/sexp-parser/Driver.cpp
+++ b/src/sexp-parser/Driver.cpp
@@ -48,11 +48,11 @@ bool Driver::parse(const std::string& Filename) {
   if (LastSlash == std::string::npos)
     BaseFilename.erase();
   else
-    BaseFilename = Filename.substr(0, LastSlash+1);
+    BaseFilename = Filename.substr(0, LastSlash + 1);
   bool Success = true;
-  std::string NextFile =  Filename;
+  std::string NextFile = Filename;
   SymbolTable::SharedPtr EnclosedSymtab;
- if (TraceFilesParsed)
+  if (TraceFilesParsed)
     fprintf(stderr, "Parsing algiorithm: '%s'\n", Filename.c_str());
   while (true) {
     Success = parseOneFile(NextFile);

--- a/src/sexp-parser/Driver.cpp
+++ b/src/sexp-parser/Driver.cpp
@@ -42,6 +42,37 @@ const char* Driver::getName(ErrorLevel Level) {
 }
 
 bool Driver::parse(const std::string& Filename) {
+  SymbolTable::SharedPtr FirstSymtab = Table;
+  Enclosing.erase();
+  size_t LastSlash = Filename.find_last_of("/\\");
+  if (LastSlash == std::string::npos)
+    BaseFilename.erase();
+  else
+    BaseFilename = Filename.substr(0, LastSlash+1);
+  bool Success = true;
+  std::string NextFile =  Filename;
+  SymbolTable::SharedPtr EnclosedSymtab;
+ if (TraceFilesParsed)
+    fprintf(stderr, "Parsing algiorithm: '%s'\n", Filename.c_str());
+  while (true) {
+    Success = parseOneFile(NextFile);
+    if (!Success)
+      break;
+    if (Enclosing.empty())
+      break;
+    EnclosedSymtab = Table;
+    Table = std::make_shared<SymbolTable>();
+    EnclosedSymtab->setEnclosingScope(Table);
+    NextFile = BaseFilename + Enclosing;
+    Enclosing.erase();
+    if (TraceFilesParsed)
+      fprintf(stderr, "Parsing enclosing algorithm: '%s'\n", NextFile.c_str());
+  }
+  Table = FirstSymtab;
+  return Success;
+}
+
+bool Driver::parseOneFile(const std::string& Filename) {
   this->Filename = Filename;
   ParsedAst = nullptr;
   Begin();

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -39,6 +39,7 @@ class Driver {
       : Table(Table),
         TraceLexing(false),
         TraceParsing(false),
+        TraceFilesParsed(false),
         ParsedAst(nullptr),
         ErrorsReported(false) {}
 
@@ -83,6 +84,10 @@ class Driver {
 
   // The name of the file being parsed.
   std::string& getFilename() { return Filename; }
+
+  void setEnclosing(const std::string& Name) { Enclosing = Name; }
+
+  void setTraceFilesParsed(bool NewValue) { TraceFilesParsed = NewValue; }
 
   void setTraceLexing(bool NewValue) { TraceLexing = NewValue; }
 
@@ -137,8 +142,11 @@ class Driver {
  private:
   std::shared_ptr<SymbolTable> Table;
   std::string Filename;
+  std::string BaseFilename;
+  std::string Enclosing;
   bool TraceLexing;
   bool TraceParsing;
+  bool TraceFilesParsed;
   bool MaintainIntegerFormatting;
   // The location of the last token.
   location Loc;
@@ -149,6 +157,8 @@ class Driver {
   void Begin();
   // Called after parsing for cleanup.
   void End();
+
+  bool parseOneFile(const std::string& Filename);
 };
 
 }  // end of namespace filt

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -221,6 +221,7 @@ letter	[a-zA-Z]
 "declarations"    return Parser::make_DECLARATIONS(Driver.getLoc());
 "define"          return Parser::make_DEFINE(Driver.getLoc());
 "enum"            return Parser::make_ENUM(Driver.getLoc());
+"enclosing"       return Parser::make_ENCLOSING(Driver.getLoc());
 "error"           return Parser::make_ERROR(Driver.getLoc());
 "eval"            return Parser::make_EVAL(Driver.getLoc());
 "header"          return Parser::make_HEADER(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -91,6 +91,7 @@ struct IntValue {
 %token DEFINE        "define"
 %token DOT           "."
 %token DOUBLE_ARROW  "=>"
+%token ENCLOSING     "enclosing"
 %token ENUM          "enum"
 %token ERROR         "error"
 %token EVAL          "eval"
@@ -156,6 +157,7 @@ struct IntValue {
 %type <wasm::filt::Node *> expression
 %type <wasm::filt::Node *> expression_redirect
 %type <wasm::filt::Node *> file
+%type <wasm::filt::Node *> file_contents
 %type <wasm::filt::Node *> file_header
 %type <wasm::filt::Node *> file_header_args
 /*%type <wasm::filt::Node *> file_header_optional*/
@@ -377,6 +379,14 @@ eval_args
         ;
 
 file
+         : file_contents { $$ = $1; }
+         | "(" "enclosing" IDENTIFIER ")" file_contents {
+             $$ = $5;
+             Driver.setEnclosing($3);
+           }
+         ;
+
+file_contents
          : file_header file_header file_header section {
              $$ = Driver.create<FileNode>();
              $$->append($1);

--- a/src/test/TestParser.cpp
+++ b/src/test/TestParser.cpp
@@ -63,8 +63,8 @@ int main(int Argc, wasm::charstring Argv[]) {
 
     ArgsParser::Toggle TraceFilesParsedFlag(TraceFilesParsed);
     Args.add(TraceFilesParsedFlag.setShortName('v')
-             .setLongName("verbose")
-             .setDescription("Show file(s) being parsed."));
+                 .setLongName("verbose")
+                 .setDescription("Show file(s) being parsed."));
 
     ArgsParser::Toggle ShowInternalStructureFlag(
         TextWriter::DefaultShowInternalStructure);
@@ -76,8 +76,7 @@ int main(int Argc, wasm::charstring Argv[]) {
                 "when printing."));
 
     ArgsParser::Toggle ValidateAstFlag(ValidateAst);
-    Args.add(ValidateAstFlag
-                 .setLongName("validate")
+    Args.add(ValidateAstFlag.setLongName("validate")
                  .setDescription(
                      "Validate parsed algorithms also. Assumes "
                      "order of input files define enclosing scopes."));

--- a/src/test/TestParser.cpp
+++ b/src/test/TestParser.cpp
@@ -34,6 +34,7 @@ int main(int Argc, wasm::charstring Argv[]) {
   std::vector<wasm::charstring> Files;
   bool TraceParser = false;
   bool TraceLexer = false;
+  bool TraceFilesParsed = false;
   bool ValidateAst = false;
 
   {
@@ -60,6 +61,11 @@ int main(int Argc, wasm::charstring Argv[]) {
                  .setLongName("print")
                  .setDescription("Write out parsed s-expression"));
 
+    ArgsParser::Toggle TraceFilesParsedFlag(TraceFilesParsed);
+    Args.add(TraceFilesParsedFlag.setShortName('v')
+             .setLongName("verbose")
+             .setDescription("Show file(s) being parsed."));
+
     ArgsParser::Toggle ShowInternalStructureFlag(
         TextWriter::DefaultShowInternalStructure);
     Args.add(
@@ -70,7 +76,7 @@ int main(int Argc, wasm::charstring Argv[]) {
                 "when printing."));
 
     ArgsParser::Toggle ValidateAstFlag(ValidateAst);
-    Args.add(ValidateAstFlag.setShortName('v')
+    Args.add(ValidateAstFlag
                  .setLongName("validate")
                  .setDescription(
                      "Validate parsed algorithms also. Assumes "
@@ -88,16 +94,15 @@ int main(int Argc, wasm::charstring Argv[]) {
   }
 
   Driver Driver(std::make_shared<SymbolTable>());
-  if (TraceParser)
-    Driver.setTraceParsing(true);
-  if (TraceLexer)
-    Driver.setTraceLexing(true);
+  Driver.setTraceParsing(TraceParser);
+  Driver.setTraceLexing(TraceLexer);
+  Driver.setTraceFilesParsed(TraceFilesParsed);
   if (Files.empty())
     Files.push_back("-");
 
   SymbolTable::SharedPtr ContextSymtab;
   for (const auto* Filename : Files) {
-    if (Files.size() > 1) {
+    if (!TraceFilesParsed && Files.size() > 1) {
       fprintf(stdout, "Parsing: %s...\n", Filename);
     }
     if (!Driver.parse(Filename)) {


### PR DESCRIPTION
Rather than requiring enclosing algorithms to be command-line arguments (when parsing CAST files), make it a directive inside the CAST file. That way, the parse can automatically read (and connect) enclosing algorithms.

Note: This change adds the fix, it doesn't modify the Makefile to take advantage of it.