### PR TITLE
Delay expansion of abbreviations to point of writing to int stream.

### DIFF
--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -89,6 +89,11 @@ int main(int Argc, const char* Argv[]) {
         "Byte align opcodes, even if using Huffman encoding. "
         "(experimental to see if helps zipping compressed files)"));
 
+    ArgsParser::Toggle MatchSingletonsLastFlag(
+        MyCompressionFlags.MatchSingletonsLast);
+    Args.add(MatchSingletonsLastFlag.setLongName("singletons").setDescription(
+        "Run experiment on how singleton patterns are handled."));
+
     ArgsParser::Optional<bool> TraceHuffmanAssignmentsFlag(
         MyCompressionFlags.TraceHuffmanAssignments);
     Args.add(

--- a/src/exec/compress-int.cpp
+++ b/src/exec/compress-int.cpp
@@ -91,8 +91,9 @@ int main(int Argc, const char* Argv[]) {
 
     ArgsParser::Toggle MatchSingletonsLastFlag(
         MyCompressionFlags.MatchSingletonsLast);
-    Args.add(MatchSingletonsLastFlag.setLongName("singletons").setDescription(
-        "Run experiment on how singleton patterns are handled."));
+    Args.add(MatchSingletonsLastFlag.setLongName("singletons")
+                 .setDescription(
+                     "Run experiment on how singleton patterns are handled."));
 
     ArgsParser::Optional<bool> TraceHuffmanAssignmentsFlag(
         MyCompressionFlags.TraceHuffmanAssignments);

--- a/src/intcomp/AbbreviationsCollector.cpp
+++ b/src/intcomp/AbbreviationsCollector.cpp
@@ -111,6 +111,10 @@ void AbbreviationsCollector::addAbbreviation(CountNode::Ptr Nd) {
     TRACE_MESSAGE("Removing, count/weight too small");
     return;
   }
+  if (MyFlags.MatchSingletonsLast && isa<SingletonCountNode>(NdPtr)) {
+    TRACE_MESSAGE("Singleton integer, ignoring");
+    return;
+  }
   Assignments.insert(Nd);
   TRACE_MESSAGE("Added to assignments");
   if (!MyFlags.TrimOverriddenPatterns) {

--- a/src/intcomp/CompressionFlags.cpp
+++ b/src/intcomp/CompressionFlags.cpp
@@ -52,6 +52,7 @@ CompressionFlags::CompressionFlags()
       AlignOpcodes(false),
       DefaultFormat(IntTypeFormat::Varint64),
       LoopSizeFormat(IntTypeFormat::Varuint64),
+      MatchSingletonsLast(false),
       TraceHuffmanAssignments(false),
       TraceReadingInput(false),
       TraceReadingIntStream(false),

--- a/src/intcomp/CompressionFlags.h
+++ b/src/intcomp/CompressionFlags.h
@@ -62,6 +62,7 @@ struct CompressionFlags {
   bool AlignOpcodes;
   interp::IntTypeFormat DefaultFormat;
   interp::IntTypeFormat LoopSizeFormat;
+  bool MatchSingletonsLast;
 
   interp::InterpreterFlags MyInterpFlags;
 


### PR DESCRIPTION
Changes when the integer compressor inserts integers (of selected patterns) into the integer output stream. This delay allows us to look at adding singleton patterns after non-singleton patterns have been selected.

This has been done as part of the add "singleton" patterns last experiment.