### PR TITLE
Add concept of checking file for algorithm file header.

### DIFF
--- a/src/casm/CasmReader.h
+++ b/src/casm/CasmReader.h
@@ -57,6 +57,10 @@ class CasmReader {
   void readBinary(charstring Filename,
                   std::shared_ptr<filt::SymbolTable> AlgSymtab);
 
+  bool hasBinaryHeader(charstring Filename);
+  bool hasBinaryHeader(charstring Filename,
+                       std::shared_ptr<filt::SymbolTable> AlgSymtab);
+
   // The following two methods call the above methods using the algorithm
   // casm0x0.
   void readBinary(std::shared_ptr<Queue> Binary);

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -613,10 +613,10 @@ std::shared_ptr<SymbolTable> Interpreter::getDefaultAlgorithm(
 
 void Interpreter::algorithmStart() {
   if (Symtab.get() != nullptr)
-    return callTopLevel(Method::GetFile, nullptr);
-  assert(!Selectors.empty());
-  // TODO(karlschimpf) Find correct symbol table to use.
-  callTopLevel(Method::GetAlgorithm, nullptr);
+    return algorithmStart(Method::GetFile);
+  if (Selectors.empty())
+    fail("No selectors specified, can't run algorithm interpreter");
+  algorithmStart(Method::GetAlgorithm);
 }
 
 void Interpreter::algorithmRead() {
@@ -1573,8 +1573,6 @@ void Interpreter::algorithmResume() {
               assert(Frame.Nd);
               assert(isa<FileNode>(Frame.Nd));
             }
-            // TODO: Separate out read and write headers, since they may
-            // be different.
             const Node* Header =
                 HeaderOverride ? HeaderOverride : Symtab->getReadHeader();
             if (!isa<FileHeaderNode>(Header))

--- a/src/interp/Interpreter.def
+++ b/src/interp/Interpreter.def
@@ -43,6 +43,7 @@ X(EvalBlock)                                                  \
 X(EvalParam)                                                  \
 X(Finished)                                                   \
 X(GetFile)                                                    \
+X(HasFileHeader)                                              \
 X(ReadIntBlock)                                               \
 X(ReadOpcode)                                                 \
 X(ReadIntValues)                                              \

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -52,6 +52,14 @@ class Interpreter {
   Interpreter& operator=(const Interpreter&) = delete;
 
  public:
+  enum class Method {
+#define X(tag) tag,
+    INTERPRETER_METHODS_TABLE
+#undef X
+        NO_SUCH_METHOD
+  };
+  static const char* getName(Method M);
+
   Interpreter(std::shared_ptr<Reader> Input,
               std::shared_ptr<Writer> Output,
               const InterpreterFlags& Flags,
@@ -88,6 +96,7 @@ class Interpreter {
 
   // Starts up decompression using a (file) algorithm.
   void algorithmStart();
+  void algorithmStart(Method M) { callTopLevel(M, nullptr); }
 
   // Resumes decompression where it left off. Assumes that more
   // input has been added since the previous start()/resume() call.
@@ -147,14 +156,6 @@ class Interpreter {
   static const char* getName(SectionCode Code);
 
  protected:
-  enum class Method {
-#define X(tag) tag,
-    INTERPRETER_METHODS_TABLE
-#undef X
-        NO_SUCH_METHOD
-  };
-  static const char* getName(Method M);
-
   enum class MethodModifier {
 #define X(tag, flags) tag = flags,
     INTERPRETER_METHOD_MODIFIERS_TABLE


### PR DESCRIPTION
This is the first step to generalizing the CasmReader to handle both text and binary files simultaneously.

To do that, we need to be able to test if the initial bytes of a file matches the algorithm's file header. If so, assume it is binary. Otherwise, assume it is text, and read it as text. This change does the first step by introducing the concept to the interpreter of checking a file header. However, it isn't currently implemented and will fail with a not-implemented error message.

The next PR will add the implementation of checking if a file has the corresponding file header.