### PR TITLE
Simplify code by using s-expressions macros

### DIFF
--- a/src/casm/FlattenAst.cpp
+++ b/src/casm/FlattenAst.cpp
@@ -303,7 +303,7 @@ void FlattenAst::flattenNode(const Node* Nd) {
       break;
     case NodeType::Define:
     case NodeType::EnclosingAlgorithms:
-    case NodeType::Eval:
+    case NodeType::EvalVirtual:
     case NodeType::LiteralActionBase:
     case NodeType::Opcode:
     case NodeType::Map:

--- a/src/casm/FlattenAst.cpp
+++ b/src/casm/FlattenAst.cpp
@@ -225,17 +225,15 @@ void FlattenAst::flattenNode(const Node* Nd) {
 
   // Now handle default cases.
   switch (NodeType Opcode = Nd->getType()) {
+#define X(NAME) case NodeType::NAME:
+    AST_CACHEDNODE_TABLE
+#undef X
     case NodeType::NO_SUCH_NODETYPE:
       return reportError("Internal error in FlattenAst::flattenNode");
-
-#define X(NAME) case NodeType::NAME:
-      AST_CACHEDNODE_TABLE
-#undef X
 
 #define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT) case NodeType::NAME:
       AST_INTEGERNODE_TABLE
 #undef X
-
     case NodeType::BinaryEvalBits: {
       write(IntType(Opcode));
       auto* Int = cast<IntegerNode>(Nd);
@@ -251,23 +249,18 @@ void FlattenAst::flattenNode(const Node* Nd) {
 #define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_NULLARYNODE_TABLE
 #undef X
-
 #define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT) case NodeType::NAME:
       AST_LITERAL_TABLE
 #undef X
-
 #define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_UNARYNODE_TABLE
 #undef X
-
 #define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_BINARYNODE_TABLE
 #undef X
-
 #define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_TERNARYNODE_TABLE
 #undef X
-
     case NodeType::BinaryEval:
     case NodeType::BinaryAccept: {
       // Operations that are written out in postorder, with a fixed number of
@@ -281,11 +274,9 @@ void FlattenAst::flattenNode(const Node* Nd) {
 #define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_NARYNODE_TABLE
 #undef X
-
 #define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_SELECTNODE_TABLE
 #undef X
-
     case NodeType::Opcode: {
       // Operations that are written out in postorder, and have a variable
       // number of arguments.

--- a/src/casm/FlattenAst.cpp
+++ b/src/casm/FlattenAst.cpp
@@ -158,87 +158,11 @@ void FlattenAst::flattenNode(const Node* Nd) {
     return;
   TRACE_METHOD("flattenNode");
   TRACE(node_ptr, nullptr, Nd);
+
+  // Handle special cases first.
   switch (NodeType Opcode = Nd->getType()) {
-    case NodeType::NO_SUCH_NODETYPE:
-    case NodeType::BinaryEvalBits:
-    case NodeType::IntLookup:
-    case NodeType::SymbolDefn:
-    case NodeType::UnknownSection: {
-      reportError("Unexpected s-expression, can't write!");
-      reportError("s-expression: ", Nd);
+    default:
       break;
-    }
-#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT) \
-  case NodeType::NAME: {                                   \
-    write(IntType(Opcode));                                \
-    auto* Int = cast<NAME>(Nd);                            \
-    if (Int->isDefaultValue()) {                           \
-      write(0);                                            \
-    } else {                                               \
-      write(int(Int->getFormat()) + 1);                    \
-      write(Int->getValue());                              \
-    }                                                      \
-    break;                                                 \
-  }
-      AST_INTEGERNODE_TABLE
-#undef X
-    case NodeType::BinaryEval:
-      if (BitCompress && binaryEvalEncode(cast<BinaryEval>(Nd)))
-        break;
-    // Not binary encoding, Intentionally fall to next case that
-    // will generate non-compressed form.
-    case NodeType::AlgorithmFlag:
-    case NodeType::AlgorithmName:
-    case NodeType::And:
-    case NodeType::Block:
-    case NodeType::BinaryAccept:
-    case NodeType::BinarySelect:
-    case NodeType::Bit:
-    case NodeType::BitwiseAnd:
-    case NodeType::BitwiseNegate:
-    case NodeType::BitwiseOr:
-    case NodeType::BitwiseXor:
-    case NodeType::Callback:
-    case NodeType::Case:
-    case NodeType::Error:
-    case NodeType::IfThen:
-    case NodeType::IfThenElse:
-    case NodeType::LastRead:
-    case NodeType::LastSymbolIs:
-    case NodeType::LiteralActionDef:
-    case NodeType::LiteralActionUse:
-    case NodeType::LiteralDef:
-    case NodeType::LiteralUse:
-    case NodeType::Loop:
-    case NodeType::LoopUnbounded:
-    case NodeType::NoLocals:
-    case NodeType::NoParams:
-    case NodeType::Not:
-    case NodeType::Or:
-    case NodeType::Peek:
-    case NodeType::Read:
-    case NodeType::Rename:
-    case NodeType::Set:
-    case NodeType::Table:
-    case NodeType::Uint32:
-    case NodeType::Uint64:
-    case NodeType::Uint8:
-    case NodeType::Undefine:
-    case NodeType::Varint32:
-    case NodeType::Varint64:
-    case NodeType::Varuint32:
-    case NodeType::Varuint64:
-#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT) case NodeType::NAME:
-      AST_LITERAL_TABLE
-#undef X
-    case NodeType::Void: {
-      // Operations that are written out in postorder, with a fixed number of
-      // arguments.
-      for (const auto* Kid : *Nd)
-        flattenNode(Kid);
-      write(IntType(Opcode));
-      break;
-    }
     case NodeType::Algorithm: {
       const auto* Alg = cast<Algorithm>(Nd);
       const auto* Source = Alg->getSourceHeader();
@@ -273,7 +197,7 @@ void FlattenAst::flattenNode(const Node* Nd) {
       write(IntType(Opcode));
       write(NumKids);
       writeAction(IntType(PredefinedSymbol::Block_exit));
-      break;
+      return;
     }
     case NodeType::SourceHeader: {
       // The primary header is special in that the size is defined by the
@@ -291,26 +215,78 @@ void FlattenAst::flattenNode(const Node* Nd) {
         }
         writeHeaderValue(Const->getValue(), Const->getIntTypeFormat());
       }
-      break;
-      // Intentionally drop to next case.
+      return;
     }
-    case NodeType::ReadHeader:
-    case NodeType::WriteHeader:
+    case NodeType::BinaryEval:
+      if (BitCompress && binaryEvalEncode(cast<BinaryEval>(Nd)))
+        return;
+      break;
+  }
+
+  // Now handle default cases.
+  switch (NodeType Opcode = Nd->getType()) {
+    case NodeType::NO_SUCH_NODETYPE:
+      return reportError("Internal error in FlattenAst::flattenNode");
+
+#define X(NAME) case NodeType::NAME:
+      AST_CACHEDNODE_TABLE
+#undef X
+
+#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT) case NodeType::NAME:
+      AST_INTEGERNODE_TABLE
+#undef X
+
+    case NodeType::BinaryEvalBits: {
+      write(IntType(Opcode));
+      auto* Int = cast<IntegerNode>(Nd);
+      if (Int->isDefaultValue()) {
+        write(0);
+      } else {
+        write(int(Int->getFormat()) + 1);
+        write(Int->getValue());
+      }
+      break;
+    }
+
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
+      AST_NULLARYNODE_TABLE
+#undef X
+
+#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT) case NodeType::NAME:
+      AST_LITERAL_TABLE
+#undef X
+
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
+      AST_UNARYNODE_TABLE
+#undef X
+
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
+      AST_BINARYNODE_TABLE
+#undef X
+
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
+      AST_TERNARYNODE_TABLE
+#undef X
+
+    case NodeType::BinaryEval:
+    case NodeType::BinaryAccept: {
+      // Operations that are written out in postorder, with a fixed number of
+      // arguments.
       for (const auto* Kid : *Nd)
         flattenNode(Kid);
       write(IntType(Opcode));
-      write(Nd->getNumKids());
       break;
-    case NodeType::Define:
-    case NodeType::EnclosingAlgorithms:
-    case NodeType::EvalVirtual:
-    case NodeType::LiteralActionBase:
-    case NodeType::Opcode:
-    case NodeType::Map:
-    case NodeType::ParamArgs:
-    case NodeType::Switch:
-    case NodeType::Sequence:
-    case NodeType::Write: {
+    }
+
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
+      AST_NARYNODE_TABLE
+#undef X
+
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
+      AST_SELECTNODE_TABLE
+#undef X
+
+    case NodeType::Opcode: {
       // Operations that are written out in postorder, and have a variable
       // number of arguments.
       for (const auto* Kid : *Nd)

--- a/src/casm/InflateAst.cpp
+++ b/src/casm/InflateAst.cpp
@@ -238,8 +238,8 @@ bool InflateAst::applyOp(IntType Op) {
       return buildNary<EnclosingAlgorithms>();
     case NodeType::Error:
       return buildNullary<Error>();
-    case NodeType::Eval:
-      return buildNary<Eval>();
+    case NodeType::EvalVirtual:
+      return buildNary<EvalVirtual>();
     case NodeType::SourceHeader:
       return buildNary<SourceHeader>();
     case NodeType::IfThen:

--- a/src/casm/InflateAst.cpp
+++ b/src/casm/InflateAst.cpp
@@ -198,90 +198,10 @@ bool InflateAst::writeHeaderValue(decode::IntType Value,
 }
 
 bool InflateAst::applyOp(IntType Op) {
+  // Handle special cases first.
   switch (NodeType(Op)) {
-#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT) \
-  case NodeType::NAME:                            \
-    return buildNullary<NAME>();
-    AST_LITERAL_TABLE
-#undef X
-    case NodeType::AlgorithmFlag:
-      return buildUnary<AlgorithmFlag>();
-    case NodeType::AlgorithmName:
-      return buildUnary<AlgorithmName>();
-    case NodeType::And:
-      return buildBinary<And>();
-    case NodeType::BinaryAccept:
-      return buildNullary<BinaryAccept>();
-    case NodeType::BinaryEval:
-      return buildUnary<BinaryEval>();
-    case NodeType::BinarySelect:
-      return buildBinary<BinarySelect>();
-    case NodeType::Bit:
-      return buildNullary<Bit>();
-    case NodeType::BitwiseAnd:
-      return buildBinary<BitwiseAnd>();
-    case NodeType::BitwiseOr:
-      return buildBinary<BitwiseOr>();
-    case NodeType::BitwiseNegate:
-      return buildUnary<BitwiseNegate>();
-    case NodeType::BitwiseXor:
-      return buildBinary<BitwiseXor>();
-    case NodeType::Block:
-      return buildUnary<Block>();
-    case NodeType::Callback:
-      return buildUnary<Callback>();
-    case NodeType::Case:
-      return buildBinary<Case>();
-    case NodeType::Define:
-      return buildNary<Define>();
-    case NodeType::EnclosingAlgorithms:
-      return buildNary<EnclosingAlgorithms>();
-    case NodeType::Error:
-      return buildNullary<Error>();
-    case NodeType::EvalVirtual:
-      return buildNary<EvalVirtual>();
-    case NodeType::SourceHeader:
-      return buildNary<SourceHeader>();
-    case NodeType::IfThen:
-      return buildBinary<IfThen>();
-    case NodeType::IfThenElse:
-      return buildTernary<IfThenElse>();
-    case NodeType::LastRead:
-      return buildNullary<LastRead>();
-    case NodeType::LastSymbolIs:
-      return buildUnary<LastSymbolIs>();
-    case NodeType::LiteralActionBase:
-      return buildNary<LiteralActionBase>();
-    case NodeType::LiteralActionDef:
-      return buildBinary<LiteralActionDef>();
-    case NodeType::LiteralActionUse:
-      return buildUnary<LiteralActionUse>();
-    case NodeType::LiteralDef:
-      return buildBinary<LiteralDef>();
-    case NodeType::LiteralUse:
-      return buildUnary<LiteralUse>();
-    case NodeType::Loop:
-      return buildBinary<Loop>();
-    case NodeType::LoopUnbounded:
-      return buildUnary<LoopUnbounded>();
-    case NodeType::Map:
-      return buildNary<Map>();
-    case NodeType::NoLocals:
-      return buildNullary<NoLocals>();
-    case NodeType::NoParams:
-      return buildNullary<NoParams>();
-    case NodeType::Not:
-      return buildUnary<Not>();
-    case NodeType::Or:
-      return buildBinary<Or>();
-    case NodeType::Peek:
-      return buildUnary<Peek>();
-    case NodeType::Read:
-      return buildUnary<Read>();
-    case NodeType::ReadHeader:
-      return buildNary<ReadHeader>();
-    case NodeType::Rename:
-      return buildBinary<Rename>();
+    default:
+      break;
     case NodeType::Algorithm: {
       Algorithm* Alg = buildNary<Algorithm>() ? getGeneratedFile() : nullptr;
       if (Alg == nullptr)
@@ -291,12 +211,6 @@ bool InflateAst::applyOp(IntType Op) {
         Symtab->install();
       return true;
     }
-    case NodeType::Sequence:
-      return buildNary<Sequence>();
-    case NodeType::Set:
-      return buildBinary<Set>();
-    case NodeType::Switch:
-      return buildNary<Switch>();
     case NodeType::Symbol: {
       Symbol* Sym = SymIndex->getIndexSymbol(Values.popValue());
       Values.pop();
@@ -307,34 +221,61 @@ bool InflateAst::applyOp(IntType Op) {
       Asts.push(Sym);
       return true;
     }
-    case NodeType::Table:
-      return buildBinary<Table>();
-    case NodeType::Undefine:
-      return buildUnary<Undefine>();
-    case NodeType::UnknownSection:
-      return buildUnary<UnknownSection>();
-    case NodeType::Uint32:
-      return buildNullary<Uint32>();
-    case NodeType::Uint64:
-      return buildNullary<Uint64>();
-    case NodeType::Uint8:
-      return buildNullary<Uint8>();
-    case NodeType::Varint32:
-      return buildNullary<Varint32>();
-    case NodeType::Varint64:
-      return buildNullary<Varint64>();
-    case NodeType::Varuint32:
-      return buildNullary<Varuint32>();
-    case NodeType::Varuint64:
-      return buildNullary<Varuint64>();
-    case NodeType::Void:
-      return buildNullary<Void>();
-    case NodeType::Write:
-      return buildNary<Write>();
-    case NodeType::WriteHeader:
-      return buildNary<WriteHeader>();
-    default:
+  }
+
+  // Now handle default cases.
+  switch (NodeType(Op)) {
+#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT) case NodeType::NAME:
+    AST_INTEGERNODE_TABLE
+#undef X
+#define X(NAME) case NodeType::NAME:
+    AST_CACHEDNODE_TABLE
+#undef X
+    case NodeType::BinaryEvalBits:
+    case NodeType::Opcode:
+    case NodeType::Symbol:
+    case NodeType::NO_SUCH_NODETYPE:
       return failWriteActionMalformed();
+
+#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT) \
+  case NodeType::NAME:                            \
+    return buildNullary<NAME>();
+      AST_LITERAL_TABLE
+#undef X
+#define X(NAME, BASE, DECLS, INIT) \
+  case NodeType::NAME:             \
+    return buildNullary<NAME>();
+      AST_NULLARYNODE_TABLE
+#undef X
+#define X(NAME, BASE, DECLS, INIT) \
+  case NodeType::NAME:             \
+    return buildUnary<NAME>();
+      AST_UNARYNODE_TABLE
+#undef X
+#define X(NAME, BASE, DECLS, INIT) \
+  case NodeType::NAME:             \
+    return buildBinary<NAME>();
+      AST_BINARYNODE_TABLE
+#undef X
+#define X(NAME, BASE, DECLS, INIT) \
+  case NodeType::NAME:             \
+    return buildNary<NAME>();
+      AST_NARYNODE_TABLE
+#undef X
+#define X(NAME, BASE, DECLS, INIT) \
+  case NodeType::NAME:             \
+    return buildNary<NAME>();
+      AST_SELECTNODE_TABLE
+#undef X
+#define X(NAME, BASE, DECLS, INIT) \
+  case NodeType::NAME:             \
+    return buildTernary<NAME>();
+      AST_TERNARYNODE_TABLE
+#undef X
+    case NodeType::BinaryAccept:
+      return buildNullary<BinaryAccept>();
+    case NodeType::BinaryEval:
+      return buildUnary<BinaryEval>();
   }
   return failWriteActionMalformed();
 }

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -38,6 +38,11 @@ using namespace utils;
 
 namespace {
 
+utils::TraceClass& getTrace() {
+  static TraceClass Trace("cast2casm");
+  return Trace;
+}
+
 charstring LocalName = "Local_";
 charstring FuncName = "Func_";
 
@@ -152,6 +157,7 @@ void CodeGenerator::generateFormat(ValueFormat Format) {
 }
 
 void CodeGenerator::generateHeader() {
+  TRACE_METHOD("generateHeader");
   puts(
       "// -*- C++ -*- \n"
       "\n"
@@ -184,6 +190,7 @@ void CodeGenerator::generateHeader() {
 }
 
 void CodeGenerator::generateEnterNamespaces() {
+  TRACE_METHOD("generateEnterNamespaces");
   for (charstring Name : Namespaces) {
     puts("namespace ");
     puts(Name);
@@ -194,6 +201,7 @@ void CodeGenerator::generateEnterNamespaces() {
 }
 
 void CodeGenerator::generateExitNamespaces() {
+  TRACE_METHOD("generateExitNamespaces");
   for (std::vector<charstring>::reverse_iterator Iter = Namespaces.rbegin(),
                                                  IterEnd = Namespaces.rend();
        Iter != IterEnd; ++Iter) {
@@ -320,6 +328,7 @@ void CodeGenerator::collectActionDefs() {
 }
 
 void CodeGenerator::generatePredefinedEnum() {
+  TRACE_METHOD("generatePredefinedEnum");
   collectActionDefs();
   puts("enum class Predefined");
   puts(AlgName);
@@ -348,6 +357,7 @@ void CodeGenerator::generatePredefinedEnum() {
 }
 
 void CodeGenerator::generatePredefinedEnumNames() {
+  TRACE_METHOD("generatePredefinedEnumNames");
   collectActionDefs();
   puts(
       "struct {\n"
@@ -378,6 +388,7 @@ void CodeGenerator::generatePredefinedEnumNames() {
 }
 
 void CodeGenerator::generatePredefinedNameFcn() {
+  TRACE_METHOD("generatePredefinedNameFcn");
   puts("charstring getName(Predefined");
   puts(AlgName);
   puts(
@@ -396,6 +407,7 @@ void CodeGenerator::generateAlgorithmHeader() {
 }
 
 void CodeGenerator::generateAlgorithmHeader(charstring AlgName) {
+  TRACE_METHOD("generateAlgorithmHeader");
   puts("std::shared_ptr<filt::SymbolTable> get");
   puts(AlgName);
   puts("Symtab()");
@@ -436,6 +448,7 @@ void CodeGenerator::generateFunctionCall(size_t Index) {
 }
 
 void CodeGenerator::generateFunctionHeader(std::string NodeType, size_t Index) {
+  TRACE_METHOD("generateFunctionHeader");
   puts(NodeType.c_str());
   puts("* ");
   generateFunctionName(Index);
@@ -443,6 +456,7 @@ void CodeGenerator::generateFunctionHeader(std::string NodeType, size_t Index) {
 }
 
 void CodeGenerator::generateFunctionFooter() {
+  TRACE_METHOD("generateFunctionFooter");
   puts(
       "}\n"
       "\n");
@@ -476,6 +490,7 @@ size_t CodeGenerator::generateNodeFcn(const Node* Nd,
 }
 
 size_t CodeGenerator::generateSymbol(const Node* Nd) {
+  TRACE_METHOD("generateSymbol");
   assert(isa<Symbol>(Nd));
   const Symbol* Sym = cast<Symbol>(Nd);
   size_t Index = NextIndex++;
@@ -489,6 +504,7 @@ size_t CodeGenerator::generateSymbol(const Node* Nd) {
 }
 
 size_t CodeGenerator::generateInteger(const Node* Nd) {
+  TRACE_METHOD("generateInteger");
   return generateNodeFcn(Nd, [&]() {
     assert(isa<IntegerNode>(Nd));
     const IntegerNode* IntNd = cast<IntegerNode>(Nd);
@@ -499,17 +515,20 @@ size_t CodeGenerator::generateInteger(const Node* Nd) {
 }
 
 size_t CodeGenerator::generateNullary(const Node* Nd) {
+  TRACE_METHOD("generateNullary");
   assert(Nd->getNumKids() == 0);
   return generateNodeFcn(Nd, []() { return; });
 }
 
 size_t CodeGenerator::generateUnary(const Node* Nd) {
+  TRACE_METHOD("generateUnary");
   assert(Nd->getNumKids() == 1);
   size_t Kid1 = generateNode(Nd->getKid(0));
   return generateNodeFcn(Nd, [&]() { generateFunctionCall(Kid1); });
 }
 
 size_t CodeGenerator::generateBinary(const Node* Nd) {
+  TRACE_METHOD("generateBinary");
   assert(Nd->getNumKids() == 2);
   size_t Kid1 = generateNode(Nd->getKid(0));
   size_t Kid2 = generateNode(Nd->getKid(1));
@@ -521,6 +540,7 @@ size_t CodeGenerator::generateBinary(const Node* Nd) {
 }
 
 size_t CodeGenerator::generateTernary(const Node* Nd) {
+  TRACE_METHOD("generateTernary");
   assert(Nd->getNumKids() == 3);
   size_t Kid1 = generateNode(Nd->getKid(0));
   size_t Kid2 = generateNode(Nd->getKid(1));
@@ -535,6 +555,7 @@ size_t CodeGenerator::generateTernary(const Node* Nd) {
 }
 
 size_t CodeGenerator::generateNary(const Node* Nd) {
+  TRACE_METHOD("generateNary");
   std::vector<size_t> Kids;
   charstring NodeType = Nd->getNodeName();
   for (int i = 0; i < Nd->getNumKids(); ++i)
@@ -559,6 +580,8 @@ size_t CodeGenerator::generateNary(const Node* Nd) {
 }
 
 size_t CodeGenerator::generateNode(const Node* Nd) {
+  TRACE_METHOD("generateNode");
+  TRACE(node_ptr, "Nd", Nd);
   if (Nd == nullptr)
     return generateBadLocal(Nd);
 
@@ -633,6 +656,7 @@ size_t CodeGenerator::generateNode(const Node* Nd) {
 }
 
 void CodeGenerator::generateDeclFile() {
+  TRACE_METHOD("generateDeclFile");
   generateHeader();
   generateEnterNamespaces();
   if (GenerateEnum)
@@ -646,6 +670,7 @@ void CodeGenerator::generateDeclFile() {
 
 #if WASM_CAST_BOOT > 1
 void CodeGenerator::generateArrayImplFile() {
+  TRACE_METHOD("generateArrayImplFile");
   puts(
       "namespace {\n"
       "\n");
@@ -757,6 +782,7 @@ void CodeGenerator::generateArrayImplFile() {
 #endif
 
 void CodeGenerator::generateFunctionImplFile() {
+  TRACE_METHOD("generateFunctionImplFile");
   puts(
       "namespace {\n"
       "\n");
@@ -783,6 +809,7 @@ void CodeGenerator::generateFunctionImplFile() {
 }
 
 void CodeGenerator::generateImplFile(bool UseArrayImpl) {
+  TRACE_METHOD("generateImplFile");
   generateHeader();
   if (UseArrayImpl)
     puts(
@@ -826,6 +853,7 @@ std::shared_ptr<SymbolTable> readCasmFile(
     bool TraceLexer,
     bool TraceParser,
     std::shared_ptr<SymbolTable> EnclosingScope) {
+  TRACE_METHOD("readCasmFile");
   bool HasErrors = false;
   std::shared_ptr<SymbolTable> Symtab;
 #if WASM_CAST_BOOT < 3
@@ -852,10 +880,11 @@ std::shared_ptr<SymbolTable> readCasmFile(
 }
 
 bool install(SymbolTable::SharedPtr Symtab, bool Display, const char* Title) {
+  TRACE_METHOD("install");
   if (Display) {
-    fprintf(stdout, "After stripping %s:\n", Title);
+    fprintf(stderr, "After stripping %s:\n", Title);
     TextWriter Writer;
-    Writer.write(stdout, Symtab->getAlgorithm());
+    Writer.write(stderr, Symtab->getAlgorithm());
   }
   bool Success = Symtab->install();
   if (!Success)
@@ -893,6 +922,7 @@ int main(int Argc, charstring Argv[]) {
   bool TraceParser = false;
   bool Verbose = false;
   bool HeaderFile = false;
+  bool TraceProgress = false;
 
 #if WASM_CAST_BOOT > 1
   bool BitCompress = true;
@@ -1011,6 +1041,10 @@ int main(int Argc, charstring Argv[]) {
     Args.add(StripLiteralUsesFlag.setLongName("strip-literal-uses")
                  .setDescription("Replace literal uses with their defintion"));
 
+    ArgsParser::Optional<bool> TraceProgressFlag(TraceProgress);
+    Args.add(TraceProgressFlag.setLongName("verbose=progress")
+                 .setDescription("Trace progress of compiling casm file"));
+
     ArgsParser::Optional<bool> TraceLexerFlag(TraceLexer);
     Args.add(
         TraceLexerFlag.setLongName("verbose=lexer")
@@ -1121,6 +1155,11 @@ int main(int Argc, charstring Argv[]) {
 #endif
   }
 
+  if (TraceProgress)
+    getTrace().setTraceProgress(true);
+
+  if (Verbose)
+    fprintf(stderr, "Parsing input files...\n");
   std::shared_ptr<SymbolTable> InputSymtab;
   charstring InputFilename = "-";
   for (charstring Filename : InputFilenames) {
@@ -1142,30 +1181,40 @@ int main(int Argc, charstring Argv[]) {
   }
 
   if (StripActions) {
+    if (Verbose)
+      fprintf(stderr, "Stripping actions..\n");
     InputSymtab->stripCallbacksExcept(KeepActions);
     if (!install(InputSymtab, DisplayStripAll, "actions"))
       return exit_status(EXIT_FAILURE);
   }
 
   if (StripSymbolicActions) {
+    if (Verbose)
+      fprintf(stderr, "Stripping symbolic actions...\n");
     InputSymtab->stripSymbolicCallbacks();
     if (!install(InputSymtab, DisplayStripAll, "symbolic actions"))
       return exit_status(EXIT_FAILURE);
   }
 
   if (StripLiteralUses) {
+    if (Verbose)
+      fprintf(stderr, "Stripping literal uses...\n");
     InputSymtab->stripLiteralUses();
     if (!install(InputSymtab, DisplayStripAll, "literal uses"))
       return exit_status(EXIT_FAILURE);
   }
 
   if (StripLiteralDefs) {
+    if (Verbose)
+      fprintf(stderr, "Stripping literal definitions...\n");
     InputSymtab->stripLiteralDefs();
     if (!install(InputSymtab, DisplayStripAll, "literal definitions"))
       return exit_status(EXIT_FAILURE);
   }
 
   if (StripLiterals) {
+    if (Verbose)
+      fprintf(stderr, "Stripping lierals...\n");
     InputSymtab->stripLiterals();
     if (!install(InputSymtab, DisplayStripAll, "literals"))
       return exit_status(EXIT_FAILURE);
@@ -1180,6 +1229,8 @@ int main(int Argc, charstring Argv[]) {
     return exit_status(EXIT_SUCCESS);
   }
 
+  if (Verbose)
+    fprintf(stderr, "Reading algorithms...\n");
   std::shared_ptr<SymbolTable> AlgSymtab;
   for (charstring Filename : AlgorithmFilenames) {
     AlgSymtab =
@@ -1229,6 +1280,8 @@ int main(int Argc, charstring Argv[]) {
 #if WASM_CAST_BOOT > 1
   if (OutputStream) {
     // Generate binary stream
+    if (Verbose)
+      fprintf(stderr, "Generating binary stream...\n");
     CasmWriter Writer;
     Writer.setTraceWriter(TraceWrite)
         .setTraceFlatten(TraceFlatten)
@@ -1248,6 +1301,8 @@ int main(int Argc, charstring Argv[]) {
     return exit_status(EXIT_SUCCESS);
 
   // Generate C++ code.
+  if (Verbose)
+    fprintf(stderr, "Generating c++ code...\n");
   std::vector<charstring> Namespaces;
   Namespaces.push_back("wasm");
   Namespaces.push_back("decode");

--- a/src/exec/cast2casm.h
+++ b/src/exec/cast2casm.h
@@ -604,53 +604,45 @@ size_t CodeGenerator::generateNode(const Node* Nd) {
     case NodeType::Symbol:
       return generateSymbol(Nd);
 
-#define X(NAME, BASE, DECLS, INIT) \
-  case NodeType::NAME:             \
-    return generateNullary(Nd);
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_NULLARYNODE_TABLE
 #undef X
+      return generateNullary(Nd);
 
-#define X(NAME)        \
-  case NodeType::NAME: \
-    return generateNullary(Nd);
+#define X(NAME) case NodeType::NAME:
       AST_CACHEDNODE_TABLE
 #undef X
+      return generateNullary(Nd);
 
-#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT) \
-  case NodeType::NAME:                            \
-    return generateNullary(Nd);
+#define X(NAME, BASE, VALUE, FORMAT, DECLS, INIT) case NodeType::NAME:
       AST_LITERAL_TABLE
 #undef X
+      return generateNullary(Nd);
 
-#define X(NAME, BASE, DECLS, INIT) \
-  case NodeType::NAME:             \
-    return generateUnary(Nd);
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_UNARYNODE_TABLE
 #undef X
+      return generateUnary(Nd);
 
-#define X(NAME, BASE, DECLS, INIT) \
-  case NodeType::NAME:             \
-    return generateBinary(Nd);
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_BINARYNODE_TABLE
 #undef X
+      return generateBinary(Nd);
 
-#define X(NAME, BASE, DECLS, INIT) \
-  case NodeType::NAME:             \
-    return generateTernary(Nd);
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_TERNARYNODE_TABLE
 #undef X
+      return generateTernary(Nd);
 
-#define X(NAME, BASE, DECLS, INIT) \
-  case NodeType::NAME:             \
-    return generateNary(Nd);
+#define X(NAME, BASE, DECLS, INIT) case NodeType::NAME:
       AST_NARYNODE_TABLE AST_SELECTNODE_TABLE
 #undef X
+          return generateNary(Nd);
 
-#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT) \
-  case NodeType::NAME:                                     \
-    return generateInteger(Nd);
-          AST_INTEGERNODE_TABLE
+#define X(NAME, FORMAT, DEFAULT, MERGE, BASE, DECLS, INIT) case NodeType::NAME:
+      AST_INTEGERNODE_TABLE
 #undef X
+      return generateInteger(Nd);
   }
   WASM_RETURN_UNREACHABLE(0);
 }

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1449,7 +1449,7 @@ void Interpreter::algorithmResume() {
                 return failBadState();
             }
             break;
-          case NodeType::Eval:  // Method::Eval
+          case NodeType::EvalVirtual:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter: {
                 auto* Sym = dyn_cast<Symbol>(Frame.Nd->getKid(0));

--- a/src/interp/Interpreter.cpp
+++ b/src/interp/Interpreter.cpp
@@ -1452,8 +1452,8 @@ void Interpreter::algorithmResume() {
           case NodeType::EvalVirtual:  // Method::Eval
             switch (Frame.CallState) {
               case State::Enter: {
-                auto* Sym = dyn_cast<Symbol>(Frame.Nd->getKid(0));
-                assert(Sym);
+                const Eval* EvalNd = cast<Eval>(Frame.Nd);
+                const Symbol* Sym = EvalNd->getCallName();
                 const Define* Defn =
                     Symtab->getSymbolDefn(Sym)->getDefineDefinition();
                 if (Defn == nullptr) {
@@ -1506,7 +1506,8 @@ void Interpreter::algorithmResume() {
                 break;
               }
               case State::Step3: {
-                auto* Sym = dyn_cast<Symbol>(Frame.Nd->getKid(0));
+                const Eval* EvalNd = cast<Eval>(Frame.Nd);
+                const Symbol* Sym = EvalNd->getCallName();
                 const Define* Defn =
                     Symtab->getSymbolDefn(Sym)->getDefineDefinition();
                 Frame.CallState = State::Exit;

--- a/src/sexp-parser/Parser.ypp
+++ b/src/sexp-parser/Parser.ypp
@@ -445,7 +445,7 @@ expression_redirect
 
 eval_args
         : symbol {
-            $$ = Driver.create<Eval>();
+            $$ = Driver.create<EvalVirtual>();
             $$->append($1);
           }
         | eval_args expression {

--- a/src/sexp/Ast-defs.h
+++ b/src/sexp/Ast-defs.h
@@ -170,7 +170,7 @@
   X(Algorithm, Nary, ALGORITHM_DECLS, init();) \
   X(Define, Nary, DEFINE_DECLS, )              \
   X(EnclosingAlgorithms, Nary, , )             \
-  X(Eval, Nary, EVAL_DECLS, )                  \
+  X(EvalVirtual, Eval, , )                     \
   X(LiteralActionBase, Nary, , )               \
   X(ParamArgs, Nary, , )                       \
   X(ReadHeader, Header, , )                    \
@@ -222,7 +222,7 @@
   X(Block, 0x01, "block", 1, 0, true, true)                              \
   X(Case, 0x02, "case", 2, 0, true, true)                                \
   X(Error, 0x03, "error", 0, 0, false, false)                            \
-  X(Eval, 0x04, "eval", 1, 1, false, false)                              \
+  X(EvalVirtual, 0x04, "eval", 1, 1, false, false)                       \
   X(Loop, 0x07, "loop", 1, 1, true, true)                                \
   X(LoopUnbounded, 0x08, "loop.unbounded", 0, 1, true, true)             \
   X(Switch, 0x09, "switch", 1, 0, true, false)                           \
@@ -355,10 +355,5 @@
  private:                                                                      \
   friend class SymbolTable;                                                    \
   mutable std::unique_ptr<DefineFrame> MyDefineFrame;
-
-#define EVAL_DECLS \
-  VALIDATENODE     \
- public:           \
-  Symbol* getCallName() const;
 
 #endif  // DECOMPRESSOR_SRC_SEXP_AST_DEFS_H_

--- a/src/sexp/Ast.cpp
+++ b/src/sexp/Ast.cpp
@@ -2117,12 +2117,20 @@ bool Header::implementsClass(NodeType Type) {
          Type == NodeType::WriteHeader;
 }
 
+Eval::Eval(SymbolTable& Symtab, NodeType Type) : Nary(Symtab, Type) {}
+
+Eval::~Eval() {}
+
+bool Eval::implementsClass(NodeType Type) {
+  return Type == NodeType::EvalVirtual;
+}
+
 Symbol* Eval::getCallName() const {
   return dyn_cast<Symbol>(getKid(0));
 }
 
 bool Eval::validateNode(ConstNodeVectorType& Parents) const {
-  TRACE_METHOD("validateNode");
+  TRACE_METHOD("validateNodeEval");
   TRACE(node_ptr, nullptr, this);
   const auto* Sym = dyn_cast<Symbol>(getKid(0));
   assert(Sym);

--- a/src/sexp/Ast.h
+++ b/src/sexp/Ast.h
@@ -554,6 +554,22 @@ class Header : public Nary {
   Header(SymbolTable& Symtab, NodeType Type);
 };
 
+class Eval : public Nary {
+  Eval() = delete;
+  Eval(const Eval&) = delete;
+  Eval& operator=(const Eval&) = delete;
+  friend class SymbolTable;
+
+ public:
+  ~Eval() OVERRIDE;
+  Symbol* getCallName() const;
+  bool validateNode(ConstNodeVectorType& Parents) const OVERRIDE;
+  static bool implementsClass(NodeType Type);
+
+ protected:
+  Eval(SymbolTable& Symtab, NodeType Type);
+};
+
 class IntLookup FINAL : public Cached {
   IntLookup() = delete;
   IntLookup(const IntLookup&) = delete;


### PR DESCRIPTION
Also renames s-expression Eval to EvalVirtual (as a base class of Eval). This was done to allow EvalSuper to be added later, and calls the enclosing's version of the symbol.