### PR TITLE
Add literals and algorithm flag to algorithms 

### DIFF
--- a/src/algorithms/casm0x0-lits.cast
+++ b/src/algorithms/casm0x0-lits.cast
@@ -15,6 +15,7 @@
 # Defines symbolic literals used by the CASM algorithm as an enclosing scope.
 
 (header (u32.const 0x6d736163) (u32.const 0x0))
+(algorithm 1)
 
 (literal.action.enum (u32.const 101)
                      'int.value.begin'
@@ -101,3 +102,4 @@
 (literal 'header.file'    (u8.const 0x77))
 (literal 'header.read'    (u8.const 0x78))
 (literal 'header.write'   (u8.const 0x79))
+(literal 'algorithm'      (u8.const 0x7a))

--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -18,11 +18,13 @@
 (enclosing 'casm0x0Boot.cast')
 
 (header (u32.const 0x6d736163) (u32.const 0x0))
+(algorithm 1)
 
 (define 'node' (params)
   (switch (uint8)
     (error)
     (case 'accept'
+     case 'algorithm'
      case 'and'
      case 'binary'
      case 'bit'

--- a/src/algorithms/casm0x0Boot.cast
+++ b/src/algorithms/casm0x0Boot.cast
@@ -18,6 +18,7 @@
 (enclosing 'casm0x0-lits.cast')
 
 (header (u32.const 0x6d736163) (u32.const 0x0))
+(algorithm 1)
 
 (define 'file' (params)
   (block
@@ -44,7 +45,8 @@
 (define 'node' (params)
   (switch (uint8)
     (error)
-    (case 'bit'
+    (case 'algorithm'
+     case 'bit'
      case 'block'
      case 'case'
      case 'error'

--- a/src/casm/FlattenAst.cpp
+++ b/src/casm/FlattenAst.cpp
@@ -162,6 +162,7 @@ void FlattenAst::flattenNode(const Node* Nd) {
     case NodeType::NO_SUCH_NODETYPE:
     case NodeType::BinaryEvalBits:
     case NodeType::IntLookup:
+    case NodeType::SourceType:
     case NodeType::SymbolDefn:
     case NodeType::UnknownSection: {
       reportError("Unexpected s-expression, can't write!");

--- a/src/casm/FlattenAst.cpp
+++ b/src/casm/FlattenAst.cpp
@@ -168,10 +168,10 @@ void FlattenAst::flattenNode(const Node* Nd) {
       reportError("s-expression: ", Nd);
       break;
     }
-#define X(tag, format, defval, mergable, BASE, NODE_DECLS) \
-  case NodeType::tag: {                                    \
+#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT) \
+  case NodeType::NAME: {                                    \
     write(IntType(Opcode));                                \
-    auto* Int = cast<tag>(Nd);                             \
+    auto* Int = cast<NAME>(Nd);                             \
     if (Int->isDefaultValue()) {                           \
       write(0);                                            \
     } else {                                               \
@@ -182,8 +182,8 @@ void FlattenAst::flattenNode(const Node* Nd) {
   }
       AST_INTEGERNODE_TABLE
 #undef X
-#define X(tag, BASE, VALUE, FORMAT, NODE_DECLS) \
-  case NodeType::tag: {                                    \
+#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT)               \
+  case NodeType::NAME: {                                    \
     write(IntType(Opcode));                                \
     break;                                                 \
   }

--- a/src/casm/FlattenAst.cpp
+++ b/src/casm/FlattenAst.cpp
@@ -162,7 +162,6 @@ void FlattenAst::flattenNode(const Node* Nd) {
     case NodeType::NO_SUCH_NODETYPE:
     case NodeType::BinaryEvalBits:
     case NodeType::IntLookup:
-    case NodeType::SourceType:
     case NodeType::SymbolDefn:
     case NodeType::UnknownSection: {
       reportError("Unexpected s-expression, can't write!");
@@ -183,11 +182,19 @@ void FlattenAst::flattenNode(const Node* Nd) {
   }
       AST_INTEGERNODE_TABLE
 #undef X
+#define X(tag, BASE, VALUE, FORMAT, NODE_DECLS) \
+  case NodeType::tag: {                                    \
+    write(IntType(Opcode));                                \
+    break;                                                 \
+  }
+      AST_LITERAL_TABLE
+#undef X
     case NodeType::BinaryEval:
       if (BitCompress && binaryEvalEncode(cast<BinaryEval>(Nd)))
         break;
     // Not binary encoding, Intentionally fall to next case that
     // will generate non-compressed form.
+    case NodeType::AlgorithmFlag:
     case NodeType::And:
     case NodeType::Block:
     case NodeType::BinaryAccept:

--- a/src/casm/InflateAst.cpp
+++ b/src/casm/InflateAst.cpp
@@ -199,6 +199,8 @@ bool InflateAst::writeHeaderValue(decode::IntType Value,
 
 bool InflateAst::applyOp(IntType Op) {
   switch (NodeType(Op)) {
+    case NodeType::AlgorithmFlag:
+      return buildUnary<AlgorithmFlag>();
     case NodeType::And:
       return buildBinary<And>();
     case NodeType::BinaryAccept:

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -569,6 +569,8 @@ size_t CodeGenerator::generateNode(const Node* Nd) {
   switch (Nd->getType()) {
     default:
       return generateBadLocal(Nd);
+    case NodeType::AlgorithmFlag:
+      return generateUnary("AlgorithmFlag", Nd);
     case NodeType::And:
       return generateBinary("And", Nd);
     case NodeType::Bit:

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -265,6 +265,7 @@ Interpreter::Interpreter(std::shared_ptr<Reader> Input,
       OpcodeLocalsStack(OpcodeLocals),
       HeaderOverride(nullptr),
       FreezeEofAtExit(true) {
+  assert(Symtab->isAlgorithmInstalled());
   init();
 }
 
@@ -679,20 +680,21 @@ void Interpreter::algorithmResume() {
       case Method::Eval:
         switch (Frame.Nd->getType()) {
           case NodeType::NO_SUCH_NODETYPE:
-          case NodeType::SymbolDefn:
-          case NodeType::IntLookup:
-          case NodeType::BinaryEvalBits:
+          case NodeType::Algorithm:
           case NodeType::BinaryAccept:
+          case NodeType::BinaryEvalBits:
           case NodeType::BinarySelect:
+          case NodeType::IntLookup:
           case NodeType::Params:
           case NodeType::LastSymbolIs:
           case NodeType::LiteralActionBase:
           case NodeType::LiteralActionDef:
           case NodeType::LiteralDef:
-          case NodeType::Algorithm:
           case NodeType::Locals:
           case NodeType::Rename:
+          case NodeType::SourceType:
           case NodeType::Symbol:
+          case NodeType::SymbolDefn:
           case NodeType::Undefine:
           case NodeType::UnknownSection:  // Method::Eval
             return failNotImplemented();

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -681,6 +681,7 @@ void Interpreter::algorithmResume() {
         switch (Frame.Nd->getType()) {
           case NodeType::NO_SUCH_NODETYPE:
           case NodeType::Algorithm:
+          case NodeType::AlgorithmFlag:
           case NodeType::BinaryAccept:
           case NodeType::BinaryEvalBits:
           case NodeType::BinarySelect:
@@ -692,7 +693,6 @@ void Interpreter::algorithmResume() {
           case NodeType::LiteralDef:
           case NodeType::Locals:
           case NodeType::Rename:
-          case NodeType::SourceType:
           case NodeType::Symbol:
           case NodeType::SymbolDefn:
           case NodeType::Undefine:
@@ -857,9 +857,11 @@ void Interpreter::algorithmResume() {
           }
           case NodeType::I32Const:
           case NodeType::I64Const:
+          case NodeType::One:
           case NodeType::U8Const:
           case NodeType::U32Const:
-          case NodeType::U64Const: {  // Method::Eval
+          case NodeType::U64Const:
+          case NodeType::Zero: {  // Method::Eval
             IntType Value = dyn_cast<IntegerNode>(Frame.Nd)->getValue();
             if (hasReadMode())
               LastReadValue = Value;

--- a/src/sexp-parser/Driver.cpp
+++ b/src/sexp-parser/Driver.cpp
@@ -19,6 +19,8 @@
 
 namespace wasm {
 
+using namespace decode;
+
 namespace filt {
 
 namespace {
@@ -92,6 +94,24 @@ bool Driver::parseOneFile(std::string& Filename) {
   int Result = parser.parse();
   End();
   return Result == 0 && !ErrorsReported;
+}
+
+IntegerNode* Driver::createLiteral(IntType Value,
+                                   ValueFormat Format) {
+  /*
+  switch (Value) {
+#define X(tag, BASE, VALUE, FORMAT, NODE_DECLS) \
+    case VALUE:                                 \
+      if (Format == ValueFormat::FORMAT)        \
+        return Table->create<tag>();            \
+      break;
+      AST_LITERAL_TABLE
+#undef X
+    default:
+      break;
+  }
+  */
+  return create<U64Const>(Value, Format);
 }
 
 void Driver::report(ErrorLevel Level,

--- a/src/sexp-parser/Driver.h
+++ b/src/sexp-parser/Driver.h
@@ -69,6 +69,8 @@ class Driver {
     return Table->createBinaryAccept(Value, NumBits);
   }
 
+  IntegerNode* createLiteral(decode::IntType Value, decode::ValueFormat Format);
+
   Symbol* getOrCreateSymbol(std::string& Name) {
     return Table->getOrCreateSymbol(Name);
   }

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -219,7 +219,6 @@ letter	[a-zA-Z]
 "block"           return Parser::make_BLOCK(Driver.getLoc());
 "bitwise"         return Parser::make_BITWISE(Driver.getLoc());
 "case"            return Parser::make_CASE(Driver.getLoc());
-"data"            return Parser::make_DATA(Driver.getLoc());
 "define"          return Parser::make_DEFINE(Driver.getLoc());
 "enum"            return Parser::make_ENUM(Driver.getLoc());
 "enclosing"       return Parser::make_ENCLOSING(Driver.getLoc());
@@ -248,10 +247,8 @@ letter	[a-zA-Z]
 "rename"          return Parser::make_RENAME(Driver.getLoc());
 "seq"             return Parser::make_SEQ(Driver.getLoc());
 "set"             return Parser::make_SET(Driver.getLoc());
-"source"          return Parser::make_SOURCE(Driver.getLoc());
 "switch"          return Parser::make_SWITCH(Driver.getLoc());
 "symbol"          return Parser::make_SYMBOL(Driver.getLoc());
-"type"            return Parser::make_TYPE(Driver.getLoc());
 "table"           return Parser::make_TABLE(Driver.getLoc());
 "uint8"           return Parser::make_UINT8(Driver.getLoc());
 "uint32"          return Parser::make_UINT32(Driver.getLoc());

--- a/src/sexp-parser/Lexer.lex
+++ b/src/sexp-parser/Lexer.lex
@@ -212,12 +212,14 @@ letter	[a-zA-Z]
 "."               return Parser::make_DOT(Driver.getLoc());
 "accept"          return Parser::make_ACCEPT(Driver.getLoc());
 "action"          return Parser::make_ACTION(Driver.getLoc());
+"algorithm"       return Parser::make_ALGORITHM(Driver.getLoc());
 "and"             return Parser::make_AND(Driver.getLoc());
 "binary"          return Parser::make_BINARY(Driver.getLoc());
 "bit"             return Parser::make_BIT(Driver.getLoc());
 "block"           return Parser::make_BLOCK(Driver.getLoc());
 "bitwise"         return Parser::make_BITWISE(Driver.getLoc());
 "case"            return Parser::make_CASE(Driver.getLoc());
+"data"            return Parser::make_DATA(Driver.getLoc());
 "define"          return Parser::make_DEFINE(Driver.getLoc());
 "enum"            return Parser::make_ENUM(Driver.getLoc());
 "enclosing"       return Parser::make_ENCLOSING(Driver.getLoc());
@@ -246,8 +248,10 @@ letter	[a-zA-Z]
 "rename"          return Parser::make_RENAME(Driver.getLoc());
 "seq"             return Parser::make_SEQ(Driver.getLoc());
 "set"             return Parser::make_SET(Driver.getLoc());
+"source"          return Parser::make_SOURCE(Driver.getLoc());
 "switch"          return Parser::make_SWITCH(Driver.getLoc());
 "symbol"          return Parser::make_SYMBOL(Driver.getLoc());
+"type"            return Parser::make_TYPE(Driver.getLoc());
 "table"           return Parser::make_TABLE(Driver.getLoc());
 "uint8"           return Parser::make_UINT8(Driver.getLoc());
 "uint32"          return Parser::make_UINT32(Driver.getLoc());

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -88,7 +88,6 @@ struct IntValue {
 %token CASE          "case"
 %token CLOSEPAREN    ")"
 %token COLON         ":"
-%token DATA          "data"
 %token DEFINE        "define"
 %token DOT           "."
 %token DOUBLE_ARROW  "=>"
@@ -120,10 +119,8 @@ struct IntValue {
 %token RENAME        "rename"
 %token SEQ           "seq"
 %token SET           "set"
-%token SOURCE        "source"
 %token SWITCH        "switch"
 %token SYMBOL        "symbol"
-%token TYPE          "type"
 %token TABLE         "table"
 %token UINT8         "uint8"
 %token UINT32        "uint32"
@@ -321,15 +318,8 @@ declaration
         | "(" algorithm_header_args ")" {
             $$ = $2;
           }
-        | "(" "source" "." "type" "algorithm" ")" {
-            auto* SrcTy = Driver.create<SourceType>();
-            SrcTy->setIsAlgorithm(true);
-            $$ = SrcTy;
-          }
-        | "(" "source" "." "type" "data" ")" {
-            auto* SrcTy = Driver.create<SourceType>();
-            SrcTy->setIsAlgorithm(false);
-            $$ = SrcTy;
+        | "(" "algorithm" literal_expression ")" {
+            $$ = Driver.create<AlgorithmFlag>($3);
           }
         | "(" "rename" symbol symbol ")" {
             $$ = Driver.create<Rename>($3, $4);
@@ -509,6 +499,9 @@ literal_expression
           }
         | "(" "u64.const" INTEGER ")" {
             $$ = Driver.create<U64Const>($3.Value, $3.Format);
+          }
+        | INTEGER {
+            $$ = Driver.createLiteral($1.Value, $1.Format);
           }
         ;
 

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -79,6 +79,7 @@ struct IntValue {
 // Keywords
 %token ACCEPT        "accept"
 %token ACTION        "action"
+%token ALGORITHM     "algorithm"
 %token AND           "and"
 %token BINARY        "binary"
 %token BIT           "bit"
@@ -87,6 +88,7 @@ struct IntValue {
 %token CASE          "case"
 %token CLOSEPAREN    ")"
 %token COLON         ":"
+%token DATA          "data"
 %token DEFINE        "define"
 %token DOT           "."
 %token DOUBLE_ARROW  "=>"
@@ -118,8 +120,10 @@ struct IntValue {
 %token RENAME        "rename"
 %token SEQ           "seq"
 %token SET           "set"
+%token SOURCE        "source"
 %token SWITCH        "switch"
 %token SYMBOL        "symbol"
+%token TYPE          "type"
 %token TABLE         "table"
 %token UINT8         "uint8"
 %token UINT32        "uint32"
@@ -156,7 +160,6 @@ struct IntValue {
 %type <wasm::filt::Node *> expression
 %type <wasm::filt::Node *> expression_redirect
 %type <wasm::filt::Node *> algorithm
-%type <wasm::filt::Node *> algorithm_header
 %type <wasm::filt::Node *> algorithm_header_args
 %type <wasm::filt::Node *> fixed_format_directive
 %type <wasm::filt::Node *> format_binary
@@ -179,36 +182,24 @@ struct IntValue {
 %%
 
 algorithm
-         /* Note: Declarations must appear after headers, and the
-            primary (soure) header must appear fisrt (checked during
-            validation).
-         */
-         : algorithm_header {
-             $$ = Driver.create<Algorithm>();
-             Driver.setAlgorithm($$);
-             $$->append($1);
-           }
-         | "(" "enclosing" IDENTIFIER ")" algorithm_header {
-             Driver.setEnclosing($3);
-             $$ = Driver.create<Algorithm>();
+        : "(" "enclosing" IDENTIFIER ")" declaration {
+            Driver.setEnclosing($3);
+            $$ = Driver.create<Algorithm>();
+            Driver.setAlgorithm($$);
              Driver.setAlgorithm($$);
              $$->append($5);
            }
-         | algorithm algorithm_header {
-             $$ = $1;
-             $$->append($2);
-           }
-         | algorithm declaration {
-             $$ = $1;
-             $$->append($2);
-           }
-         ;
-
-algorithm_header
-        : "(" algorithm_header_args ")" {
-           $$ = $2;
+        | declaration {
+            $$ = Driver.create<Algorithm>();
+            Driver.setAlgorithm($$);
+            $$->append($1);
+          }
+        | algorithm declaration {
+            $$ = $1;
+            $$->append($2);
           }
         ;
+
 
 algorithm_header_args
         : "header" {
@@ -326,6 +317,19 @@ control_flow
 declaration
         : "(" "define" define_args ")" {
             $$ = $3;
+          }
+        | "(" algorithm_header_args ")" {
+            $$ = $2;
+          }
+        | "(" "source" "." "type" "algorithm" ")" {
+            auto* SrcTy = Driver.create<SourceType>();
+            SrcTy->setIsAlgorithm(true);
+            $$ = SrcTy;
+          }
+        | "(" "source" "." "type" "data" ")" {
+            auto* SrcTy = Driver.create<SourceType>();
+            SrcTy->setIsAlgorithm(false);
+            $$ = SrcTy;
           }
         | "(" "rename" symbol symbol ")" {
             $$ = Driver.create<Rename>($3, $4);

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -89,7 +89,7 @@ void errorDescribeNodeContext(const char* Message,
 }
 
 static const char* PredefinedName[NumPredefinedSymbols]{"Unknown"
-#define X(tag, name) , name
+#define X(NAME, name) , name
                                                         PREDEFINED_SYMBOLS_TABLE
 #undef X
 };
@@ -138,8 +138,8 @@ const char* getName(PredefinedSymbol Sym) {
 }
 
 AstTraitsType AstTraits[NumNodeTypes] = {
-#define X(tag, opcode, sexp_name, text_num_args, text_max_args, NSL, hidden) \
-  {NodeType::tag, #tag, sexp_name, text_num_args, text_max_args, NSL, hidden},
+#define X(NAME, opcode, sexp_name, text_num_args, text_max_args, NSL, hidden) \
+  {NodeType::NAME, #NAME, sexp_name, text_num_args, text_max_args, NSL, hidden},
     AST_OPCODE_TABLE
 #undef X
 };
@@ -428,7 +428,8 @@ bool Cached::implementsClass(NodeType Type) {
   switch (Type) {
     default:
       return false;
-#define X(tag) case NodeType::tag:
+#define X(NAME) \
+      case NodeType::NAME:
       AST_CACHEDNODE_TABLE
 #undef X
       return true;
@@ -1318,26 +1319,27 @@ bool Unary::implementsClass(NodeType Type) {
     default:
       return false;
     case NodeType::BinaryEval:
-#define X(tag, BASE, NODE_DECLS) \
-  case NodeType::tag:            \
+#define X(NAME, BASE, DECLS, INIT)     \
+  case NodeType::NAME:            \
     return true;
       AST_UNARYNODE_TABLE
 #undef X
   }
 }
 
-#define X(tag, BASE, NODE_DECLS) \
-  tag::tag(SymbolTable& Symtab, Node* Kid) : BASE(Symtab, NodeType::tag, Kid) {}
+#define X(NAME, BASE, DECLS, INIT)                                           \
+  NAME::NAME(SymbolTable& Symtab, Node* Kid) \
+      : BASE(Symtab, NodeType::NAME, Kid) { INIT }
 AST_UNARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS) \
-  template tag* SymbolTable::create<tag>(Node * Nd);
+#define X(NAME, BASE, DECLS, INIT)                           \
+  template NAME* SymbolTable::create<NAME>(Node * Nd);
 AST_UNARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS) \
-  tag::~tag() {}
+#define X(NAME, BASE, DECLS, INIT)                   \
+  NAME::~NAME() {}
 AST_UNARYNODE_TABLE
 #undef X
 
@@ -1634,27 +1636,27 @@ bool Binary::implementsClass(NodeType Type) {
   switch (Type) {
     default:
       return false;
-#define X(tag, BASE, NODE_DECLS) \
-  case NodeType::tag:            \
+#define X(NAME, BASE, DECLS, INIT)     \
+  case NodeType::NAME:            \
     return true;
       AST_BINARYNODE_TABLE
 #undef X
   }
 }
 
-#define X(tag, BASE, NODE_DECLS)                        \
-  tag::tag(SymbolTable& Symtab, Node* Kid1, Node* Kid2) \
-      : BASE(Symtab, NodeType::tag, Kid1, Kid2) {}
+#define X(NAME, BASE, DECLS, INIT)                             \
+  NAME::NAME(SymbolTable& Symtab, Node* Kid1, Node* Kid2) \
+      : BASE(Symtab, NodeType::NAME, Kid1, Kid2) { INIT }
 AST_BINARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS) \
-  template tag* SymbolTable::create<tag>(Node * Nd1, Node * Nd2);
+#define X(NAME, BASE, DECLS, INIT)                                           \
+  template NAME* SymbolTable::create<NAME>(Node * Nd1, Node * Nd2);
 AST_BINARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS) \
-  tag::~tag() {}
+#define X(NAME, BASE, DECLS, INIT)                   \
+  NAME::~NAME() {}
 AST_BINARYNODE_TABLE
 #undef X
 
@@ -1690,27 +1692,27 @@ bool Ternary::implementsClass(NodeType Type) {
   switch (Type) {
     default:
       return false;
-#define X(tag, BASE, NODE_DECLS) \
-  case NodeType::tag:            \
+#define X(NAME, BASE, DECLS, INIT)     \
+  case NodeType::NAME:            \
     return true;
       AST_TERNARYNODE_TABLE
 #undef X
   }
 }
 
-#define X(tag, BASE, NODE_DECLS)                                    \
-  tag::tag(SymbolTable& Symtab, Node* Kid1, Node* Kid2, Node* Kid3) \
-      : BASE(Symtab, NodeType::tag, Kid1, Kid2, Kid3) {}
+#define X(NAME, BASE, DECLS, INIT)                                         \
+  NAME::NAME(SymbolTable& Symtab, Node* Kid1, Node* Kid2, Node* Kid3) \
+      : BASE(Symtab, NodeType::NAME, Kid1, Kid2, Kid3) { INIT }
 AST_TERNARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS) \
-  template tag* SymbolTable::create<tag>(Node * Nd1, Node * Nd2, Node * Nd3);
+#define X(NAME, BASE, DECLS, INIT)                                           \
+  template NAME* SymbolTable::create<NAME>(Node * Nd1, Node * Nd2, Node * Nd3);
 AST_TERNARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS) \
-  tag::~tag() {}
+#define X(NAME, BASE, DECLS, INIT)                   \
+  NAME::~NAME() {}
 AST_TERNARYNODE_TABLE
 #undef X
 
@@ -1978,8 +1980,8 @@ bool SelectBase::implementsClass(NodeType Type) {
   switch (Type) {
     default:
       return false;
-#define X(tag, NODE_DECLS) \
-  case NodeType::tag:      \
+#define X(NAME, BASE, DECLS, INIT)                   \
+  case NodeType::NAME:      \
     return true;
       AST_SELECTNODE_TABLE
 #undef X
@@ -2168,17 +2170,19 @@ bool collectCaseWidths(IntType Key,
 
 }  // end of anonymous namespace
 
-#define X(tag, NODE_DECLS) \
-  tag::tag(SymbolTable& Symtab) : SelectBase(Symtab, NodeType::tag) {}
+#define X(NAME, BASE, DECLS, INIT)                                           \
+  NAME::NAME(SymbolTable& Symtab) \
+      : BASE(Symtab, NodeType::NAME) { INIT }
 AST_SELECTNODE_TABLE
 #undef X
 
-#define X(tag, NODE_DECLS) template tag* SymbolTable::create<tag>();
+#define X(NAME, BASE, DECLS, INIT) \
+  template NAME* SymbolTable::create<NAME>();
 AST_SELECTNODE_TABLE
 #undef X
 
-#define X(tag, NODE_DECLS) \
-  tag::~tag() {}
+#define X(NAME, BASE, DECLS,INIT)                   \
+  NAME::~NAME() {}
 AST_SELECTNODE_TABLE
 #undef X
 

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -1937,7 +1937,7 @@ bool Algorithm::validateNode(ConstNodeVectorType& Parents) const {
   WriteHdr = nullptr;
   IsAlgorithmSpecified = false;
   for (const Node* Kid : *this) {
-    switch (NodeType Opcode = Kid->getType()) {
+    switch (Kid->getType()) {
       case NodeType::SourceHeader:
         if (SourceHdr) {
           errorDescribeNode("Duplicate source header", Kid);

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -110,6 +110,7 @@
   X(SourceHeader,      0x77, "header",           0, 3, true,  false)           \
   X(ReadHeader,        0x78, "header.read",      0, 3, true,  false)           \
   X(WriteHeader,       0x79, "header.write",     0, 3, true,  false)           \
+  X(SourceType,        0x80, "source.type",      0, 0, false, false)           \
                                                                                \
   /* Internal (not opcodes in compressed file) */                              \
   X(UnknownSection,    0xFF, "unknown.section",  1, 0, true,  false)           \
@@ -129,6 +130,15 @@
   X(Varuint32, Nullary,)                                                       \
   X(Varuint64, Nullary,)                                                       \
   X(Void, Nullary,)                                                            \
+  X(SourceType, Nullary, SOURCE_TYPE_DECLS)                                    \
+
+#define SOURCE_TYPE_DECLS                                                      \
+ public:                                                                       \
+  bool getIsAlgorithm() const { return IsAlgorithm; }                          \
+  void setIsAlgorithm(bool Value) {  IsAlgorithm = Value; }                    \
+ private:                                                                      \
+  bool IsAlgorithm = false;                                                    \
+  
 
 //#define X(tag, defval, mergable, BASE, NODE_DECLS)
 // where:
@@ -236,7 +246,14 @@
     const Header* getSourceHeader(bool UseEnclosing=true) const;               \
     const Header* getReadHeader(bool UseEnclosing=true) const;                 \
     const Header* getWriteHeader(bool UseEnclosing=true) const;                \
+    bool isAlgorithm() const { return IsAlgorithmSpecified; }                  \
     bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;            \
+  private:                                                                     \
+    mutable const Header* SourceHdr = nullptr;                                 \
+    mutable const Header* ReadHdr = nullptr;                                   \
+    mutable const Header* WriteHdr = nullptr;                                  \
+    mutable bool IsAlgorithmSpecified = false;                                 \
+    mutable bool IsValidated = false;                                          \
 
 #define DEFINE_DECLS                                                           \
   public:                                                                      \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -119,43 +119,59 @@
   X(SymbolDefn,        0x100, "symbol.defn",     0, 0, false, false)           \
   X(IntLookup,         0x101, "int.lookup",      0, 0, false, false)           \
 
-//#define X(tag, BASE, NODE_DECLS)
-#define AST_NULLARYNODE_TABLE                                                  \
-  X(Bit, Nullary,)                                                             \
-  X(Error, Nullary,)                                                           \
-  X(LastRead, Nullary,)                                                        \
-  X(Uint32, Nullary,)                                                          \
-  X(Uint64, Nullary,)                                                          \
-  X(Uint8, Nullary,)                                                           \
-  X(Varint32, Nullary,)                                                        \
-  X(Varint64, Nullary,)                                                        \
-  X(Varuint32, Nullary,)                                                       \
-  X(Varuint64, Nullary,)                                                       \
-  X(Void, Nullary,)                                                            \
-
-//#define X(tag, defval, mergable, BASE, NODE_DECLS)
+//#define X(NAME, BASE, NODE_DECLS, INIT)
 // where:
-//   tag: enumeration name (less Op prefix).
-//   format: Format for printing out value.
-//   defval: Default value assumed if not provided.
-//   mergable: True if instances can be merged.
+//   NAME: Class/enum node type name
 //   BASE: Base class for node class.
-//   NODE_DECLS: Other declarations for the node.
-#define AST_INTEGERNODE_TABLE                                                  \
-  X(I32Const, Varint32, 0, true, IntegerNode,)                                 \
-  X(I64Const, Varint64, 0, true, IntegerNode,)                                 \
-  X(Local, Varuint32, 0, true, IntegerNode, LOCAL_DECLS)                       \
-  X(Locals, Varuint32, 0, true, IntegerNode,)                                  \
-  X(Param, Varuint32, 0, false, IntegerNode, PARAM_DECLS)                      \
-  X(Params, Varuint32, 0, false, IntegerNode,)                                 \
-  X(U8Const, Uint8, 0, true, IntegerNode,)                                     \
-  X(U32Const, Varuint32, 0, true, IntegerNode,)                                \
-  X(U64Const, Varuint64, 0, true, IntegerNode,)                                \
+//   DECLS: Other declarations for the node.
+//   INIT: code to run in the body of the constructors to finish
+//         initialization
+#define AST_NULLARYNODE_TABLE                                                  \
+  X(Bit, Nullary,,)                                                            \
+  X(Error, Nullary,,)                                                          \
+  X(LastRead, Nullary,,)                                                       \
+  X(Uint32, Nullary,,)                                                         \
+  X(Uint64, Nullary,,)                                                         \
+  X(Uint8, Nullary,,)                                                          \
+  X(Varint32, Nullary,,)                                                       \
+  X(Varint64, Nullary,,)                                                       \
+  X(Varuint32, Nullary,,)                                                      \
+  X(Varuint64, Nullary,,)                                                      \
+  X(Void, Nullary,,)                                                           \
 
-//#define X(tag, BASE, VALUE, FORMAT, NODE_DECLS)
+//#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT)
+// where:
+//   NAME: Class/enum node type name
+//   FORMAT: The binary format (in binary files) of the value.
+//   DEFAULT: Default value assumed if not provided.
+//   MERGE: True if instances can be merged.
+//   BASE: Base class for node class.
+//   DECLS: Other declarations for the node.
+//   INIT: code to run in the body of the constructors to finish
+//         initialization
+#define AST_INTEGERNODE_TABLE                                                  \
+  X(I32Const, Varint32, 0, true, IntegerNode,,)                                \
+  X(I64Const, Varint64, 0, true, IntegerNode,,)                                \
+  X(Local, Varuint32, 0, true, IntegerNode, LOCAL_DECLS,)                      \
+  X(Locals, Varuint32, 0, true, IntegerNode,,)                                 \
+  X(Param, Varuint32, 0, false, IntegerNode, PARAM_DECLS,)                     \
+  X(Params, Varuint32, 0, false, IntegerNode,,)                                \
+  X(U8Const, Uint8, 0, true, IntegerNode,,)                                    \
+  X(U32Const, Varuint32, 0, true, IntegerNode,,)                               \
+  X(U64Const, Varuint64, 0, true, IntegerNode,,)                               \
+
+//#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT)
+// where:
+//   NAME: Class/enum node type name
+//   BASE: Base class for node class.
+//   VALUE: The value of the literal.
+//   FORMAT: The ValueFormat to use to represent the literal.
+//   DECLS: Other declarations for the node.
+//   INIT: code to run in the body of the constructors to finish
+//         initialization
 #define AST_LITERAL_TABLE                                                      \
-  X(Zero, IntegerNode, 0, Decimal,)                                            \
-  X(One, IntegerNode, 1, Decimal,)                                             \
+  X(Zero, IntegerNode, 0, Decimal,,)                                           \
+  X(One, IntegerNode, 1, Decimal,,)                                            \
 
 #define LOCAL_DECLS                                                            \
   public:                                                                      \
@@ -228,17 +244,17 @@
   X(Switch,)                                                                   \
   X(Map,)                                                                      \
 
-//#define X(tag, BASE, NODE_DECLS)
+//#define X(tag, BASE, NODE_DECLS, CTR_INIT)
 #define AST_NARYNODE_TABLE                                                     \
-  X(Algorithm, Nary, ALGORITHM_DECLS)                                          \
-  X(Define, Nary, DEFINE_DECLS)                                                \
-  X(Eval, Nary, EVAL_DECLS)                                                    \
-  X(LiteralActionBase, Nary,)                                                  \
-  X(ReadHeader, Header,)                                                       \
-  X(Sequence, Nary,)                                                           \
-  X(SourceHeader, Header,)                                                     \
-  X(Write, Nary,)                                                              \
-  X(WriteHeader, Header,)                                                      \
+  X(Algorithm, Nary, ALGORITHM_DECLS, init();)                                 \
+  X(Define, Nary, DEFINE_DECLS,)                                               \
+  X(Eval, Nary, EVAL_DECLS,)                                                   \
+  X(LiteralActionBase, Nary,,)                                                 \
+  X(ReadHeader, Header,,)                                                      \
+  X(Sequence, Nary,,)                                                          \
+  X(SourceHeader, Header,,)                                                    \
+  X(Write, Nary,,)                                                             \
+  X(WriteHeader, Header,,)                                                     \
 
 #define ALGORITHM_DECLS                                                        \
   public:                                                                      \
@@ -247,12 +263,13 @@
     const Header* getWriteHeader(bool UseEnclosing=true) const;                \
     bool isAlgorithm() const { return IsAlgorithmSpecified; }                  \
     bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;            \
+    void init();                                                               \
   private:                                                                     \
-    mutable const Header* SourceHdr = nullptr;                                 \
-    mutable const Header* ReadHdr = nullptr;                                   \
-    mutable const Header* WriteHdr = nullptr;                                  \
-    mutable bool IsAlgorithmSpecified = false;                                 \
-    mutable bool IsValidated = false;                                          \
+    mutable const Header* SourceHdr;                                           \
+    mutable const Header* ReadHdr;                                             \
+    mutable const Header* WriteHdr;                                            \
+    mutable bool IsAlgorithmSpecified;                                         \
+    mutable bool IsValidated;                                                  \
 
 #define DEFINE_DECLS                                                           \
   public:                                                                      \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -54,6 +54,8 @@
   X(U8Const,           0x14, "u8.const",         1, 0, false, false)           \
   X(U32Const,          0x15, "u32.const",        1, 0, false, false)           \
   X(U64Const,          0x16, "u64.const",        1, 0, false, false)           \
+  X(Zero,              0x17, "0",                0, 0, false, false)           \
+  X(One,               0x18, "1",                0, 0, false, false)           \
                                                                                \
   /* Formatting */                                                             \
   X(Uint32,            0x20, "uint32",           0, 0, false, false)           \
@@ -97,7 +99,7 @@
                                                                                \
   /* Declarations */                                                           \
   X(Define,            0x60, "define",           2, 1, true,  true)            \
-  X(Algorithm,         0x62, "algorithm",        2, 0, false, false)           \
+  X(Algorithm,         0x62, "algorithm.node",   2, 0, false, false)           \
   X(Undefine,          0x64, "undefine",         1, 0, true, false)            \
   X(LiteralDef,        0x65, "literal",          2, 0, false, false)           \
   X(LiteralUse,        0x66, "literal.use",      1, 0, false, false)           \
@@ -110,7 +112,7 @@
   X(SourceHeader,      0x77, "header",           0, 3, true,  false)           \
   X(ReadHeader,        0x78, "header.read",      0, 3, true,  false)           \
   X(WriteHeader,       0x79, "header.write",     0, 3, true,  false)           \
-  X(SourceType,        0x80, "source.type",      0, 0, false, false)           \
+  X(AlgorithmFlag,     0x7a, "algorithm",        1, 0, false, false)           \
                                                                                \
   /* Internal (not opcodes in compressed file) */                              \
   X(UnknownSection,    0xFF, "unknown.section",  1, 0, true,  false)           \
@@ -130,15 +132,6 @@
   X(Varuint32, Nullary,)                                                       \
   X(Varuint64, Nullary,)                                                       \
   X(Void, Nullary,)                                                            \
-  X(SourceType, Nullary, SOURCE_TYPE_DECLS)                                    \
-
-#define SOURCE_TYPE_DECLS                                                      \
- public:                                                                       \
-  bool getIsAlgorithm() const { return IsAlgorithm; }                          \
-  void setIsAlgorithm(bool Value) {  IsAlgorithm = Value; }                    \
- private:                                                                      \
-  bool IsAlgorithm = false;                                                    \
-  
 
 //#define X(tag, defval, mergable, BASE, NODE_DECLS)
 // where:
@@ -159,6 +152,11 @@
   X(U32Const, Varuint32, 0, true, IntegerNode,)                                \
   X(U64Const, Varuint64, 0, true, IntegerNode,)                                \
 
+//#define X(tag, BASE, VALUE, FORMAT, NODE_DECLS)
+#define AST_LITERAL_TABLE                                                      \
+  X(Zero, IntegerNode, 0, Decimal,)                                            \
+  X(One, IntegerNode, 1, Decimal,)                                             \
+
 #define LOCAL_DECLS                                                            \
   public:                                                                      \
     bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;            \
@@ -169,6 +167,7 @@
 
 //#define X(tag, BASE, NODE_DECLS)
 #define AST_UNARYNODE_TABLE                                                    \
+  X(AlgorithmFlag, Unary,)                                                     \
   X(Block, Unary,)                                                             \
   X(BitwiseNegate, Unary,)                                                     \
   X(Callback, Unary, CALLBACK_DECLS)                                           \

--- a/src/sexp/Ast.def
+++ b/src/sexp/Ast.def
@@ -119,7 +119,7 @@
   X(SymbolDefn,        0x100, "symbol.defn",     0, 0, false, false)           \
   X(IntLookup,         0x101, "int.lookup",      0, 0, false, false)           \
 
-//#define X(NAME, BASE, NODE_DECLS, INIT)
+//#define X(NAME, BASE, DECLS, INIT)
 // where:
 //   NAME: Class/enum node type name
 //   BASE: Base class for node class.
@@ -181,21 +181,27 @@
   public:                                                                      \
     bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;            \
 
-//#define X(tag, BASE, NODE_DECLS)
+//#define X(NAME, BASE, DECLS, INIT)
+// where:
+//   NAME: Class/enum node type name
+//   BASE: Base class for node class.
+//   DECLS: Other declarations for the node.
+//   INIT: code to run in the body of the constructors to finish
+//         initialization
 #define AST_UNARYNODE_TABLE                                                    \
-  X(AlgorithmFlag, Unary,)                                                     \
-  X(Block, Unary,)                                                             \
-  X(BitwiseNegate, Unary,)                                                     \
-  X(Callback, Unary, CALLBACK_DECLS)                                           \
-  X(LastSymbolIs, Unary,)                                                      \
-  X(LiteralActionUse, Unary, LITERALACTIONUSE_DECLS)                           \
-  X(LiteralUse, Unary, LITERALUSE_DECLS)                                       \
-  X(LoopUnbounded, Unary,)                                                     \
-  X(Not, Unary,)                                                               \
-  X(Peek, Unary,)                                                              \
-  X(Read, Unary,)                                                              \
-  X(Undefine, Unary,)                                                          \
-  X(UnknownSection, Unary,)                                                    \
+  X(AlgorithmFlag, Unary,,)                                                    \
+  X(Block, Unary,,)                                                            \
+  X(BitwiseNegate, Unary,,)                                                    \
+  X(Callback, Unary, CALLBACK_DECLS,)                                          \
+  X(LastSymbolIs, Unary,,)                                                     \
+  X(LiteralActionUse, Unary, LITERALACTIONUSE_DECLS,)                          \
+  X(LiteralUse, Unary, LITERALUSE_DECLS,)                                      \
+  X(LoopUnbounded, Unary,,)                                                    \
+  X(Not, Unary,,)                                                              \
+  X(Peek, Unary,,)                                                             \
+  X(Read, Unary,,)                                                             \
+  X(Undefine, Unary,,)                                                         \
+  X(UnknownSection, Unary,,)                                                   \
 
 #define CALLBACK_DECLS                                                         \
   public:                                                                      \
@@ -213,22 +219,28 @@
   const IntegerNode* getIntNode() const;                                       \
   bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;              \
 
-//#define X(tag, BASE, NODE_DECLS)
+//#define X(NAME, BASE, DECLS, INIT)
+// where:
+//   NAME: Class/enum node type name
+//   BASE: Base class for node class.
+//   DECLS: Other declarations for the node.
+//   INIT: code to run in the body of the constructors to finish
+//         initialization
 #define AST_BINARYNODE_TABLE                                                   \
-  X(And, Binary,)                                                              \
-  X(BinarySelect, Binary,)                                                     \
-  X(BitwiseAnd, Binary,)                                                       \
-  X(BitwiseOr, Binary,)                                                        \
-  X(BitwiseXor, Binary,)                                                       \
-  X(Case, Binary, CASE_DECLS)                                                  \
-  X(IfThen, Binary,)                                                           \
-  X(LiteralActionDef, Binary,)                                                 \
-  X(LiteralDef, Binary,)                                                       \
-  X(Loop, Binary,)                                                             \
-  X(Or, Binary,)                                                               \
-  X(Rename, Binary,)                                                           \
-  X(Set, Binary,)                                                              \
-  X(Table, Binary,)                                                            \
+  X(And, Binary,,)                                                             \
+  X(BinarySelect, Binary,,)                                                    \
+  X(BitwiseAnd, Binary,,)                                                      \
+  X(BitwiseOr, Binary,,)                                                       \
+  X(BitwiseXor, Binary,,)                                                      \
+  X(Case, Binary, CASE_DECLS,)                                                 \
+  X(IfThen, Binary,,)                                                          \
+  X(LiteralActionDef, Binary,,)                                                \
+  X(LiteralDef, Binary,,)                                                      \
+  X(Loop, Binary,,)                                                            \
+  X(Or, Binary,,)                                                              \
+  X(Rename, Binary,,)                                                          \
+  X(Set, Binary,,)                                                             \
+  X(Table, Binary,,)                                                           \
 
 #define CASE_DECLS                                                             \
   public:                                                                      \
@@ -239,12 +251,24 @@
     mutable decode::IntType Value;                                             \
     mutable const Node* CaseBody;                                              \
 
-//#define X(tag, NODE_DECLS)
+//#define X(NAME, BASE, DECLS, INIT)
+// where:
+//   NAME: Class/enum node type name
+//   BASE: Base class for node class.
+//   DECLS: Other declarations for the node.
+//   INIT: code to run in the body of the constructors to finish
+//         initialization
 #define AST_SELECTNODE_TABLE                                                   \
-  X(Switch,)                                                                   \
-  X(Map,)                                                                      \
+  X(Switch, SelectBase,,)                                                      \
+  X(Map, SelectBase,,)                                                         \
 
-//#define X(tag, BASE, NODE_DECLS, CTR_INIT)
+//#define X(NAME, BASE, DECLS, INIT)
+// where:
+//   NAME: Class/enum node type name
+//   BASE: Base class for node class.
+//   DECLS: Other declarations for the node.
+//   INIT: code to run in the body of the constructors to finish
+//         initialization
 #define AST_NARYNODE_TABLE                                                     \
   X(Algorithm, Nary, ALGORITHM_DECLS, init();)                                 \
   X(Define, Nary, DEFINE_DECLS,)                                               \
@@ -284,11 +308,19 @@
   Symbol* getCallName() const;                                                 \
   bool validateNode(ConstNodeVectorType &Parents) const OVERRIDE;              \
 
-//#define X(tag, BASE, NODE_DECLS)
+//#define X(NAME, BASE, DECLS, INIT)
+// where:
+//   NAME: Class/enum node type name
+//   BASE: Base class for node class.
+//   DECLS: Other declarations for the node.
+//   INIT: code to run in the body of the constructors to finish
+//         initialization
 #define AST_TERNARYNODE_TABLE                                                  \
-  X(IfThenElse, Ternary,)                                                      \
+  X(IfThenElse, Ternary,,)                                                     \
 
-//#define X(tag)
+//#define X(NAME)
+// where:
+//   NAME: Class/enum node type name
 #define AST_CACHEDNODE_TABLE                                                   \
   X(SymbolDefn)                                                                \
   X(IntLookup)                                                                 \

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -571,6 +571,23 @@ AST_NULLARYNODE_TABLE
 AST_INTEGERNODE_TABLE
 #undef X
 
+#define X(tag, BASE, VALUE, FORMAT, NODE_DECLS) \
+  class tag FINAL : public BASE {                                   \
+    tag() = delete;                                                 \
+    tag(const tag&) = delete;                                       \
+    tag& operator=(const tag&) = delete;                            \
+                                                                    \
+   public:                                                          \
+    tag(SymbolTable& Symtab);                                       \
+    ~tag() OVERRIDE;                                                \
+    static bool implementsClass(NodeType Type) {                    \
+      return Type == NodeType::tag;                                 \
+    }                                                               \
+    NODE_DECLS                                                      \
+  };
+AST_LITERAL_TABLE
+#undef X
+
 // The Value/Numbit fields are set by validateNode(). NumBits is the number of
 // bits used to reach this accept, and Value encodes the path (from leaf to
 // root) for the accept node. Note: The Value is unique for each accept, and

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -57,7 +57,8 @@ class SymbolTable;
 class Callback;
 class WriteHeader;
 
-#define X(tag, format, defval, mergable, BASE, NODE_DECLS) class tag;
+#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT) \
+  class NAME;
 AST_INTEGERNODE_TABLE
 #undef X
 
@@ -533,57 +534,57 @@ class IntLookup FINAL : public Cached {
   LookupMap Lookup;
 };
 
-#define X(tag, BASE, NODE_DECLS)                 \
-  class tag FINAL : public BASE {                \
-    tag() = delete;                              \
-    tag(const tag&) = delete;                    \
-    tag& operator=(const tag&) = delete;         \
+#define X(NAME, BASE, DECLS, INIT)                    \
+  class NAME FINAL : public BASE {                \
+    NAME() = delete;                              \
+    NAME(const NAME&) = delete;                    \
+    NAME& operator=(const NAME&) = delete;         \
                                                  \
    public:                                       \
-    explicit tag(SymbolTable& Symtab);           \
-    ~tag() OVERRIDE;                             \
+    explicit NAME(SymbolTable& Symtab);           \
+    ~NAME() OVERRIDE;                             \
     static bool implementsClass(NodeType Type) { \
-      return Type == NodeType::tag;              \
+      return Type == NodeType::NAME;              \
     }                                            \
-    NODE_DECLS                                   \
+    DECLS                                   \
   };
 AST_NULLARYNODE_TABLE
 #undef X
 
-#define X(tag, format, defval, mergable, BASE, NODE_DECLS)          \
-  class tag FINAL : public BASE {                                   \
-    tag() = delete;                                                 \
-    tag(const tag&) = delete;                                       \
-    tag& operator=(const tag&) = delete;                            \
+#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT)          \
+  class NAME FINAL : public BASE {                                   \
+    NAME() = delete;                                                 \
+    NAME(const NAME&) = delete;                                       \
+    NAME& operator=(const NAME&) = delete;                            \
                                                                     \
-   public:                                                          \
-    tag(SymbolTable& Symtab,                                        \
+  public:                                                          \
+    NAME(SymbolTable& Symtab,                                        \
         decode::IntType Value,                                      \
         decode::ValueFormat Format = decode::ValueFormat::Decimal); \
                                                                     \
-    tag(SymbolTable& Symtab);                                       \
-    ~tag() OVERRIDE;                                                \
+    NAME(SymbolTable& Symtab);                                       \
+    ~NAME() OVERRIDE;                                                \
     static bool implementsClass(NodeType Type) {                    \
-      return Type == NodeType::tag;                                 \
+      return Type == NodeType::NAME;                                 \
     }                                                               \
-    NODE_DECLS                                                      \
+    DECLS                                                      \
   };
 AST_INTEGERNODE_TABLE
 #undef X
 
-#define X(tag, BASE, VALUE, FORMAT, NODE_DECLS) \
-  class tag FINAL : public BASE {                                   \
-    tag() = delete;                                                 \
-    tag(const tag&) = delete;                                       \
-    tag& operator=(const tag&) = delete;                            \
+#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT)                        \
+  class NAME FINAL : public BASE {                                   \
+    NAME() = delete;                                                 \
+    NAME(const NAME&) = delete;                                       \
+    NAME& operator=(const NAME&) = delete;                            \
                                                                     \
    public:                                                          \
-    tag(SymbolTable& Symtab);                                       \
-    ~tag() OVERRIDE;                                                \
+    NAME(SymbolTable& Symtab);                                       \
+    ~NAME() OVERRIDE;                                                \
     static bool implementsClass(NodeType Type) {                    \
-      return Type == NodeType::tag;                                 \
+      return Type == NodeType::NAME;                                 \
     }                                                               \
-    NODE_DECLS                                                      \
+    DECLS                                                      \
   };
 AST_LITERAL_TABLE
 #undef X
@@ -739,19 +740,19 @@ AST_BINARYNODE_TABLE
 AST_TERNARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS)                 \
-  class tag FINAL : public BASE {                \
-    tag() = delete;                              \
-    tag(const tag&) = delete;                    \
-    tag& operator=(const tag&) = delete;         \
+#define X(NAME, BASE, DECLS, INIT)       \
+  class NAME FINAL : public BASE {                \
+    NAME() = delete;                              \
+    NAME(const NAME&) = delete;                    \
+    NAME& operator=(const NAME&) = delete;         \
                                                  \
    public:                                       \
-    explicit tag(SymbolTable& Symtab);           \
-    ~tag() OVERRIDE;                             \
+    explicit NAME(SymbolTable& Symtab);           \
+    ~NAME() OVERRIDE;                             \
     static bool implementsClass(NodeType Type) { \
-      return NodeType::tag == Type;              \
+      return NodeType::NAME == Type;              \
     }                                            \
-    NODE_DECLS                                   \
+    DECLS                                   \
   };
 AST_NARYNODE_TABLE
 #undef X

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -689,53 +689,53 @@ class Symbol FINAL : public Nullary {
   void setPredefinedSymbol(PredefinedSymbol NewValue);
 };
 
-#define X(tag, BASE, NODE_DECLS)                 \
-  class tag FINAL : public BASE {                \
-    tag() = delete;                              \
-    tag(const tag&) = delete;                    \
-    tag& operator=(const tag&) = delete;         \
+#define X(NAME, BASE, DECLS, INIT)                     \
+  class NAME FINAL : public BASE {                \
+    NAME() = delete;                              \
+    NAME(const NAME&) = delete;                    \
+    NAME& operator=(const NAME&) = delete;         \
                                                  \
    public:                                       \
-    tag(SymbolTable& Symtab, Node* Kid);         \
-    ~tag() OVERRIDE;                             \
+    NAME(SymbolTable& Symtab, Node* Kid);         \
+    ~NAME() OVERRIDE;                             \
     static bool implementsClass(NodeType Type) { \
-      return NodeType::tag == Type;              \
+      return NodeType::NAME == Type;              \
     }                                            \
-    NODE_DECLS                                   \
+    DECLS                                   \
   };
 AST_UNARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS)                      \
-  class tag FINAL : public BASE {                     \
-    tag() = delete;                                   \
-    tag(const tag&) = delete;                         \
-    tag& operator=(const tag&) = delete;              \
+#define X(NAME, BASE, DECLS, INIT)                          \
+  class NAME FINAL : public BASE {                     \
+    NAME() = delete;                                   \
+    NAME(const NAME&) = delete;                         \
+    NAME& operator=(const NAME&) = delete;              \
                                                       \
    public:                                            \
-    tag(SymbolTable& Symtab, Node* Kid1, Node* Kid2); \
-    ~tag() OVERRIDE;                                  \
+    NAME(SymbolTable& Symtab, Node* Kid1, Node* Kid2); \
+    ~NAME() OVERRIDE;                                  \
     static bool implementsClass(NodeType Type) {      \
-      return NodeType::tag == Type;                   \
+      return NodeType::NAME == Type;                   \
     }                                                 \
-    NODE_DECLS                                        \
+    DECLS                                        \
   };
 AST_BINARYNODE_TABLE
 #undef X
 
-#define X(tag, BASE, NODE_DECLS)                                  \
-  class tag FINAL : public BASE {                                 \
-    tag() = delete;                                               \
-    tag(const tag&) = delete;                                     \
-    tag& operator=(const tag&) = delete;                          \
+#define X(NAME, BASE, DECLS, INIT)                                      \
+  class NAME FINAL : public BASE {                                 \
+    NAME() = delete;                                               \
+    NAME(const NAME&) = delete;                                     \
+    NAME& operator=(const NAME&) = delete;                          \
                                                                   \
    public:                                                        \
-    tag(SymbolTable& Symtab, Node* Kid1, Node* Kid2, Node* Kid3); \
-    ~tag() OVERRIDE;                                              \
+    NAME(SymbolTable& Symtab, Node* Kid1, Node* Kid2, Node* Kid3); \
+    ~NAME() OVERRIDE;                                              \
     static bool implementsClass(NodeType Type) {                  \
-      return NodeType::tag == Type;                               \
+      return NodeType::NAME == Type;                               \
     }                                                             \
-    NODE_DECLS                                                    \
+    DECLS                                                    \
   };
 AST_TERNARYNODE_TABLE
 #undef X
@@ -773,19 +773,19 @@ class SelectBase : public Nary {
   IntLookup* getIntLookup() const;
 };
 
-#define X(tag, NODE_DECLS)                       \
-  class tag FINAL : public SelectBase {          \
-    tag() = delete;                              \
-    tag(const tag&) = delete;                    \
-    tag& operator=(const tag&) = delete;         \
+#define X(NAME, BASE, DECLS, INIT)           \
+  class NAME FINAL : public BASE {          \
+    NAME() = delete;                              \
+    NAME(const NAME&) = delete;                    \
+    NAME& operator=(const NAME&) = delete;         \
                                                  \
    public:                                       \
-    explicit tag(SymbolTable& Symtab);           \
-    ~tag() OVERRIDE;                             \
+    explicit NAME(SymbolTable& Symtab);           \
+    ~NAME() OVERRIDE;                             \
     static bool implementsClass(NodeType Type) { \
-      return NodeType::tag == Type;              \
+      return NodeType::NAME == Type;              \
     }                                            \
-    NODE_DECLS                                   \
+    DECLS                                   \
   };
 AST_SELECTNODE_TABLE
 #undef X

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -218,14 +218,15 @@ void TextWriter::writeNode(const Node* Nd,
         break;
       writeNode(Nd->getKid(0), AddNewline, EmbedInParent);
       return;
+    case NodeType::SourceType:
+      return writeSourceType(cast<SourceType>(Nd), AddNewline);
+    case NodeType::Symbol:
+      return writeSymbol(cast<Symbol>(Nd), AddNewline);
     case NodeType::SymbolDefn: {
       Parenthesize _(this, Type, AddNewline);
       writeSpace();
       writeNode(cast<SymbolDefn>(Nd)->getSymbol(), false);
       return;
-    }
-    case NodeType::Symbol: {
-      return writeSymbolNode(cast<Symbol>(Nd), AddNewline);
     }
   }
   // Default case.
@@ -304,16 +305,18 @@ void TextWriter::writeNodeAbbrev(const Node* Nd,
       fprintf(File, "(%s ...)\n", getNodeName(Nd));
       return;
     }
-    case NodeType::Symbol:
-      return writeSymbolNode(cast<Symbol>(Nd), AddNewline);
-    case NodeType::SymbolDefn:
-      writeNode(Nd, AddNewline, EmbedInParent);
-      return;
     case NodeType::LiteralUse:
     case NodeType::LiteralActionUse:
       if (ShowInternalStructure)
         break;
       writeNodeAbbrev(Nd->getKid(0), AddNewline, EmbedInParent);
+      return;
+    case NodeType::SourceType:
+      return writeSourceType(cast<SourceType>(Nd), AddNewline);
+    case NodeType::Symbol:
+      return writeSymbol(cast<Symbol>(Nd), AddNewline);
+    case NodeType::SymbolDefn:
+      writeNode(Nd, AddNewline, EmbedInParent);
       return;
   }
   Parenthesize _(this, Type, AddNewline);
@@ -366,7 +369,7 @@ void TextWriter::writeSymbolName(std::string Name) {
   fputc('\'', File);
 }
 
-void TextWriter::writeSymbolNode(const Symbol* Sym, bool AddNewline) {
+void TextWriter::writeSymbol(const Symbol* Sym, bool AddNewline) {
   if (ShowInternalStructure) {
     Parenthesize _(this, Sym->getType(), AddNewline);
     writeSpace();
@@ -377,6 +380,13 @@ void TextWriter::writeSymbolNode(const Symbol* Sym, bool AddNewline) {
     LineEmpty = false;
   }
   return;
+}
+
+void TextWriter::writeSourceType(const SourceType* SrcTy, bool AddNewline) {
+  Parenthesize _(this, SrcTy->getType(), AddNewline);
+  writeSpace();
+  fprintf(File, "%s",
+          cast<SourceType>(SrcTy)->getIsAlgorithm() ? "algorithm" : "data");
 }
 
 void TextWriter::writeIntegerNode(const IntegerNode* Int, bool AddNewline) {

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -218,8 +218,6 @@ void TextWriter::writeNode(const Node* Nd,
         break;
       writeNode(Nd->getKid(0), AddNewline, EmbedInParent);
       return;
-    case NodeType::SourceType:
-      return writeSourceType(cast<SourceType>(Nd), AddNewline);
     case NodeType::Symbol:
       return writeSymbol(cast<Symbol>(Nd), AddNewline);
     case NodeType::SymbolDefn: {
@@ -311,8 +309,6 @@ void TextWriter::writeNodeAbbrev(const Node* Nd,
         break;
       writeNodeAbbrev(Nd->getKid(0), AddNewline, EmbedInParent);
       return;
-    case NodeType::SourceType:
-      return writeSourceType(cast<SourceType>(Nd), AddNewline);
     case NodeType::Symbol:
       return writeSymbol(cast<Symbol>(Nd), AddNewline);
     case NodeType::SymbolDefn:
@@ -380,13 +376,6 @@ void TextWriter::writeSymbol(const Symbol* Sym, bool AddNewline) {
     LineEmpty = false;
   }
   return;
-}
-
-void TextWriter::writeSourceType(const SourceType* SrcTy, bool AddNewline) {
-  Parenthesize _(this, SrcTy->getType(), AddNewline);
-  writeSpace();
-  fprintf(File, "%s",
-          cast<SourceType>(SrcTy)->getIsAlgorithm() ? "algorithm" : "data");
 }
 
 void TextWriter::writeIntegerNode(const IntegerNode* Int, bool AddNewline) {

--- a/src/sexp/TextWriter.h
+++ b/src/sexp/TextWriter.h
@@ -32,6 +32,7 @@ namespace filt {
 
 class Node;
 class IntegerNode;
+class SourceType;
 class Symbol;
 class SymbolTable;
 
@@ -116,7 +117,8 @@ class TextWriter {
                        bool EmbedInParent = false);
   void writeNodeKidsAbbrev(const Node* Node, bool EmbeddedInParent);
 
-  void writeSymbolNode(const Symbol* Sym, bool AddNewline);
+  void writeSourceType(const SourceType* SrcTy, bool AddNewline);
+  void writeSymbol(const Symbol* Sym, bool AddNewline);
   void writeSymbolName(std::string Name);
   void writeIntegerNode(const IntegerNode* Int, bool AddNewline);
 

--- a/src/sexp/TextWriter.h
+++ b/src/sexp/TextWriter.h
@@ -32,7 +32,6 @@ namespace filt {
 
 class Node;
 class IntegerNode;
-class SourceType;
 class Symbol;
 class SymbolTable;
 
@@ -117,7 +116,6 @@ class TextWriter {
                        bool EmbedInParent = false);
   void writeNodeKidsAbbrev(const Node* Node, bool EmbeddedInParent);
 
-  void writeSourceType(const SourceType* SrcTy, bool AddNewline);
   void writeSymbol(const Symbol* Sym, bool AddNewline);
   void writeSymbolName(std::string Name);
   void writeIntegerNode(const IntegerNode* Int, bool AddNewline);


### PR DESCRIPTION
Literals simplify the text form, and allow better compression for predefined literals.

Adds flag to communicate when algorithm parses algorithms. This allows one version of an algorithm to be used to parse a different (i.e. new) version.