### PR TITLE
Fix algorithm selection in the algorithm interpreter.

### DIFF
--- a/src/intcomp/IntCompress.cpp
+++ b/src/intcomp/IntCompress.cpp
@@ -107,7 +107,6 @@ void IntCompressor::writeDataOutput(const BitWriteCursor& StartPos,
                        MyFlags.MyInterpFlags, Symtab);
   if (MyFlags.TraceWritingDataOutput)
     MyReader.getTrace().setTraceProgress(true);
-  MyReader.useFileHeader(Symtab->getReadHeader());
   MyReader.algorithmStart();
   MyReader.algorithmReadBackFilled();
   bool Successful = MyReader.isFinished() && MyReader.isSuccessful();

--- a/src/interp/DecompressSelector.h
+++ b/src/interp/DecompressSelector.h
@@ -57,8 +57,8 @@ class DecompAlgState : public std::enable_shared_from_this<DecompAlgState> {
  private:
   Interpreter* MyInterpreter;
   std::queue<std::shared_ptr<filt::SymbolTable>> AlgQueue;
+  std::shared_ptr<filt::SymbolTable> FinalSymtab;
   std::shared_ptr<filt::InflateAst> Inflator;
-  std::shared_ptr<filt::SymbolTable> OrigSymtab;
   std::shared_ptr<Writer> OrigWriter;
   std::shared_ptr<IntStream> IntermediateStream;
 };

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -152,6 +152,10 @@ bool IntWriter::writeFreezeEof() {
 }
 
 bool IntWriter::writeHeaderValue(IntType Value, IntTypeFormat Format) {
+#if 0
+  fprintf(stderr, "Appending %" PRIuMAX "\n", uintmax_t(Value));
+  Output->describe(stderr);
+#endif
   Output->appendHeader(Value, Format);
   return true;
 }

--- a/src/interp/IntWriter.cpp
+++ b/src/interp/IntWriter.cpp
@@ -152,10 +152,6 @@ bool IntWriter::writeFreezeEof() {
 }
 
 bool IntWriter::writeHeaderValue(IntType Value, IntTypeFormat Format) {
-#if 0
-  fprintf(stderr, "Appending %" PRIuMAX "\n", uintmax_t(Value));
-  Output->describe(stderr);
-#endif
   Output->appendHeader(Value, Format);
   return true;
 }

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -83,6 +83,7 @@ class Interpreter {
   void setSymbolTable(std::shared_ptr<filt::SymbolTable> NewSymtab) {
     Symtab = NewSymtab;
   }
+  void resetSymbolTable() { Symtab.reset(); }
 
   bool getFreezeEofAtExit() { return FreezeEofAtExit; }
   void setFreezeEofAtExit(bool NewValue) { FreezeEofAtExit = NewValue; }

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -86,6 +86,10 @@ void TextWriter::writeName(NodeType Type) {
 }
 
 void TextWriter::write(FILE* File, SymbolTable* Symtab) {
+  if (Symtab == nullptr) {
+    fprintf(File, "nullptr\n");
+    return;
+  }
   write(File, Symtab->getAlgorithm());
   Symtab = Symtab->getEnclosingScope().get();
   while (Symtab != nullptr) {

--- a/src/utils/Trace.h
+++ b/src/utils/Trace.h
@@ -26,7 +26,7 @@
 
 #ifdef NDEBUG
 
-#define TRACE_METHOD_USING(Name, Trace)
+#define TRACE_METHOD_USING(Trace, Name)
 #define TRACE_METHOD(Name)
 #define TRACE_USING(trace, type, name, value)
 #define TRACE(type, name, value)
@@ -45,9 +45,9 @@
 
 #else
 
-#define TRACE_METHOD_USING(name, trace) \
+#define TRACE_METHOD_USING(trace, name) \
   wasm::utils::TraceClass::Method tracEmethoD((name), (trace))
-#define TRACE_METHOD(name) TRACE_METHOD_USING(name, getTrace())
+#define TRACE_METHOD(name) TRACE_METHOD_USING(getTrace(), (name))
 #define TRACE_USING(trace, type, name, value) \
   do {                                        \
     auto& tracE = (trace);                    \


### PR DESCRIPTION
Fixes subtle bug in the algorithm selection. The problem was the old code was not selecting the correct last (default) algorithm to apply (if algorithms exist in the input stream) to convert the integer stream into a binary stream.