### PR TITLE
Remove need for interpreter method EvalParam.

### DIFF
--- a/src/interp/Interpreter.def
+++ b/src/interp/Interpreter.def
@@ -40,7 +40,6 @@ X(GetAlgorithm)                                               \
 X(CopyBlock)                                                  \
 X(Eval)                                                       \
 X(EvalBlock)                                                  \
-X(EvalParam)                                                  \
 X(Finished)                                                   \
 X(GetFile)                                                    \
 X(HasFileHeader)                                              \


### PR DESCRIPTION
Backfilled into the Eval method, since there is no gain (except for code complexity) for a separate method with an indirect dispatch.