### PR TITLE
Add the define frame to the eval frame.

### DIFF
--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -143,14 +143,20 @@ Interpreter::EvalFrame::EvalFrame() {
   reset();
 }
 
-Interpreter::EvalFrame::EvalFrame(const filt::Eval* Caller,
+Interpreter::EvalFrame::EvalFrame(const Eval* Caller,
+                                  const DefineFrame* DefinedFrame,
                                   size_t CallingEvalIndex)
-    : Caller(Caller), CallingEvalIndex(CallingEvalIndex) {
+    : Caller(Caller),
+      DefinedFrame(DefinedFrame),
+      CallingEvalIndex(CallingEvalIndex) {
   assert(Caller != nullptr);
+  assert(DefinedFrame != nullptr);
 }
 
 Interpreter::EvalFrame::EvalFrame(const EvalFrame& F)
-    : Caller(F.Caller), CallingEvalIndex(F.CallingEvalIndex) {}
+    : Caller(F.Caller),
+      DefinedFrame(F.DefinedFrame),
+      CallingEvalIndex(F.CallingEvalIndex) {}
 
 bool Interpreter::EvalFrame::isDefined() const {
   return Caller != nullptr;
@@ -158,6 +164,7 @@ bool Interpreter::EvalFrame::isDefined() const {
 
 void Interpreter::EvalFrame::reset() {
   Caller = nullptr;
+  DefinedFrame = nullptr;
   CallingEvalIndex = 0;
 }
 
@@ -1409,8 +1416,9 @@ void Interpreter::algorithmResume() {
                 size_t CallingEvalIndex = CallingEvalStack.size();
                 CurEvalFrameStack.push_back(CallingEvalIndex);
                 CallingEvalStack.push();
-                CallingEval.Caller = cast<Eval>(Frame.Nd);
-                CallingEval.CallingEvalIndex = CallingEvalIndex;
+                EvalFrame CalledFrame(cast<Eval>(Frame.Nd),
+                                      Defn->getDefineFrame(), CallingEvalIndex);
+                CallingEval = CalledFrame;
                 Frame.CallState = State::Exit;
                 call(Method::Eval, Frame.CallModifier, Defn);
                 break;

--- a/src/interp/Interpreter.h
+++ b/src/interp/Interpreter.h
@@ -31,6 +31,7 @@ namespace wasm {
 namespace filt {
 
 class Case;
+class DefineFrame;
 class Eval;
 class Header;
 class Node;
@@ -198,12 +199,15 @@ class Interpreter {
   // The stack of calling "eval" expressions.
   struct EvalFrame {
     EvalFrame();
-    EvalFrame(const filt::Eval* Caller, size_t CallingEvalIndex);
+    EvalFrame(const filt::Eval* Caller,
+              const filt::DefineFrame* DefinedFrame,
+              size_t CallingEvalIndex);
     EvalFrame(const EvalFrame& F);
     bool isDefined() const;
     void reset();
     void describe(FILE* File, filt::TextWriter* Writer) const;
     const filt::Eval* Caller;
+    const filt::DefineFrame* DefinedFrame;
     size_t CallingEvalIndex;
   };
 

--- a/src/sexp/Ast-defs.h
+++ b/src/sexp/Ast-defs.h
@@ -325,26 +325,26 @@
   mutable bool IsValidated;                                      \
   bool setIsAlgorithm(const Node* Nd);
 
-#define DEFINE_DECLS                                                     \
-  VALIDATENODE                                                           \
- public:                                                                 \
-  typedef std::vector<const Node*> ParamTypeVector;                      \
-  CallFrame* getCallFrame() const;                                       \
-  bool isValidParam(decode::IntType Index) const {                       \
-    return Index < getCallFrame()->getNumParams();                       \
-  }                                                                      \
-  bool isValidLocal(decode::IntType Index) const {                       \
-    return Index < getCallFrame()->getNumLocals();                       \
-  }                                                                      \
-  const std::string getName() const;                                     \
-  size_t getNumLocals() const { return getCallFrame()->getNumLocals(); } \
-  size_t getNumParams() const { return getCallFrame()->getNumParams(); } \
-  size_t getNumArgs() const { return getCallFrame()->getNumArgs(); }     \
-  Node* getBody() const;                                                 \
-                                                                         \
- private:                                                                \
-  friend class SymbolTable;                                              \
-  mutable std::unique_ptr<CallFrame> MyCallFrame;
+#define DEFINE_DECLS                                                       \
+  VALIDATENODE                                                             \
+ public:                                                                   \
+  typedef std::vector<const Node*> ParamTypeVector;                        \
+  DefineFrame* getDefineFrame() const;                                     \
+  bool isValidParam(decode::IntType Index) const {                         \
+    return Index < getDefineFrame()->getNumParams();                       \
+  }                                                                        \
+  bool isValidLocal(decode::IntType Index) const {                         \
+    return Index < getDefineFrame()->getNumLocals();                       \
+  }                                                                        \
+  const std::string getName() const;                                       \
+  size_t getNumLocals() const { return getDefineFrame()->getNumLocals(); } \
+  size_t getNumParams() const { return getDefineFrame()->getNumParams(); } \
+  size_t getNumArgs() const { return getDefineFrame()->getNumArgs(); }     \
+  Node* getBody() const;                                                   \
+                                                                           \
+ private:                                                                  \
+  friend class SymbolTable;                                                \
+  mutable std::unique_ptr<DefineFrame> MyDefineFrame;
 
 #define EVAL_DECLS \
   VALIDATENODE     \

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -1042,7 +1042,7 @@ void SymbolTable::installDefinitions(const Node* Nd) {
             for (int i = 1; i < OldDefn->getNumKids(); ++i)
               NewDefn->append(OldDefn->getKid(i));
             installDefinitions(NewDefn);
-            if (!NewDefn->getCallFrame()->isConsistent())
+            if (!NewDefn->getDefineFrame()->isConsistent())
               return fatal("Can't install rename!");
             return;
           }
@@ -1763,14 +1763,14 @@ AST_TERNARYNODE_TABLE
 AST_TERNARYNODE_TABLE
 #undef X
 
-CallFrame::CallFrame(const Define* Def)
+DefineFrame::DefineFrame(const Define* Def)
     : NumParams(0), NumLocals(0), InitSuccessful(false) {
   init(Def);
 }
 
-CallFrame::~CallFrame() {}
+DefineFrame::~DefineFrame() {}
 
-void CallFrame::init(const Define* Def) {
+void DefineFrame::init(const Define* Def) {
   if (Def->getNumKids() != 4) {
     errorDescribeNode("Malformed define", Def);
     return;
@@ -1837,14 +1837,14 @@ void CallFrame::init(const Define* Def) {
   return;
 }
 
-CallFrame* Define::getCallFrame() const {
-  if (!MyCallFrame)
-    MyCallFrame = utils::make_unique<CallFrame>(this);
-  return MyCallFrame.get();
+DefineFrame* Define::getDefineFrame() const {
+  if (!MyDefineFrame)
+    MyDefineFrame = utils::make_unique<DefineFrame>(this);
+  return MyDefineFrame.get();
 }
 
 bool Define::validateNode(ConstNodeVectorType& Parents) const {
-  return getCallFrame()->isConsistent();
+  return getDefineFrame()->isConsistent();
 }
 
 const std::string Define::getName() const {

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -116,13 +116,13 @@ static constexpr PredefinedSymbol MaxPredefinedSymbol =
 PredefinedSymbol toPredefinedSymbol(uint32_t Value);
 charstring getName(PredefinedSymbol);
 
-class CallFrame {
-  CallFrame(const CallFrame&) = delete;
-  CallFrame& operator=(const CallFrame&) = delete;
+class DefineFrame {
+  DefineFrame(const DefineFrame&) = delete;
+  DefineFrame& operator=(const DefineFrame&) = delete;
 
  public:
-  explicit CallFrame(const Define* Def);
-  ~CallFrame();
+  explicit DefineFrame(const Define* Def);
+  ~DefineFrame();
   bool isConsistent() { return InitSuccessful; }
   size_t getNumArgs() const { return ParamTypes.size(); }
   size_t getNumLocals() const { return NumLocals; }


### PR DESCRIPTION
Renamed filt::CallFrame to DefineFrame to make different than CallFrame in interpreter.

Also adds DefineFrame to EvalFrame, so that queries about the parameter layout can be made without re-looking up the corresponding Define node.