### PR TITLE
Fix Casm Reader to sniff out if file is text/binary.

### DIFF
--- a/src/casm/CasmReader.h
+++ b/src/casm/CasmReader.h
@@ -57,15 +57,31 @@ class CasmReader {
   void readBinary(charstring Filename,
                   std::shared_ptr<filt::SymbolTable> AlgSymtab);
 
+  void readBinary(charstring Filename,
+                  std::shared_ptr<filt::SymbolTable> AlgSymtab,
+                  std::shared_ptr<filt::SymbolTable> EnclosingScope);
+
   bool hasBinaryHeader(charstring Filename);
   bool hasBinaryHeader(charstring Filename,
                        std::shared_ptr<filt::SymbolTable> AlgSymtab);
+
+  void readTextOrBinary(charstring Filename);
+
+  void readTextOrBinary(charstring Filename,
+                        std::shared_ptr<filt::SymbolTable> EnclosingScope);
+
+  void readTextOrBinary(charstring Filename,
+                        std::shared_ptr<filt::SymbolTable> EnclosingScope,
+                        std::shared_ptr<filt::SymbolTable> AlgSymtab);
 
   // The following two methods call the above methods using the algorithm
   // casm0x0.
   void readBinary(std::shared_ptr<Queue> Binary);
 
   void readBinary(charstring Filename);
+
+  bool hasFileHeader(charstring Filename,
+                     std::shared_ptr<filt::SymbolTable> AlgSymtab);
 
   bool hasErrors() const { return ErrorsFound; }
   CasmReader& setTraceRead(bool Value) {

--- a/src/casm/CasmReaderBinary.cpp
+++ b/src/casm/CasmReaderBinary.cpp
@@ -36,6 +36,20 @@ void CasmReader::readBinary(charstring Filename) {
   readBinary(Filename, getAlgcasm0x0Symtab());
 }
 
+bool CasmReader::hasBinaryHeader(charstring Filename) {
+  return hasBinaryHeader(Filename, getAlgcasm0x0Symtab());
+}
+
+void CasmReader::readTextOrBinary(charstring Filename) {
+  SymbolTable::SharedPtr EnclosingScope;
+  readTextOrBinary(Filename, EnclosingScope);
+}
+
+void CasmReader::readTextOrBinary(charstring Filename,
+                                  std::shared_ptr<SymbolTable> EnclosingScope) {
+  readTextOrBinary(Filename, EnclosingScope, getAlgcasm0x0Symtab());
+}
+
 }  // end of namespace filt
 
 }  // end of namespace wasm

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -1247,6 +1247,7 @@ int main(int Argc, charstring Argv[]) {
       return exit_status(EXIT_FAILURE);
     }
   }
+
 #if WASM_CAST_BOOT > 1
   if (AlgorithmFilenames.empty()) {
     if (Verbose)

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -878,7 +878,7 @@ std::shared_ptr<SymbolTable> readCasmFile(
     std::shared_ptr<SymbolTable> EnclosingScope) {
   bool HasErrors = false;
   std::shared_ptr<SymbolTable> Symtab;
-#if WASM_CAST_BOOT == 1
+#if WASM_CAST_BOOT < 3
   Symtab = std::make_shared<SymbolTable>(EnclosingScope);
   Driver Parser(Symtab);
   Parser.setTraceLexing(TraceLexer);
@@ -889,12 +889,13 @@ std::shared_ptr<SymbolTable> readCasmFile(
   CasmReader Reader;
   Reader.setTraceRead(TraceParser)
       .setTraceLexer(TraceLexer)
-      .readText(Filename, EnclosingScope);
-  Symtab = Reader.getReadSymtab();
+      .readTextOrBinary(Filename, EnclosingScope);
   HasErrors = Reader.hasErrors();
+  if (!HasErrors)
+    Symtab = Reader.getReadSymtab();
 #endif
   if (HasErrors)
-    Symtab.reset();
+    Symtab = SymbolTable::SharedPtr();
   return Symtab;
 }
 

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -227,7 +227,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceIntCountsCollectionFlag(
         MyCompressionFlags.TraceIntCountsCollection);
     Args.add(TraceIntCountsCollectionFlag.setLongName(
-                                              "verbose=int-counts-collection")
+                                             "verbose=int-counts-collection")
                  .setDescription("Show how int counts were selected"));
 
     ArgsParser::Optional<bool> TraceSequenceCountsFlag(
@@ -241,7 +241,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceSequenceCountsCollection);
     Args.add(
         TraceSequenceCountsCollectionFlag.setLongName(
-                                              "verbose=seq-counts-collection")
+                                             "verbose=seq-counts-collection")
             .setDescription(
                 "Show how frequency of integer sequences were "
                 "selected"));
