### PR TITLE
Fix predefined algorithms to use enclosing directives.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,8 +201,7 @@ alg_name = $(patsubst $(ALG_GENDIR)/%.cast, Alg%, $(1))
 
 ALG_CAST = casm0x0.cast
 
-ALG_GENDIR_ALG = -a $(ALG_GENDIR)/casm0x0Boot.cast \
-		-a $(ALG_GENDIR)/casm0x0.cast
+ALG_GENDIR_ALG = -a $(ALG_GENDIR)/casm0x0.cast
 
 #### Boot step 1
 
@@ -807,29 +806,23 @@ ifeq ($(GENSRCS), 3)
 
   $(ALG_BOOT1_LIT_H_SRCS): $(ALG_GENDIR)/%.h: $(ALG_GENDIR)/%.cast \
 		$(BUILD_EXECDIR_BOOT)/cast2casm-boot1
-	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 \
-		-a $< $< -o $@ --header --enum \
+	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 $< -o $@ --header --enum \
 		--name $(call alg_name, $(patsubst %-lits.cast, %.cast, $<))
 
   $(ALG_BOOT1_LIT_CPP_SRCS): $(ALG_GENDIR)/%.cpp: $(ALG_GENDIR)/%.cast \
 		$(BUILD_EXECDIR_BOOT)/cast2casm-boot1
-	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 \
-		-a $< $< -o $@ --enum \
+	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 $< -o $@ --enum \
 		--name $(call alg_name, $(patsubst %-lits.cast, %.cast, $<))
 
   $(ALG_BOOT1_H_SRCS): $(ALG_GENDIR)/%Boot.h: $(ALG_GENDIR)/%Boot.cast \
 		$(ALG_GENDIR)/%-lits.cast $(BUILD_EXECDIR_BOOT)/cast2casm-boot1
-	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 \
-		-a $< \
-		$< -o $@ \
+	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 $< -o $@ \
 		--header --strip-literals --function \
 		--name $(call alg_name, $<)
 
   $(ALG_BOOT1_BASE_CPP_SRCS): $(ALG_GENDIR)/%Boot.cpp: $(ALG_GENDIR)/%Boot.cast \
 		$(ALG_GENDIR)/%-lits.cast $(BUILD_EXECDIR_BOOT)/cast2casm-boot1
-	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 \
-		-a $< \
-		$< -o $@ \
+	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 $< -o $@ \
 		--strip-literals --strip-symbolic-actions --function \
 		--name $(call alg_name, $<)
 
@@ -841,38 +834,30 @@ ifeq ($(GENSRCS), 4)
   # requires a separate implementation file for enumerations.
 
   $(ALG_BOOT2_LIT_H_SRCS): $(ALG_GENDIR)/%.h: $(ALG_GENDIR)/%.cast \
-		$(BUILD_EXECDIR_BOOT)/cast2casm-boot1
-	@echo "case lit h $< $@"
-	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 \
-		-a $< $< -o $@ --header --enum \
+		$(BUILD_EXECDIR_BOOT)/cast2casm-boot2
+	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2 \
+		$< -o $@ --header --enum --validate \
 		--name $(call alg_name, $(patsubst %-lits.cast, %.cast, $<))
 
   $(ALG_BOOT2_LIT_CPP_SRCS): $(ALG_GENDIR)/%.cpp: $(ALG_GENDIR)/%.cast \
-		$(BUILD_EXECDIR_BOOT)/cast2casm-boot1
-	@echo "case lit cpp $< $@"
-	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 \
-		-a $< $< -o $@ --enum \
+		$(BUILD_EXECDIR_BOOT)/cast2casm-boot2
+	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2 $< -o $@ --enum --validate \
 		--name $(call alg_name, $(patsubst %-lits.cast, %.cast, $<))
 
   $(ALG_BOOT2_BASE_H_SRCS): $(ALG_GENDIR)/%.h: $(ALG_GENDIR)/%.cast \
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2
-	@echo "case h $< $@"
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2 \
-		$(if $(findstring casm0x0, $<), \
-			$(patsubst %.cast, %Boot.cast, $<), \
-			--strip-actions) \
-		$< -o $@ --header --strip-literal-uses $(ALG_GENDIR_ALG) \
-		--function --name $(call alg_name, $<)
+		$(if $(findstring casm0x0, $<),,--strip-actions) $< -o $@ \
+		--header --strip-literal-uses $(ALG_GENDIR_ALG) \
+		--function --name $(call alg_name, $<) --validate
 
   $(ALG_BOOT2_BASE_CPP_SRCS): $(ALG_GENDIR)/%.cpp: $(ALG_GENDIR)/%.cast \
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2
-	@echo "case cpp $< $@"
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2  \
 		$(if $(findstring casm0x0, $<), \
-			$(patsubst %.cast, %Boot.cast, $<) \
 			--boot --strip-symbolic-actions, \
 			--strip-actions) \
