### PR TITLE
Fix capturing circular enclosing definitions.

### DIFF
--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -1097,8 +1097,7 @@ int main(int Argc, charstring Argv[]) {
                      "the casm binary file, use the aglorithm defined by "
                      "ALGORITHM(s). If repeated, each file defines the "
                      "enclosing "
-                     "scope for the next ALGORITHM file"
-                     ));
+                     "scope for the next ALGORITHM file"));
 
     ArgsParser::Optional<bool> BitCompressFlag(BitCompress);
     Args.add(BitCompressFlag.setLongName("bit-compress")

--- a/src/sexp-parser/Driver.cpp
+++ b/src/sexp-parser/Driver.cpp
@@ -61,7 +61,7 @@ bool Driver::parse(const std::string& Filename) {
       Success = false;
       break;
     }
-    ParsedFilenames.emplace(NextFile);
+    ParsedFilenames.insert(NextFile);
     Success = parseOneFile(NextFile);
     if (!Success)
       break;

--- a/src/sexp-parser/Driver.cpp
+++ b/src/sexp-parser/Driver.cpp
@@ -54,7 +54,14 @@ bool Driver::parse(const std::string& Filename) {
   SymbolTable::SharedPtr EnclosedSymtab;
   if (TraceFilesParsed)
     fprintf(stderr, "Parsing algiorithm: '%s'\n", Filename.c_str());
+  std::set<std::string> ParsedFilenames;
   while (true) {
+    if (ParsedFilenames.count(NextFile) > 0) {
+      fprintf(stderr, "Algorithm encloses self: %s\n", NextFile.c_str());
+      Success = false;
+      break;
+    }
+    ParsedFilenames.emplace(NextFile);
     Success = parseOneFile(NextFile);
     if (!Success)
       break;
@@ -69,11 +76,13 @@ bool Driver::parse(const std::string& Filename) {
       fprintf(stderr, "Parsing enclosing algorithm: '%s'\n", NextFile.c_str());
   }
   Table = FirstSymtab;
+  ParsedAst = Table->getInstalledRoot();
   return Success;
 }
 
-bool Driver::parseOneFile(const std::string& Filename) {
+bool Driver::parseOneFile(std::string& Filename) {
   this->Filename = Filename;
+  Loc.initialize(&Filename);
   ParsedAst = nullptr;
   Begin();
   wasm::filt::Parser parser(*this);

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -105,13 +105,13 @@ class Driver {
   bool parse(const std::string& Filename);
 
   // Returns the last parsed ast.
-  Node* getParsedAst() const { return ParsedAst; }
+  const Node* getParsedAst() const { return ParsedAst; }
 
   SymbolTable::SharedPtr getSymbolTable() const { return Table; }
 
   bool install() { return Table->install(); }
 
-  void setParsedAst(Node* Ast) {
+  void setParsedAst(const Node* Ast) {
     ParsedAst = Ast;
     Table->setRoot(dyn_cast<FileNode>(ParsedAst));
   }
@@ -150,7 +150,7 @@ class Driver {
   bool MaintainIntegerFormatting;
   // The location of the last token.
   location Loc;
-  Node* ParsedAst;
+  const Node* ParsedAst;
   bool ErrorsReported;
 
   // Called before parsing for setup.
@@ -158,7 +158,7 @@ class Driver {
   // Called after parsing for cleanup.
   void End();
 
-  bool parseOneFile(const std::string& Filename);
+  bool parseOneFile(std::string& Filename);
 };
 
 }  // end of namespace filt

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -145,7 +145,7 @@
 
 #define PARAM_DECLS                                                            \
   public:                                                                      \
-    bool validateNode(NodeVectorType &Parents) OVERRIDE;                       \
+    bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;            \
 
 //#define X(tag, NODE_DECLS)
 #define AST_UNARYNODE_TABLE                                                    \
@@ -164,19 +164,19 @@
 
 #define CALLBACK_DECLS                                                         \
   public:                                                                      \
-    bool validateNode(NodeVectorType &Parents) OVERRIDE;                       \
+    bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;            \
     const IntegerNode* getValue() const;                                       \
 
 #define LITERALUSE_DECLS                                                       \
   const LiteralDefNode* getDef() const;                                        \
   const IntegerNode* getIntNode() const;                                       \
-  bool validateNode(NodeVectorType &Parents) OVERRIDE;                         \
+  bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;              \
 
 
 #define LITERALACTIONUSE_DECLS                                                 \
   const LiteralActionDefNode* getDef() const;                                  \
   const IntegerNode* getIntNode() const;                                       \
-  bool validateNode(NodeVectorType &Parents) OVERRIDE;                         \
+  bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;              \
 
 //#define X(tag, NODE_DECLS)
 #define AST_BINARYNODE_TABLE                                                   \
@@ -199,10 +199,10 @@
   public:                                                                      \
     decode::IntType getValue() const { return Value; }                         \
     const Node* getCaseBody() const { return CaseBody; }                       \
-    bool validateNode(NodeVectorType &Parents) OVERRIDE;                       \
+    bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;            \
   private:                                                                     \
-    decode::IntType Value;                                                     \
-    const Node* CaseBody;                                                      \
+    mutable decode::IntType Value;                                             \
+    mutable const Node* CaseBody;                                              \
 
 //#define X(tag, NODE_DECLS)
 #define AST_SELECTNODE_TABLE                                                   \
@@ -226,11 +226,11 @@
     const FileHeaderNode* getReadHeader(bool UseEnclosing=true) const;         \
     const FileHeaderNode* getWriteHeader(bool UseEnclosing=true) const;        \
     const SectionNode* getDeclarations() const;                                \
-    bool validateNode(NodeVectorType &Parents) OVERRIDE;                       \
+    bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;            \
 
 #define DEFINE_DECLS                                                           \
   public:                                                                      \
-    bool isValidParam(decode::IntType Index);                                  \
+    bool isValidParam(decode::IntType Index) const;                            \
     const std::string getName() const;                                         \
     size_t getNumLocals() const;                                               \
     Node* getBody() const;                                                     \
@@ -238,7 +238,7 @@
 #define EVAL_DECLS                                                             \
  public:                                                                       \
   SymbolNode* getCallName() const;                                             \
-  bool validateNode(NodeVectorType &Parents) OVERRIDE;                         \
+  bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;              \
 
 //#define X(tag, NODE_DECLS)
 #define AST_TERNARYNODE_TABLE                                                  \

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -39,6 +39,8 @@ class TraceClass;
 
 namespace filt {
 
+// Note: mutable fields define caching values in classes.
+
 class BinaryAcceptNode;
 class DefineNode;
 class FileHeaderNode;
@@ -59,6 +61,7 @@ AST_INTEGERNODE_TABLE
 
 typedef std::unordered_set<Node*> VisitedNodesType;
 typedef std::vector<Node*> NodeVectorType;
+typedef std::vector<const Node*> ConstNodeVectorType;
 typedef std::vector<const Node*> ConstNodeVectorType;
 
 static constexpr size_t NumNodeTypes = 0
@@ -175,7 +178,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   const CallbackNode* getBlockEnterCallback();
   const CallbackNode* getBlockExitCallback();
   const FileNode* getRoot() const { return Root; }
-  void setRoot(FileNode* NewRoot);
+  void setRoot(const FileNode* NewRoot);
   // Install definitions in tree defined by root.
   bool install();
   bool isRootInstalled() const { return RootInstalled; }
@@ -259,7 +262,7 @@ class SymbolTable FINAL : public std::enable_shared_from_this<SymbolTable> {
   void deallocateNodes();
 
   void installPredefined();
-  void installDefinitions(Node* Root);
+  void installDefinitions(const Node* Root);
 
   bool areActionsConsistent();
   Node* stripUsing(Node* Root, std::function<Node*(Node*)> stripKid);
@@ -326,13 +329,13 @@ class Node {
   size_t getTreeSize() const;
 
   // Validates the node, based on the parents.
-  virtual bool validateNode(NodeVectorType& Parents);
+  virtual bool validateNode(ConstNodeVectorType& Parents) const;
 
   // Recursively walks tree and validates (Scope allows lexical validation).
   // Returns true if validation succeeds.
-  bool validateKid(NodeVectorType& Parents, Node* Kid);
-  bool validateKids(NodeVectorType& Parents);
-  bool validateSubtree(NodeVectorType& Parents);
+  bool validateKid(ConstNodeVectorType& Parents, const Node* Kid) const;
+  bool validateKids(ConstNodeVectorType& Parents) const;
+  bool validateSubtree(ConstNodeVectorType& Parents) const;
 
   // WARNING: Only supported if underlying type allows.
   virtual void append(Node* Kid);
@@ -352,7 +355,7 @@ class Node {
   interp::IntTypeFormat getIntTypeFormat() const;
 
   FILE* getErrorFile() const { return Symtab.getErrorFile(); }
-  FILE* error() { return Symtab.error(); }
+  FILE* error() const { return Symtab.error(); }
 
  protected:
   NodeType Type;
@@ -431,7 +434,7 @@ class IntegerNode : public NullaryNode {
   static bool implementsClass(NodeType Type);
 
  protected:
-  IntegerValue Value;
+  mutable IntegerValue Value;
   // Note: ValueFormat provided so that we can echo back out same
   // representation as when lexing s-expressions.
   IntegerNode(SymbolTable& Symtab,
@@ -586,13 +589,13 @@ class BinaryAcceptNode FINAL : public IntegerNode {
                    unsigned NumBits);
   ~BinaryAcceptNode() OVERRIDE;
   int nodeCompare(const Node*) const OVERRIDE;
-  bool validateNode(NodeVectorType& Parents) OVERRIDE;
+  bool validateNode(ConstNodeVectorType& Parents) const OVERRIDE;
   unsigned getNumBits() const { return NumBits; }
 
   static bool implementsClass(NodeType Type) { return Type == OpBinaryAccept; }
 
  protected:
-  unsigned NumBits;
+  mutable unsigned NumBits;
 };
 
 // Holds cached information about a Symbol
@@ -734,7 +737,7 @@ class SelectBaseNode : public NaryNode {
  public:
   ~SelectBaseNode() OVERRIDE;
   const CaseNode* getCase(decode::IntType Key) const;
-  bool addCase(const CaseNode* Case);
+  bool addCase(const CaseNode* Case) const;
   static bool implementsClass(NodeType Type);
 
  protected:
@@ -807,9 +810,9 @@ class OpcodeNode FINAL : public SelectBaseNode {
     uint32_t ShiftValue;
   };
 
-  bool validateNode(NodeVectorType& Paremts) OVERRIDE;
+  bool validateNode(ConstNodeVectorType& Paremts) const OVERRIDE;
   typedef std::vector<WriteRange> CaseRangeVectorType;
-  CaseRangeVectorType CaseRangeVector;
+  mutable CaseRangeVectorType CaseRangeVector;
 };
 
 class BinaryEvalNode : public UnaryNode {
@@ -822,7 +825,7 @@ class BinaryEvalNode : public UnaryNode {
   ~BinaryEvalNode() OVERRIDE;
 
   const Node* getEncoding(decode::IntType Value) const;
-  bool addEncoding(BinaryAcceptNode* Encoding);
+  bool addEncoding(const BinaryAcceptNode* Encoding) const;
 
   static bool implementsClass(NodeType Type) { return OpBinaryEval == Type; }
 

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -62,7 +62,6 @@ AST_INTEGERNODE_TABLE
 typedef std::unordered_set<Node*> VisitedNodesType;
 typedef std::vector<Node*> NodeVectorType;
 typedef std::vector<const Node*> ConstNodeVectorType;
-typedef std::vector<const Node*> ConstNodeVectorType;
 
 static constexpr size_t NumNodeTypes = 0
 #define X(tag, opcode, sexp_name, text_num_args, text_max_args) +1

--- a/src/test/TestParser.cpp
+++ b/src/test/TestParser.cpp
@@ -118,7 +118,7 @@ int main(int Argc, wasm::charstring Argv[]) {
       ContextSymtab = Symtab;
     }
     if (PrintAst) {
-      if (Node* Root = Driver.getParsedAst()) {
+      if (const Node* Root = Driver.getParsedAst()) {
         TextWriter Writer;
         Writer.write(stdout, Root);
       } else {

--- a/test/test-sources/MismatchedParens.cast-out
+++ b/test/test-sources/MismatchedParens.cast-out
@@ -1,2 +1,2 @@
-error: 7.31: syntax error, unexpected ), expecting $END
+error: test/test-sources/MismatchedParens.cast:7.31: syntax error, unexpected ), expecting $END
 Errors detected while parsing: test/test-sources/MismatchedParens.cast


### PR DESCRIPTION
Added this because I made a trivial mistake on an algorithm, and it didn't terminate.

In doing so, I realized that I was fighting the notion of "const Node*" pointers. AST's, in general, should be constant. However, during validation some cached fields are set. To get the desired effect, I made a bunch of Node methods get const pointers, and modified caching fields of nodes to be mutable so that they can be updated with validating.