### PR TITLE
Inherit s-expressions from boot algorithm for casm0x0.cast

### DIFF
--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -20,9 +20,11 @@
 (header (u32.const 0x6d736163) (u32.const 0x0))
 (algorithm 1)
 
-(define 'node'
-  (switch (uint8)
-    (error)
+(rename 'node' 'node.old')
+
+(define 'node' (params 1)
+  (switch (param 0)
+    (eval 'node.old' (param 0))
     (case 'accept'
      case 'algorithm'
      case 'and'
@@ -32,7 +34,7 @@
      case 'bitwise.negate'
      case 'bitwise.or'
      case 'bitwise.xor'
-     case 'block'
+     #case 'block'
      case 'case'
      case 'error'
      case 'if.then'

--- a/src/algorithms/casm0x0.cast
+++ b/src/algorithms/casm0x0.cast
@@ -26,77 +26,39 @@
   (switch (param 0)
     (eval 'node.old' (param 0))
     (case 'accept'
-     case 'algorithm'
      case 'and'
      case 'binary'
-     case 'bit'
      case 'bitwise.and'
      case 'bitwise.negate'
      case 'bitwise.or'
      case 'bitwise.xor'
-     #case 'block'
-     case 'case'
-     case 'error'
-     case 'if.then'
      case 'if.then.else'
      case 'last.read'
      case 'last.symbol.is'
      case 'literal.action.define'
-     case 'literal.action.use'
-     case 'literal.define'
-     case 'literal.use'
-     case 'loop'
-     case 'loop.unbounded'
-     case 'no.locals'
-     case 'no.params'
      case 'not'
-     case 'one'
      case 'opcode.binary'
      case 'or'
      case 'peek'
      case 'read'
-     case 'rename'
      case 'set'
      case 'table'
      case 'undefine'
      case 'uint32'
-     case 'uint64'
-     case 'uint8'
-     case 'varint32'
-     case 'varint64'
-     case 'varuint32'
-     case 'varuint64'
-     case 'void'
-     case 'zero'
-     case '=>'                  (=> 'postorder.inst'))
+     case 'uint64'              (=> 'postorder.inst'))
 
-    (case 'define'
-     case 'eval'
-     case 'file'
-     case 'header.file'
+    (case 'header.file'
      case 'header.read'
      case 'header.write'
-     case 'literal.action.enum'
      case 'map'
      case 'opcode.bytes'
-     case 'section'
-     case 'sequence'
-     case 'switch'
      case 'write'               (eval 'nary.node'))
 
-    (case 'param'
-     case 'params'
-     case 'local'
-     case 'locals'
-     case 'u32.const'           (eval 'int.value' (varuint32)))
+    (case 'local'
+     case 'locals'              (eval 'int.value' (varuint32)))
 
     (case 'i32.const'           (eval 'int.value' (varint32)))
     (case 'i64.const'           (eval 'int.value' (varint64)))
-    (case 'u64.const'           (eval 'int.value' (varuint64)))
-    (case 'u8.const'            (eval 'int.value' (uint8)))
-
-    (case 'symbol'              (eval 'symbol.lookup'))
-
     (case 'opcode.bits'         (eval 'opcode.binary'))
   )
 )

--- a/src/algorithms/casm0x0Boot.cast
+++ b/src/algorithms/casm0x0Boot.cast
@@ -21,10 +21,12 @@
 (algorithm 1)
 
 (define 'file'
+  (locals 1)
   (block
     (eval 'symbol.table')
     (loop.unbounded
-      (eval 'node')
+      (set (local 0) (uint8))
+      (eval 'node' (local 0))
     )
   )
 )
@@ -42,8 +44,8 @@
   (=> 'nary.inst')
 )
 
-(define 'node'
-  (switch (uint8)
+(define 'node' (params 1)
+  (switch (param 0)
     (error)
     (case 'algorithm'
      case 'bit'
@@ -59,6 +61,7 @@
      case 'no.locals'
      case 'no.params'
      case 'one'
+     case 'rename'
      case 'uint8'
      case 'varint32'
      case 'varint64'

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -808,7 +808,12 @@ void CodeGenerator::generateArrayImplFile() {
   puts("  Reader.readBinary(Input);\n");
 #endif
   puts(
-      "  assert(!Reader.hasErrors());\n"
+      "  if (Reader.hasErrors()) {\n"
+      "    fatal(\"Malformed builtin algorithm: ");
+  puts(AlgName);
+  puts(
+      "\");\n"
+      "  }\n"
       "  Symtable = Reader.getReadSymtab();\n"
       "  return Symtable;\n");
   generateFunctionFooter();

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -298,6 +298,7 @@ void Interpreter::init() {
   FrameStack.reserve(DefaultStackSize);
   CallingEvalStack.reserve(DefaultStackSize);
   CurEvalFrameStack.reserve(DefaultStackSize);
+  CurEvalFrameStack.push_back(0);
   LocalsBaseStack.reserve(DefaultStackSize);
   LocalValues.reserve(DefaultStackSize * DefaultExpectedLocals);
   OpcodeLocalsStack.reserve(DefaultStackSize);
@@ -422,6 +423,9 @@ void Interpreter::traceExitFrame() {
 void Interpreter::reset() {
   Frame.reset();
   FrameStack.clear();
+  CallingEvalStack.clear();
+  CurEvalFrameStack.clear();
+  CurEvalFrameStack.push_back(0);
   LoopCounter = 0;
   LoopCounterStack.clear();
   LocalsBase = 0;
@@ -1304,7 +1308,9 @@ void Interpreter::algorithmResume() {
                 if (ParamIndex >= IntType(CallingEval.Caller->getNumKids()))
                   return throwMessage(
                       "Parameter reference doesn't match callling context!");
-                const Node* Context = CallingEval.Caller->getKid(ParamIndex);
+                const EvalFrame& CallingFrame =
+                    CallingEvalStack[CurEvalFrameStack.back()];
+                const Node* Context = CallingFrame.Caller->getKid(ParamIndex);
                 size_t ContextFrameIndex =
                     CurEvalFrameStack[CurEvalFrameStack.back()];
                 CurEvalFrameStack.push_back(ContextFrameIndex);

--- a/src/sexp/TextWriter.cpp
+++ b/src/sexp/TextWriter.cpp
@@ -129,9 +129,12 @@ void TextWriter::writeNodeKids(const Node* Nd, bool EmbeddedInParent) {
   // Write out with number of kids specified to be on same line,
   // with remaining kids on separate (indented) lines.
   std::vector<Node*> Kids;
+  Node* LastKid = nullptr;
   for (Node* Kid : *Nd) {
-    if (!isa<TextInvisible>(Kid))
+    if (!isa<TextInvisible>(Kid)) {
+      LastKid = Kid;
       Kids.push_back(Kid);
+    }
   }
   int Count = 0;
   const AstTraitsType* Traits = getAstTraits(Nd->getType());
@@ -140,7 +143,6 @@ void TextWriter::writeNodeKids(const Node* Nd, bool EmbeddedInParent) {
   int NumKids = Kids.size();
   if (NumKids <= MaxKidsSameLine)
     KidsSameLine = MaxKidsSameLine;
-  Node* LastKid = Nd->getLastKid();
   bool HasHiddenSeq = Traits->HidesSeqInText;
   bool ForceNewline = false;
   for (auto* Kid : Kids) {


### PR DESCRIPTION
This does two things:

1) It tests that the "rename"  s-expression works.

2) Cuts out about 10k from executables by saving space.