-		$< -o $@ --strip-literal-uses --array \
+		$< -o $@ --strip-literal-uses --array --validate \
 		$(ALG_GENDIR_ALG) --function --name $(call alg_name, $<)
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -200,8 +200,8 @@ ALG_OBJDIR = $(OBJDIR)/algorithms
 alg_name = $(patsubst $(ALG_GENDIR)/%.cast, Alg%, $(1))
 
 ALG_CAST = casm0x0.cast
-ALG_GENDIR_ALG = -a $(ALG_GENDIR)/casm0x0-lits.cast \
-		-a $(ALG_GENDIR)/casm0x0Boot.cast \
+
+ALG_GENDIR_ALG = -a $(ALG_GENDIR)/casm0x0Boot.cast \
 		-a $(ALG_GENDIR)/casm0x0.cast
 
 #### Boot step 1
@@ -820,16 +820,16 @@ ifeq ($(GENSRCS), 3)
   $(ALG_BOOT1_H_SRCS): $(ALG_GENDIR)/%Boot.h: $(ALG_GENDIR)/%Boot.cast \
 		$(ALG_GENDIR)/%-lits.cast $(BUILD_EXECDIR_BOOT)/cast2casm-boot1
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 \
-		-a $(patsubst %Boot.cast, %-lits.cast, $<) -a $< \
-		$(patsubst %Boot.cast, %-lits.cast, $<) $< -o $@ \
+		-a $< \
+		$< -o $@ \
 		--header --strip-literals --function \
 		--name $(call alg_name, $<)
 
   $(ALG_BOOT1_BASE_CPP_SRCS): $(ALG_GENDIR)/%Boot.cpp: $(ALG_GENDIR)/%Boot.cast \
 		$(ALG_GENDIR)/%-lits.cast $(BUILD_EXECDIR_BOOT)/cast2casm-boot1
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot1 \
-		-a $(patsubst %Boot.cast, %-lits.cast, $<) -a $< \
-		$(patsubst %Boot.cast, %-lits.cast, $<) $< -o $@ \
+		-a $< \
+		$< -o $@ \
 		--strip-literals --strip-symbolic-actions --function \
 		--name $(call alg_name, $<)
 
@@ -858,7 +858,6 @@ ifeq ($(GENSRCS), 4)
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2
 	@echo "case h $< $@"
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2 \
-		$(patsubst %.cast, %-lits.cast, $<) \
 		$(if $(findstring casm0x0, $<), \
 			$(patsubst %.cast, %Boot.cast, $<), \
 			--strip-actions) \
@@ -869,7 +868,6 @@ ifeq ($(GENSRCS), 4)
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2
 	@echo "case cpp $< $@"
 	$(BUILD_EXECDIR_BOOT)/cast2casm-boot2  \