@@ -298,7 +298,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbrevSelectionProgress);
     Args.add(
         TraceAbbrevSelectionProgressFlag.setLongName(
-                                             "verbose=select-abbrevs-progress")
+                                            "verbose=select-abbrevs-progress")
             .setOptionName("INTEGER")
             .setDescription(
                 "For every INTEGER values generated in the output integer "
@@ -309,7 +309,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceAbbrevSelectionSelectFlag(
         MyCompressionFlags.TraceAbbrevSelectionSelect);
     Args.add(TraceAbbrevSelectionSelectFlag.setLongName(
-                                                "verbose=select-abbrevs-select")
+                                               "verbose=select-abbrevs-select")
                  .setDescription(
                      "Show selected pattern sequences, as they apply. "
                      "Only appiles when --verbose=select-abbrevs is "
@@ -319,7 +319,7 @@ int main(int Argc, const char* Argv[]) {
         MyCompressionFlags.TraceAbbrevSelectionCreate);
     Args.add(
         TraceAbbrevSelectionCreateFlag.setLongName(
-                                           "verbose=select-abbrevs-create")
+                                          "verbose=select-abbrevs-create")
             .setDescription(
                 "Show each created pattern sequence that is tried (not just "
                 "the selected ones). Only applies when "
@@ -328,7 +328,7 @@ int main(int Argc, const char* Argv[]) {
     ArgsParser::Optional<bool> TraceAbbrevSelectionDetailFlag(
         MyCompressionFlags.TraceAbbrevSelectionDetail);
     Args.add(TraceAbbrevSelectionDetailFlag.setLongName(
-                                                "verbose=select-abbrev-details")
+                                               "verbose=select-abbrev-details")
                  .setDescription(
                      "Show additional detail (besides creating and selecting) "
                      "when creating the applied pattern sequence. Only applies "

--- a/src/interp/ByteReader.cpp
+++ b/src/interp/ByteReader.cpp
@@ -147,8 +147,8 @@ decode::StreamType ByteReader::getStreamType() {
   return Input->getType();
 }
 
-bool ByteReader::processedInputCorrectly() {
-  return ReadPos.atEof() && ReadPos.isQueueGood();
+bool ByteReader::processedInputCorrectly(bool CheckForEof) {
+  return (!CheckForEof || ReadPos.atEof()) && ReadPos.isQueueGood();
 }
 
 bool ByteReader::readBlockEnter() {

--- a/src/interp/ByteReader.h
+++ b/src/interp/ByteReader.h
@@ -49,7 +49,7 @@ class ByteReader : public Reader {
   bool pushPeekPos() OVERRIDE;
   bool popPeekPos() OVERRIDE;
   decode::StreamType getStreamType() OVERRIDE;
-  bool processedInputCorrectly() OVERRIDE;
+  bool processedInputCorrectly(bool CheckForEof) OVERRIDE;
   void readFillStart() OVERRIDE;
   void readFillMoreInput() OVERRIDE;
   uint8_t readBit() OVERRIDE;

--- a/src/interp/IntReader.cpp
+++ b/src/interp/IntReader.cpp
@@ -135,8 +135,8 @@ StreamType IntReader::getStreamType() {
   return StreamType::Int;
 }
 
-bool IntReader::processedInputCorrectly() {
-  return Pos.atEnd();
+bool IntReader::processedInputCorrectly(bool CheckForEof) {
+  return !CheckForEof || Pos.atEnd();
 }
 
 bool IntReader::readBlockEnter() {

--- a/src/interp/IntReader.h
+++ b/src/interp/IntReader.h
@@ -51,7 +51,7 @@ class IntReader : public Reader {
   bool pushPeekPos() OVERRIDE;
   bool popPeekPos() OVERRIDE;
   decode::StreamType getStreamType() OVERRIDE;
-  bool processedInputCorrectly() OVERRIDE;
+  bool processedInputCorrectly(bool CheckForEof) OVERRIDE;
   void readFillStart() OVERRIDE;
   void readFillMoreInput() OVERRIDE;
   uint64_t readVaruint64() OVERRIDE;

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -96,7 +96,7 @@ class Interpreter {
 
   // Starts up decompression using a (file) algorithm.
   void algorithmStart();
-  void algorithmStart(Method M) { callTopLevel(M, nullptr); }
+  void algorithmStartHasFileHeader();
 
   // Resumes decompression where it left off. Assumes that more
   // input has been added since the previous start()/resume() call.
@@ -235,6 +235,7 @@ class Interpreter {
   // Fatal override that causes reader to fail, even wth the presence of
   // catches.
   bool IsFatalFailure;
+  bool CheckForEof;
   // The stack of called methods.
   CallFrame Frame;
   utils::ValueStack<CallFrame> FrameStack;
@@ -270,7 +271,7 @@ class Interpreter {
   bool FreezeEofAtExit;
 
   void reset();
-
+  void algorithmStart(Method M) { callTopLevel(M, nullptr); }
   void handleOtherMethods();
 
   // Initializes all internal stacks, for an initial call to Method with

--- a/src/interp/Reader.h
+++ b/src/interp/Reader.h
@@ -58,7 +58,7 @@ class Reader : public std::enable_shared_from_this<Reader> {
   virtual bool pushPeekPos() = 0;
   virtual bool popPeekPos() = 0;
   virtual decode::StreamType getStreamType() = 0;
-  virtual bool processedInputCorrectly() = 0;
+  virtual bool processedInputCorrectly(bool CheckForEof) = 0;
   virtual bool readAction(decode::IntType Action);
   virtual void readFillStart() = 0;
   virtual void readFillMoreInput() = 0;


### PR DESCRIPTION
This simplifies reading (when using readTextOrBinary()) by allowing the casm reader to sniff out the format, and then read appropriately.

This is used (currently) by cast2casm for both algorithm and input files.