### PR TITLE
Add aligning opcodes for better zipping.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1194,10 +1194,14 @@ $(TEST_WASM_COMP_FILES): $(TEST_0XD_GENDIR)/%.wasm-comp: $(TEST_0XD_SRCDIR)/%.wa
 	| $(BUILD_EXECDIR)/decompress - | cmp - $<
 	$(BUILD_EXECDIR)/compress-int --min-count 2 --min-weight 5 --cism $< \
 	| $(BUILD_EXECDIR)/decompress - | cmp - $<
-	$(BUILD_EXECDIR)/compress-int --Huffman --min-count 2 --min-weight 5 $< \
-	| $(BUILD_EXECDIR)/decompress - | cmp - $<
-	$(BUILD_EXECDIR)/compress-int --Huffman --min-count 2 --min-weight 5 --cism $< \
-	| $(BUILD_EXECDIR)/decompress - | cmp - $<
+	$(BUILD_EXECDIR)/compress-int --min-count 2 --min-weight 5 --cism \
+          --align $< | $(BUILD_EXECDIR)/decompress - | cmp - $<
+	$(BUILD_EXECDIR)/compress-int --Huffman --min-count 2 --min-weight 5 \
+          $< | $(BUILD_EXECDIR)/decompress - | cmp - $<
+	$(BUILD_EXECDIR)/compress-int --Huffman --min-count 2 --min-weight 5 \
+          --cism $< | $(BUILD_EXECDIR)/decompress - | cmp - $<
+	$(BUILD_EXECDIR)/compress-int --Huffman --min-count 2 --min-weight 5 \
+          --cism --align $< | $(BUILD_EXECDIR)/decompress - | cmp - $<
 
 .PHONY: $(TEST_WASM_COMP_FILES)
 

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -82,8 +82,12 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Toggle UseCismModelFlag(MyCompressionFlags.UseCismModel);
     Args.add(UseCismModelFlag.setLongName("cism").setDescription(
-        "Generate compressed algorithm using Cism algorithm "
-        "(experimental - not working yet)"));
+        "Generate compressed algorithm using Cism algorithm"));
+
+    ArgsParser::Toggle AlignOpcodesFlag(MyCompressionFlags.AlignOpcodes);
+    Args.add(AlignOpcodesFlag.setLongName("align").setDescription(
+        "Byte align opcodes, even if using Huffman encoding. "
+        "(experimental to see if helps zipping compressed files)"));
 
     ArgsParser::Optional<bool> TraceHuffmanAssignmentsFlag(
         MyCompressionFlags.TraceHuffmanAssignments);

--- a/src/intcomp/CompressionFlags.cpp
+++ b/src/intcomp/CompressionFlags.cpp
@@ -49,6 +49,7 @@ CompressionFlags::CompressionFlags()
       BitCompressOpcodes(false),
       ReassignAbbreviations(true),
       UseCismModel(false),
+      AlignOpcodes(false),
       DefaultFormat(IntTypeFormat::Varint64),
       LoopSizeFormat(IntTypeFormat::Varuint64),
       TraceHuffmanAssignments(false),

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -59,6 +59,7 @@ struct CompressionFlags {
   bool BitCompressOpcodes;
   bool ReassignAbbreviations;
   bool UseCismModel;
+  bool AlignOpcodes;
   interp::IntTypeFormat DefaultFormat;
   interp::IntTypeFormat LoopSizeFormat;
 


### PR DESCRIPTION
Aligns Huffman bit encoding to bytes.

This was added to see if gzip does better when this is done.

For banana bread (version 0xD) we get:

Original size: 2107044
          + gzip: 720742
 
cism/huffman: 1186420
            + gzip: 1030927
            + align: 1559552
  + align + gzip: 867964

This shows that if you are going to gzip, adding byte alignment pays. If not, you are (as expected) better off not doing alignment.

Note: gzip by itself does better, but we aren't too far away, and we haven't fine-tuned integer compression. The decompressor may also do tree simplifications that hasn't been implemented yet, resulting it better results than gzip.