-		$(patsubst %.cast, %-lits.cast, $<) \
 		$(if $(findstring casm0x0, $<), \
 			$(patsubst %.cast, %Boot.cast, $<) \
 			--boot --strip-symbolic-actions, \

--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -15,6 +15,8 @@
 # Defines the CAST algorithm for reading/writing "Compressed binary
 # algorithm" ("CASM") files.
 
+(enclosing 'casm0x0Boot.cast')
+
 (header (u32.const 0x6d736163) (u32.const 0x0))
 
 (declarations)

--- a/src/algorithms/casm0x0Boot.cast
+++ b/src/algorithms/casm0x0Boot.cast
@@ -15,6 +15,8 @@
 # Defines the boot CAST algorithm for reading/writing "Compressed binary
 # algorithm" ("CASM") files.
 
+(enclosing 'casm0x0-lits.cast')
+
 (header (u32.const 0x6d736163) (u32.const 0x0))
 
 (declarations)

--- a/src/algorithms/cism0x0.cast
+++ b/src/algorithms/cism0x0.cast
@@ -15,6 +15,8 @@
 # Defines the CAST algorithm for reading/writing "Compressed binary
 # integer sequence" ("cism") file.
 
+(enclosing 'cism0x0-lits.cast')
+
 (header (u32.const 0x6d736163) (u32.const 0x0))
 (header (u32.const 0x6d736963) (u32.const 0x0))
 

--- a/src/algorithms/wasm0xd.cast
+++ b/src/algorithms/wasm0xd.cast
@@ -14,6 +14,8 @@
 
 # Defines the CAST algorithm for reading/writing WASM files.
 
+(enclosing 'wasm0xd-lits.cast')
+
 (header (u32.const 0x6d736163) (u32.const 0x0))
 (header (u32.const 0x6d736100) (u32.const 0xd))
 

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -956,25 +956,6 @@ int main(int Argc, charstring Argv[]) {
   {
     ArgsParser Args("Converts compression algorithm from text to binary");
 
-    ArgsParser::OptionalVector<charstring> AlgorithmFilenamesFlag(
-        AlgorithmFilenames);
-    Args.add(AlgorithmFilenamesFlag.setShortName('a')
-                 .setLongName("algorithm")
-                 .setOptionName("ALGORITHM")
-                 .setDescription(
-#if WASM_CAST_BOOT == 1
-                     "use the aglorithm defined by ALGORITHM(s) to generate "
-                     "the cast binary file. If repeated, each file defines "
-                     "the enclosing scope for the next ALGORITHM file"
-#else
-                     "Instead of using the default casm algorithm to generate "
-                     "the casm binary file, use the aglorithm defined by "
-                     "ALGORITHM(s). If repeated, each file defines the "
-                     "enclosing "
-                     "scope for the next ALGORITHM file"
-#endif
-                     ));
-
     ArgsParser::Optional<bool> ExpectFailFlag(ExpectExitFail);
     Args.add(ExpectFailFlag.setDefault(false)
                  .setLongName("expect-fail")
@@ -1106,6 +1087,19 @@ int main(int Argc, charstring Argv[]) {
 
 #if WASM_CAST_BOOT > 1
 
+    ArgsParser::OptionalVector<charstring> AlgorithmFilenamesFlag(
+        AlgorithmFilenames);
+    Args.add(AlgorithmFilenamesFlag.setShortName('a')
+                 .setLongName("algorithm")
+                 .setOptionName("ALGORITHM")
+                 .setDescription(
+                     "Instead of using the default casm algorithm to generate "
+                     "the casm binary file, use the aglorithm defined by "
+                     "ALGORITHM(s). If repeated, each file defines the "
+                     "enclosing "
+                     "scope for the next ALGORITHM file"
+                     ));
+
     ArgsParser::Optional<bool> BitCompressFlag(BitCompress);
     Args.add(BitCompressFlag.setLongName("bit-compress")
                  .setDescription(
@@ -1167,13 +1161,6 @@ int main(int Argc, charstring Argv[]) {
 
     if (InputFilenames.empty())
       InputFilenames.push_back("-");
-
-#if WASM_CAST_BOOT < 2
-    if (AlgorithmFilenames.empty() && !DisplayParsedInput) {
-      fprintf(stderr, "No algorithm files specified, can't continue\n");
-      return exit_status(EXIT_FAILURE);
-    }
-#endif
 
 #if WASM_CAST_BOOT > 1
     if (TraceTree)
@@ -1266,13 +1253,13 @@ int main(int Argc, charstring Argv[]) {
       fprintf(stderr, "Using prebuilt casm algorithm\n");
     AlgSymtab = WASM_CASM_GET_SYMTAB();
   }
-#endif
 
   if (TraceAlgorithm) {
     fprintf(stderr, "Algorithm:\n");
     TextWriter Writer;
     Writer.write(stderr, AlgSymtab);
   }
+#endif
 
   if (Verbose && strcmp(OutputFilename, "-") != 0)
     fprintf(stderr, "Opening file: %s\n", OutputFilename);


### PR DESCRIPTION
Fixes predefined algorithms to use enclosing directives. Then modified the make file to not specify enclosing chains since they are no longer needed.

Also fixed bug in cast2casm-boot1 that required an algorithm. This is not true since it can't generate the array form, and only the array form needs an algorithm.