### PR TITLE
Clean up lexical scoping of expression parameters.

### DIFF
--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -297,6 +297,7 @@ void Interpreter::init() {
   CurSectionName.reserve(MaxExpectedSectionNameSize);
   FrameStack.reserve(DefaultStackSize);
   CallingEvalStack.reserve(DefaultStackSize);
+  CurEvalFrameStack.reserve(DefaultStackSize);
   LocalsBaseStack.reserve(DefaultStackSize);
   LocalValues.reserve(DefaultStackSize * DefaultExpectedLocals);
   OpcodeLocalsStack.reserve(DefaultStackSize);
@@ -355,6 +356,9 @@ void Interpreter::describeCallingEvalStack(FILE* File) {
   TextWriter Writer;
   for (const auto& Frame : CallingEvalStack.iterRange(1))
     Frame.describe(File, &Writer);
+  fprintf(File, "*** Current Eval Call Stack ***\n");
+  for (size_t Index : CurEvalFrameStack)
+    fprintf(File, "%" PRIuMAX "\n", uintmax_t(Index));
   fprintf(File, "************************\n");
 }
 
@@ -1288,7 +1292,7 @@ void Interpreter::algorithmResume() {
           case NodeType::Param:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter: {
-                if (CallingEvalStack.empty())
+                if (CallingEvalStack.empty() || CurEvalFrameStack.empty())
                   return throwMessage(
                       "Not inside a call frame, can't evaluate parameter "
                       "accessor!");
@@ -1299,14 +1303,23 @@ void Interpreter::algorithmResume() {
                   return throwMessage(
                       "Parameter reference doesn't match callling context!");
                 const Node* Context = CallingEval.Caller->getKid(ParamIndex);
-                CallingEvalStack.push(
-                    CallingEvalStack.at(CallingEval.CallingEvalIndex));
+                size_t ContextFrameIndex =
+                    CurEvalFrameStack[CurEvalFrameStack.back()];
+                if (ContextFrameIndex != CallingEval.CallingEvalIndex) {
+                  fprintf(stderr,
+                          "Cur Frame index mismatch: %" PRIuMAX " and %" PRIuMAX
+                          "\n",
+                          uintmax_t(ContextFrameIndex),
+                          uintmax_t(CallingEval.CallingEvalIndex));
+                  return throwMessage("Unable to continue");
+                }
+                CurEvalFrameStack.push_back(ContextFrameIndex);
                 Frame.CallState = State::Exit;
                 call(Method::Eval, Frame.CallModifier, Context);
                 break;
               }
               case State::Exit:
-                CallingEvalStack.pop();
+                CurEvalFrameStack.pop_back();
                 popAndReturn(Frame.ReturnValue);
                 break;
               default:
@@ -1394,6 +1407,7 @@ void Interpreter::algorithmResume() {
                   return throwMessage("Unable to evaluate call");
                 }
                 size_t CallingEvalIndex = CallingEvalStack.size();
+                CurEvalFrameStack.push_back(CallingEvalIndex);
                 CallingEvalStack.push();
                 CallingEval.Caller = cast<Eval>(Frame.Nd);
                 CallingEval.CallingEvalIndex = CallingEvalIndex;
@@ -1402,6 +1416,7 @@ void Interpreter::algorithmResume() {
                 break;
               }
               case State::Exit:
+                CurEvalFrameStack.pop_back();
                 CallingEvalStack.pop();
                 popAndReturn(LastReadValue);
                 break;

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1305,14 +1305,6 @@ void Interpreter::algorithmResume() {
                 const Node* Context = CallingEval.Caller->getKid(ParamIndex);
                 size_t ContextFrameIndex =
                     CurEvalFrameStack[CurEvalFrameStack.back()];
-                if (ContextFrameIndex != CallingEval.CallingEvalIndex) {
-                  fprintf(stderr,
-                          "Cur Frame index mismatch: %" PRIuMAX " and %" PRIuMAX
-                          "\n",
-                          uintmax_t(ContextFrameIndex),
-                          uintmax_t(CallingEval.CallingEvalIndex));
-                  return throwMessage("Unable to continue");
-                }
                 CurEvalFrameStack.push_back(ContextFrameIndex);
                 Frame.CallState = State::Exit;
                 call(Method::Eval, Frame.CallModifier, Context);

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -241,6 +241,7 @@ class Interpreter {
   // The stack of (eval) calls.
   EvalFrame CallingEval;
   utils::ValueStack<EvalFrame> CallingEvalStack;
+  std::vector<size_t> CurEvalFrameStack;
   // The stack of loop counters.
   size_t LoopCounter;
   utils::ValueStack<size_t> LoopCounterStack;


### PR DESCRIPTION
Simplify to using a current eval frame to denote lexical scope for expression parameters.

This means that we don't have to push copies of eval frames onto the stack while evaluating expression parameters. This doesn't help much at the moment, but will as shortly as eval frame will become more complex as other types of parameter passing is added to the model.